### PR TITLE
Adding uv to install the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Full documentation can be found [here](https://huggingface.co/docs/smolagents/in
 
 First install the package.
 ```bash
-pip install smolagents
+pip install uv
+uv pip install smolagents
 ```
 Then define your agent, give it the tools it needs and run it!
 ```py


### PR DESCRIPTION
[uv](https://astral.sh/blog/uv) is made by the same creators as Ruff. uv allows for [faster installs](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) for any library in python as compared to pip itself.

I have just modified readme.md to allow users to install the library via uv instead of pip.