### PR TITLE
fix ToolCollection usage 

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -904,12 +904,12 @@ class ToolCollection:
     ```
     """
 
-    def __init__(self, collection_slug: str, token: Optional[str] = None):
+    def __init__(self, collection_slug: str, token: Optional[str] = None, trust_remote_code=False):
         self._collection = get_collection(collection_slug, token=token)
         self._hub_repo_ids = {
             item.item_id for item in self._collection.items if item.item_type == "space"
         }
-        self.tools = {Tool.from_hub(repo_id) for repo_id in self._hub_repo_ids}
+        self.tools = {Tool.from_hub(repo_id,token,trust_remote_code) for repo_id in self._hub_repo_ids}
 
 
 def tool(tool_function: Callable) -> Tool:


### PR DESCRIPTION
I was not able to use the base ToolCollection from huggingface/smolagents : it would error on trust_remote_code from the Tool.from_hub call . 
I'm adding those parameters (trust_remote_code and token) to the constructor.

HuggingFace online documentation still needs to be updated as it imports the wrong  ToolCollection (from transformers, not smolagents)