### PR TITLE
feat: Add max_results kwarg to DDGS tool

### DIFF
--- a/examples/ddg_leopard.py
+++ b/examples/ddg_leopard.py
@@ -1,0 +1,5 @@
+from smolagents import CodeAgent, DuckDuckGoSearchTool, HfApiModel
+
+agent = CodeAgent(tools=[DuckDuckGoSearchTool(max_results=2)], model=HfApiModel())
+
+agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")

--- a/examples/ddg_leopard.py
+++ b/examples/ddg_leopard.py
@@ -1,5 +1,0 @@
-from smolagents import CodeAgent, DuckDuckGoSearchTool, HfApiModel
-
-agent = CodeAgent(tools=[DuckDuckGoSearchTool(max_results=2)], model=HfApiModel())
-
-agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -153,8 +153,9 @@ class DuckDuckGoSearchTool(Tool):
     }
     output_type = "any"
 
-    def __init__(self, **kwargs):
-        super().__init__(self, **kwargs)
+    def __init__(self, *args, max_results=10, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.max_results = max_results
         try:
             from duckduckgo_search import DDGS
         except ImportError:
@@ -164,7 +165,7 @@ class DuckDuckGoSearchTool(Tool):
         self.ddgs = DDGS()
 
     def forward(self, query: str) -> str:
-        results = self.ddgs.text(query, max_results=10)
+        results = self.ddgs.text(query, max_results=self.max_results)
         postprocessed_results = [
             f"[{result['title']}]({result['href']})\n{result['body']}"
             for result in results


### PR DESCRIPTION
You can now optionally pass `max_results` into the `DuckDuckGoSearchTool`. Default behavior is unchanged (10 results).

```python
DuckDuckGoSearchTool(max_results=2)
```

Test with `examples/ddg_leopard.py`