### PR TITLE
Compatibility fix for function names changed in new version of Transformers

### DIFF
--- a/src/smolagents/types.py
+++ b/src/smolagents/types.py
@@ -22,7 +22,7 @@ from io import BytesIO
 import numpy as np
 import requests
 from transformers.utils import (
-    is_soundfile_availble,
+    is_soundfile_available,
     is_torch_available,
     is_vision_available,
 )
@@ -41,7 +41,7 @@ if is_torch_available():
 else:
     Tensor = object
 
-if is_soundfile_availble():
+if is_soundfile_available():
     import soundfile as sf
 
 
@@ -189,7 +189,7 @@ class AgentAudio(AgentType, str):
     def __init__(self, value, samplerate=16_000):
         super().__init__(value)
 
-        if not is_soundfile_availble():
+        if not is_soundfile_available():
             raise ImportError("soundfile must be installed in order to handle audio.")
 
         self._path = None

--- a/src/smolagents/types.py
+++ b/src/smolagents/types.py
@@ -22,10 +22,15 @@ from io import BytesIO
 import numpy as np
 import requests
 from transformers.utils import (
-    is_soundfile_available,
     is_torch_available,
     is_vision_available,
 )
+
+# for compatibility with mispelling old transformers versions (fixed in https://github.com/huggingface/transformers/pull/35030)
+try:
+    from transformers.utils import is_soundfile_available
+except ImportError:
+    from transformers.utils import is_soundfile_availble as is_soundfile_available
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -26,12 +26,12 @@ from transformers.testing_utils import (
     require_vision,
 )
 from transformers.utils import (
-    is_soundfile_availble,
+    is_soundfile_available,
 )
 
 from smolagents.types import AgentAudio, AgentImage, AgentText
 
-if is_soundfile_availble():
+if is_soundfile_available():
     import soundfile as sf
 
 


### PR DESCRIPTION
There was a function that has been misspelled in transformers for a number of months that was recently fixed in main.
(`is_soundfile_availble` -> `is_soundfile_available`)

This mean `smolagents` won't work for people using current version of `transformers` installed straight from github (`pip install -U git+https://github.com/huggingface/transformers`)

Tried to come up with solution that will keep both versions working

```
> python smol.py
Traceback (most recent call last):
  File "C:\Users\User\Documents\github\security-article-reader\smol.py", line 1, in <module>
    from smolagents.agents import ToolCallingAgent
  File "C:\Users\User\AppData\Roaming\Python\Python312\site-packages\smolagents\agents.py", line 27, in <module>
    from .default_tools import FinalAnswerTool
  File "C:\Users\User\AppData\Roaming\Python\Python312\site-packages\smolagents\default_tools.py", line 34, in <module>    
    from .tools import TOOL_CONFIG_FILE, PipelineTool, Tool
  File "C:\Users\User\AppData\Roaming\Python\Python312\site-packages\smolagents\tools.py", line 52, in <module>
    from .types import ImageType, handle_agent_input_types, handle_agent_output_types
  File "C:\Users\User\AppData\Roaming\Python\Python312\site-packages\smolagents\types.py", line 24, in <module>
    from transformers.utils import (
ImportError: cannot import name 'is_soundfile_availble' from 'transformers.utils' (C:\Users\User\AppData\Roaming\Python\Python312\site-packages\transformers\utils\__init__.py). Did you mean: 'is_soundfile_available'?

> pip show transformers
Name: transformers
Version: 4.48.0.dev0

> pip show smolagents
Name: smolagents
Version: 1.1.0
```

Confirmed working after changes:
```
python .\smol.py

...──── New run ────...
What's the weather like in Paris?
```

This fix was only recently merged 3 days ago
https://github.com/huggingface/transformers/pull/35030