### PR TITLE
fix error when initializing ToolCallAgent and CodeAgent with system prompt

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -830,6 +830,8 @@ class CodeAgent(MultiStepAgent):
     ):
         if system_prompt is None:
             system_prompt = CODE_SYSTEM_PROMPT
+        else:
+            system_prompt = CODE_SYSTEM_PROMPT + "\n" + system_prompt
         super().__init__(
             tools=tools,
             model=model,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -727,6 +727,8 @@ class ToolCallingAgent(MultiStepAgent):
     ):
         if system_prompt is None:
             system_prompt = TOOL_CALLING_SYSTEM_PROMPT
+        else:
+            system_prompt = TOOL_CALLING_SYSTEM_PROMPT + "\n" + system_prompt
         super().__init__(
             tools=tools,
             model=model,


### PR DESCRIPTION
Hi again @aymeric-roucher ,

I'm facing an issue when creating a ToolCallAgent with a custom system message. You can reproduce the error as shown below and a potential fix comes with this PR.

To reproduce, this code (the system prompt in the last line is key)...

```
from smolagents.agents import ToolCallingAgent
from smolagents import tool, HfApiModel, TransformersModel, LiteLLMModel, Model
from smolagents.tools import Tool
from smolagents.models import get_clean_message_list, tool_role_conversions
from typing import Optional
import os

model = LiteLLMModel(model_id="openai/llama3.2",
                     api_base="http://localhost:11434/v1",
                     api_key="your-api-key")
                     
@tool
def bake_cake(ingredients:str)->str:
    """bake cake
    
    Args:
        ingredients: what to buy to make cake"""
    pass

agent = ToolCallingAgent(tools=[bake_cake], model=model, system_prompt="hello error")
```

... causes this error on my side:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 20
     14     """bake cake
     15     
     16     Args:
     17         ingredients: what to buy to make cake"""
     18     pass
---> 20 agent = ToolCallingAgent(tools=[bake_cake], model=model, system_prompt="hello error")

File C:\structure\code\smolagents\src\smolagents\agents.py:732, in ToolCallingAgent.__init__(self, tools, model, system_prompt, planning_interval, **kwargs)
    729     system_prompt = TOOL_CALLING_SYSTEM_PROMPT
    730 #else:
    731 #    system_prompt = TOOL_CALLING_SYSTEM_PROMPT + "\n" + system_prompt
--> 732 super().__init__(
    733     tools=tools,
    734     model=model,
    735     system_prompt=system_prompt,
    736     planning_interval=planning_interval,
    737     **kwargs,
    738 )

File C:\structure\code\smolagents\src\smolagents\agents.py:207, in MultiStepAgent.__init__(self, tools, model, system_prompt, tool_description_template, max_iterations, tool_parser, add_base_tools, verbose, grammar, managed_agents, step_callbacks, planning_interval)
    204     self._toolbox = Toolbox(tools, add_base_tools=add_base_tools)
    205 self._toolbox.add_tool(FinalAnswerTool())
--> 207 self.system_prompt = self.initialize_system_prompt()
    208 self.input_messages = None
    209 self.logs = []

File C:\structure\code\smolagents\src\smolagents\agents.py:227, in MultiStepAgent.initialize_system_prompt(self)
    221 def initialize_system_prompt(self):
    222     self.system_prompt = format_prompt_with_tools(
    223         self._toolbox,
    224         self.system_prompt_template,
    225         self.tool_description_template,
    226     )
--> 227     self.system_prompt = format_prompt_with_managed_agents_descriptions(
    228         self.system_prompt, self.managed_agents
    229     )
    231     return self.system_prompt

File C:\structure\code\smolagents\src\smolagents\agents.py:140, in format_prompt_with_managed_agents_descriptions(prompt_template, managed_agents, agent_descriptions_placeholder)
    138 if agent_descriptions_placeholder not in prompt_template:
    139     print("PROMPT TEMPLLL", prompt_template)
--> 140     raise ValueError(
    141         f"Provided prompt template does not contain the managed agents descriptions placeholder '{agent_descriptions_placeholder}'"
    142     )
    143 if len(managed_agents.keys()) > 0:
    144     return prompt_template.replace(
    145         agent_descriptions_placeholder, show_agents_descriptions(managed_agents)
    146     )

ValueError: Provided prompt template does not contain the managed agents descriptions placeholder '{{managed_agents_descriptions}}'
```

Let me know what you think!

Best,
Robert