### PR TITLE
Don't pass sanitize_inputs_outputs=True to managed agents

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -388,16 +388,22 @@ class MultiStepAgent:
 
         try:
             if isinstance(arguments, str):
-                observation = available_tools[tool_name].__call__(
-                    arguments, sanitize_inputs_outputs=True
-                )
+                if tool_name in self.managed_agents:
+                    observation = available_tools[tool_name].__call__(arguments)
+                else:
+                    observation = available_tools[tool_name].__call__(
+                        arguments, sanitize_inputs_outputs=True
+                    )
             elif isinstance(arguments, dict):
                 for key, value in arguments.items():
                     if isinstance(value, str) and value in self.state:
                         arguments[key] = self.state[value]
-                observation = available_tools[tool_name].__call__(
-                    **arguments, sanitize_inputs_outputs=True
-                )
+                if tool_name in self.managed_agents:
+                    observation = available_tools[tool_name].__call__(**arguments)
+                else:
+                    observation = available_tools[tool_name].__call__(
+                        **arguments, sanitize_inputs_outputs=True
+                    )
             else:
                 error_msg = f"Arguments passed to tool should be a dict or string: got a {type(arguments)}."
                 raise AgentExecutionError(error_msg)


### PR DESCRIPTION
As discussed https://discuss.huggingface.co/t/error-calling-custom-tool-smolagents-library/133879


Fixes errors:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────── New run ────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                         │
│ look up reviews for hotel zephyr in SF                                                                                                                                                                  │
│                                                                                                                                                                                                         │
╰─ LiteLLMModel - deepseek/deepseek-chat ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Calling tool: 'search_agent' with arguments: {'request': 'Please look up reviews for Hotel Zephyr in San Francisco (SF). Provide a summary of the reviews, including overall ratings, common praises,   │
│ and any frequent complaints.'}                                                                                                                                                                          │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Error in calling team member: MultiStepAgent.run() got an unexpected keyword argument 'sanitize_inputs_outputs'
You should only ask this team member with a correct request.
As a reminder, this team member's description is the following:
<smolagents.agents.ManagedAgent object at 0x16a0a0b50>error: MultiStepAgent.run() got an unexpected keyword argument 'sanitize_inputs_outputs'
[Step 0: Duration 2.27 seconds| Input tokens: 1,114 | Output tokens: 51]
```

The issue seems to be we're passing `sanitize_inputs_outputs` to all tools, including ManagedAgent, but `ManagedAgent.run` does not take a `sanitize_inputs_outputs=`. Instead of adding a `sanitize_inputs_outputs=` to that (which wouldn't do anything), I've opted to conditionally pass the param, based on the logic [`elif tool_name in self.managed_agents:`](https://github.com/huggingface/smolagents/blob/8b1c36b083adb7e2795e3c59a3b270851dcdf883/src/smolagents/agents.py#L421)

Tested locally and this fixes the crash in my application.