### PR TITLE
Remove dependency on Torch as it leads to installation issues on MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "torch",
-    "torchaudio",
-    "torchvision",
     "transformers>=4.0.0",
     "requests>=2.32.3",
     "rich>=13.9.4",


### PR DESCRIPTION
ERROR: Cannot install smolagents==0.1.0, smolagents==0.1.2, smolagents==0.1.3 and smolagents==1.0.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    smolagents 1.0.0 depends on torch
    smolagents 0.1.3 depends on torch
    smolagents 0.1.2 depends on torch
    smolagents 0.1.0 depends on torch>=2.5.1

Issue is raised #62 