### PR TITLE
Fix Spelling Errors in Documentation

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -233,9 +233,9 @@ Here are the rules you should always follow to solve your task:
 Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
 ```
 
-As yo can see, there are placeholders like `"{{tool_descriptions}}"`: these will be used upon agent initialization to insert certain automatically generated descriptions of tools or managed agents.
+As you can see, there are placeholders like `"{{tool_descriptions}}"`: these will be used upon agent initialization to insert certain automatically generated descriptions of tools or managed agents.
 
-So while you can overwrite this system prompt template by passing your custom prompt as an argument to the `system_prompt` parameter, your new system promptmust contain the following placeholders:
+So while you can overwrite this system prompt template by passing your custom prompt as an argument to the `system_prompt` parameter, your new system prompt must contain the following placeholders:
 - `"{{tool_descriptions}}"` to insert tool descriptions.
 - `"{{managed_agents_description}}"` to insert the description for managed agents if there are any.
 - For `CodeAgent` only: `"{{authorized_imports}}"` to insert the list of authorized imports.

--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -47,7 +47,7 @@ This interpreter is designed for security by:
  - Capping the number of operations to prevent infinite loops and resource bloating.
  - Will not perform any operation that's not pre-defined.
 
-Wev'e used this on many use cases, without ever observing any damage to the environment. 
+We've used this on many use cases, without ever observing any damage to the environment. 
 
 However this solution is not watertight: one could imagine occasions where LLMs fine-tuned for malignant actions could still hurt your environment. For instance if you've allowed an innocuous package like `Pillow` to process images, the LLM could generate thousands of saves of images to bloat your hard drive.
 It's certainly not likely if you've chosen the LLM engine yourself, but it could happen.

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -89,8 +89,8 @@ model_downloads_tool.push_to_hub("{your_username}/hf-model-downloads", token="<Y
 ```
 
 For the push to Hub to work, your tool will need to respect some rules:
-- All method are self-contained, e.g. use variables that come either from their args.
-- As per the above point, **all imports should be defined directky within the tool's functions**, else you will get an error when trying to call [`~Tool.save`] or [`~Tool.push_to_hub`] with your custom tool.
+- All methods are self-contained, e.g. use variables that come either from their args.
+- As per the above point, **all imports should be defined directly within the tool's functions**, else you will get an error when trying to call [`~Tool.save`] or [`~Tool.push_to_hub`] with your custom tool.
 - If you subclass the `__init__` method, you can give it no other argument than `self`. This is because arguments set during a specific tool instance's initialization are hard to track, which prevents from sharing them properly to the hub. And anyway, the idea of making a specific class is that you can already set class attributes for anything you need to hard-code (just set `your_variable=(...)` directly under the `class YourTool(Tool):` line). And of course you can still create a class attribute anywhere in your code by assigning stuff to `self.your_variable`.
 
 
@@ -210,7 +210,7 @@ Just make sure the new tool follows the same API as the replaced tool or adapt t
 ### Use a collection of tools
 
 You can leverage tool collections by using the ToolCollection object, with the slug of the collection you want to use.
-Then pass them as a list to initialize you agent, and start using them!
+Then pass them as a list to initialize your agent, and start using them!
 
 ```py
 from smolagents import ToolCollection, CodeAgent


### PR DESCRIPTION
Fix Spelling Errors in Documentation**

## **Summary**
This PR corrects minor spelling errors across three documentation files: `tools.md`, `secure_code_execution.md`, and `building_good_agents.md`.

---

## **Changes Made**

### **tools.md**
1. Line 92: Corrected `method` → `methods`.
2. Line 93: Corrected `directky` → `directly`.
3. Line 213: Corrected `you` → `your`.

### **secure_code_execution.md**
1. Line 50: Corrected `Wev'e` → `We've`.

### **building_good_agents.md**
1. Line 236: Corrected `yo` → `you`.
2. Line 238: Corrected `promptmust` → `prompt must`.

---

## **Reason for Changes**
These changes address minor spelling issues to enhance the documentation's clarity, readability, and professionalism.

---