### PR TITLE
bugfix: Fix plan_update message display

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -748,7 +748,7 @@ Now begin!""",
             plan_update = self.model(
                 [plan_update_message] + agent_memory + [plan_update_message_user],
                 stop_sequences=["<end_plan>"],
-            )
+            ).content
 
             # Log final facts and plan
             final_plan_redaction = PLAN_UPDATE_FINAL_PLAN_REDACTION.format(


### PR DESCRIPTION
The updated plan was saved as a Message instead of str, like this:

```
Here is my new/updated plan of action to solve the task:
\```
Message(content='...', role='assistant', tool_calls=None, function_call=None)
\```
```

This PR fixes this, saving only content. Also it is consistent now with other variables in the same function.