### PR TITLE
Implement OpenAIServerModel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "e2b-code-interpreter>=1.0.3",
   "litellm>=1.55.10",
+  "openai>=1.58.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This PR implements a new model type, OpenAIServerModel, which is compatible with any server host using an OpenAI compatible API without having to introduce LiteLLM as a middleware dependency.

This PR closes #96 

Example implementation, tested with LM Studio:

```python
from smolagents import CodeAgent, DuckDuckGoSearchTool, OpenAIServerModel

def test_openai_compatible():
    # Initialize the agent with DuckDuckGo search and OpenAI-compatible model
    agent = CodeAgent(
        tools=[DuckDuckGoSearchTool()],
        model=OpenAIServerModel(
            model_id="qwen2.5-coder-32b-instruct",  # or whatever model ID your server uses
            api_base="http://localhost:1234/v1",  # replace with your server URL
            api_key="lm-studio",  # replace with your API key
            temperature=0.7
        )
    )

    # Test the agent with a query
    query = "How many seconds would it take for a leopard at full speed to run through Pont des Arts?"
    result = agent.run(query)

    # Print the result
    print(f"Query: {query}")
    print(f"Response: {result}")

if __name__ == "__main__":
    test_openai_compatible()
```

This PR does not (yet) contain the required documentation changes, as I wanted to ensure this meets the standards of the project before I move forward with documentation changes. Maybe documentation changes should be a separate PR?