### PR TITLE
Return a dictionary from DuckDuckGoSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -17,7 +17,7 @@
 import json
 import re
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from huggingface_hub import hf_hub_download, list_spaces
 from transformers.models.whisper import (
@@ -151,7 +151,7 @@ class DuckDuckGoSearchTool(Tool):
     inputs = {
         "query": {"type": "string", "description": "The search query to perform."}
     }
-    output_type = "any"
+    output_type = "string"
 
     def __init__(self, *args, max_results=10, **kwargs):
         super().__init__(*args, **kwargs)
@@ -164,13 +164,12 @@ class DuckDuckGoSearchTool(Tool):
             )
         self.ddgs = DDGS()
 
-    def forward(self, query: str) -> str:
+    def forward(self, query: str) -> List[Dict[str, str]]:
         results = self.ddgs.text(query, max_results=self.max_results)
-        postprocessed_results = [
-            f"[{result['title']}]({result['href']})\n{result['body']}"
-            for result in results
-        ]
-        return "## Search Results\n\n" + "\n\n".join(postprocessed_results)
+        postprocessed_results = []
+        for result in results:
+            postprocessed_results.append({"title": result["title"], "href": result["href"], "body": result["body"]})
+        return postprocessed_results
 
 
 class GoogleSearchTool(Tool):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -27,4 +27,4 @@ class DuckDuckGoSearchToolTester(unittest.TestCase, ToolTesterMixin):
 
     def test_exact_match_arg(self):
         result = self.tool("Agents")
-        assert isinstance(result, str)
+        assert isinstance(result, list)


### PR DESCRIPTION
# Why?
The description is currently:
Performs a duckduckgo web search based on your query (think a Google search) then returns the top search results as a list of dict elements.  Each result has keys 'title', 'href' and 'body'.

But the return value was a Markdown string. As a result the code later was failing trying to access the 'body'/'href' key of the response

See issue #86

# What ?

The return value is a list of dict elements. This is as siginificantly different from the return value of the previous version of the tool.