### PR TITLE
Include missing pip install library in RAG example

### DIFF
--- a/docs/source/en/examples/rag.md
+++ b/docs/source/en/examples/rag.md
@@ -35,7 +35,7 @@ Let's build this system. 🛠️
 
 Run the line below to install required dependencies:
 ```bash
-!pip install smolagents pandas langchain langchain-community sentence-transformers faiss-cpu --upgrade -q
+!pip install smolagents pandas langchain langchain-community sentence-transformers faiss-cpu rank_bm25 --upgrade -q
 ```
 To call the HF Inference API, you will need a valid token as your environment variable `HF_TOKEN`.
 We use python-dotenv to load it.

--- a/docs/source/en/examples/rag.md
+++ b/docs/source/en/examples/rag.md
@@ -35,7 +35,7 @@ Let's build this system. 🛠️
 
 Run the line below to install required dependencies:
 ```bash
-!pip install smolagents pandas langchain langchain-community sentence-transformers faiss-cpu rank_bm25 --upgrade -q
+!pip install smolagents pandas langchain langchain-community sentence-transformers rank_bm25 --upgrade -q
 ```
 To call the HF Inference API, you will need a valid token as your environment variable `HF_TOKEN`.
 We use python-dotenv to load it.


### PR DESCRIPTION
As per the title, one of the needed libraries for this example was not included in the first step, where you install the required libraries using pip. 

This PR simply adds that library to the pip install list :) 