### PR TITLE
Add VLM support

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from enum import IntEnum
+from PIL import Image
 from rich import box
 from rich.console import Group
 from rich.panel import Panel
@@ -464,6 +465,7 @@ class MultiStepAgent:
         stream: bool = False,
         reset: bool = True,
         single_step: bool = False,
+        images: Optional[List[Image.Image]] = None,
         additional_args: Optional[Dict] = None,
     ):
         """
@@ -474,6 +476,7 @@ class MultiStepAgent:
             stream (`bool`): Whether to run in a streaming way.
             reset (`bool`): Whether to reset the conversation or keep it going from previous run.
             single_step (`bool`): Whether to run the agent in one-shot fashion.
+            images (`List`): List of image(s).
             additional_args (`dict`): Any other variables that you want to pass to the agent run, for instance images or dataframes. Give them clear names!
 
         Example:
@@ -804,7 +807,7 @@ class ToolCallingAgent(MultiStepAgent):
             model_message = self.model(
                 self.input_messages,
                 tools_to_call_from=list(self.tools.values()),
-                stop_sequences=["Observation:"],
+                stop_sequences=["Observation:"]
             )
             tool_calls = model_message.tool_calls[0]
             tool_arguments = tool_calls.function.arguments

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -20,6 +20,7 @@ import os
 import random
 from copy import deepcopy
 from enum import Enum
+from PIL import Image
 from typing import Dict, List, Optional
 
 from huggingface_hub import (
@@ -296,8 +297,11 @@ class TransformersModel(Model):
         self.device = device
         logger.info(f"Using device: {self.device}")
         try:
-            self.tokenizer = AutoTokenizer.from_pretrained(model_id)
             self.model = AutoModelForCausalLM.from_pretrained(model_id).to(self.device)
+            if hasattr(model.config, "vision_config"):
+                self.processor = AutoProcessor.from_pretrained(model_id)
+            else:
+                self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         except Exception as e:
             logger.warning(
                 f"Failed to load tokenizer and model for {model_id=}: {e}. Loading default tokenizer and model instead from {model_id=}."
@@ -340,25 +344,31 @@ class TransformersModel(Model):
         grammar: Optional[str] = None,
         max_tokens: int = 1500,
         tools_to_call_from: Optional[List[Tool]] = None,
+        images: Optional[List[Image.Image]] = None
     ) -> str:
         messages = get_clean_message_list(
             messages, role_conversions=tool_role_conversions
         )
 
-        if tools_to_call_from is not None:
-            prompt_tensor = self.tokenizer.apply_chat_template(
-                messages,
-                tools=[get_json_schema(tool) for tool in tools_to_call_from],
-                return_tensors="pt",
-                return_dict=True,
-                add_generation_prompt=True,
-            )
+        
+        if hasattr(self, 'processor'):
+            prompt_tensor = self.processor.apply_chat_template(
+            messages,
+            tools=[get_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
+            return_tensors="pt",
+            return_dict=True,
+            images=images,
+            add_generation_prompt=True if tools_to_call_from else False,
+        )
         else:
             prompt_tensor = self.tokenizer.apply_chat_template(
-                messages,
-                return_tensors="pt",
-                return_dict=True,
-            )
+            messages,
+            tools=[get_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
+            return_tensors="pt",
+            return_dict=True,
+            add_generation_prompt=True if tools_to_call_from else False,
+        )
+        
         prompt_tensor = prompt_tensor.to(self.model.device)
         count_prompt_tokens = prompt_tensor["input_ids"].shape[1]
 


### PR DESCRIPTION
Partially fixes https://github.com/huggingface/smolagents/issues/176 (the latter part where the VLMs are main models for the agents)

For the initial version, we could make some decisions for following questions:
1. We should give user the option to pass images only for the first step. 
2. We should give user the option to pass images at every step. 

It's just a matter of adding image(s) to chat template and keeping image(s) either in memory or passing it all the time.

For later, we could have option for agent to pull more images from somewhere, I just don't know of a use case for this yet. 