### PR TITLE
Update tool_calling_agent_ollama.py

### DIFF
--- a/examples/tool_calling_agent_ollama.py
+++ b/examples/tool_calling_agent_ollama.py
@@ -2,7 +2,7 @@ from smolagents.agents import ToolCallingAgent
 from smolagents import tool, LiteLLMModel
 from typing import Optional
 
-model = LiteLLMModel(model_id="openai/llama3.2",
+model = LiteLLMModel(model_id="ollama/llama3.2",
                      api_base="http://localhost:11434/v1", # replace with remote open-ai compatible server if necessary
                      api_key="your-api-key")               # replace with API key if necessary
 


### PR DESCRIPTION
In tool_calling_agent_ollama.py, we get the following error when trying to run:

```Traceback (most recent call last):
  File "/Users/user/coding/smolagent/agent.py", line 5, in <module>
    model = LiteLLMModel(model_id="openai/llama3.2",
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LiteLLMModel.__init__() got an unexpected keyword argument 'api_base'
```



Here is the relevant code:

```
model = LiteLLMModel(model_id="openai/llama3.2",
                     api_base="http://localhost:11434/v1", # replace with remote open-ai compatible server if necessary
                     api_key="your-api-key")               # replace with API key if necessary
```

To fix it, we need to change "openai/llama3.2" to "**ollama**/llama3.2"