### PR TITLE
Small tweaks to Gradio demo

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -23,7 +23,7 @@ from .types import AgentAudio, AgentImage, AgentText, handle_agent_output_types
 def pull_messages_from_step(step_log: AgentStep, test_mode: bool = True):
     """Extract ChatMessage objects from agent steps"""
     if isinstance(step_log, ActionStep):
-        yield gr.ChatMessage(role="assistant", content=step_log.llm_output)
+        yield gr.ChatMessage(role="assistant", content=step_log.llm_output or "")
         if step_log.tool_call is not None:
             used_code = step_log.tool_call.name == "code interpreter"
             content = step_log.tool_call.arguments
@@ -36,7 +36,7 @@ def pull_messages_from_step(step_log: AgentStep, test_mode: bool = True):
             )
         if step_log.observations is not None:
             yield gr.ChatMessage(
-                role="assistant", content=f"```\n{step_log.observations}\n```"
+                role="assistant", content=step_log.observations
             )
         if step_log.error is not None:
             yield gr.ChatMessage(
@@ -65,7 +65,7 @@ def stream_to_gradio(
     if isinstance(final_answer, AgentText):
         yield gr.ChatMessage(
             role="assistant",
-            content=f"**Final answer:**\n```\n{final_answer.to_string()}\n```",
+            content=f"**Final answer:**\n{final_answer.to_string()}\n",
         )
     elif isinstance(final_answer, AgentImage):
         yield gr.ChatMessage(


### PR DESCRIPTION
Some minor tweaks and suggestions for the gradio demo:

* The `content` of a gradio chat message cannot be None. I was running into errors when the code agent was setting the llm_output was None.
* Wrapping the observations in "```" blocks would not display the observation as markdown. By removing this, we can display the output as markdown which makes links interactive and respects the LLM format.
For example,

<img width="1404" alt="Screenshot 2025-01-06 at 5 34 47 PM" src="https://github.com/user-attachments/assets/ce3b99da-f200-4727-b36d-62b946e2f446" />

vs

<img width="1377" alt="Screenshot 2025-01-06 at 6 01 01 PM" src="https://github.com/user-attachments/assets/d96058c9-9cc7-4a76-bfa6-4766ce4ee995" />

