### PR TITLE
Improve openai server, add more examples of model with LiteLLM

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -121,7 +121,7 @@ model = LiteLLMModel(
     model_id="azure/" + AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
 )
 
-agent = CodeAgent(tools=[], model=model)
+agent = CodeAgent(tools=[], model=model, add_base_tools=True)
 
 agent.run(
     "Could you give me the 118th number in the Fibonacci sequence?",

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -67,14 +67,14 @@ agent.run(
 )
 ```
 </hfoption>
-<hfoption id="OpenAI or Anthropic API">
+<hfoption id="Anthropic API">
 
-To use `LiteLLMModel`, you need to set the environment variable `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`, or pass `api_key` variable upon initialization.
+To use `LiteLLMModel` with Anthropic API, you need to set the environment variable `ANTHROPIC_API_KEY` or pass `api_key` variable upon initialization.
 
 ```python
 from smolagents import CodeAgent, LiteLLMModel
 
-model = LiteLLMModel(model_id="anthropic/claude-3-5-sonnet-latest", api_key="YOUR_ANTHROPIC_API_KEY") # Could use 'gpt-4o'
+model = LiteLLMModel(model_id="anthropic/claude-3-5-sonnet-latest", api_key="YOUR_ANTHROPIC_API_KEY")
 agent = CodeAgent(tools=[], model=model, add_base_tools=True)
 
 agent.run(
@@ -99,6 +99,83 @@ agent.run(
     "Could you give me the 118th number in the Fibonacci sequence?",
 )
 ```
+</hfoption>
+
+<hfoption id="AzureOpenAI">
+
+You need to set the environment variables `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION`, and pass the deployment name of your model to `model_id` param to use model from Azure OpenAI.
+
+```python
+import os
+from smolagents import CodeAgent, LiteLLMModel
+# from dotenv import load_dotenv # Use this module to easily set env var from .env file
+# load_dotenv()
+
+AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="gpt-35-turbo-16k-deployment" # example of deployment name
+
+os.environ["AZURE_API_KEY"] = "" # api_key
+os.environ["AZURE_API_BASE"] = "" # "https://example-endpoint.openai.azure.com"
+os.environ["AZURE_API_VERSION"] = "" # "2024-10-01-preview"
+
+model = LiteLLMModel(
+    model_id="azure/" + AZURE_OPENAI_CHAT_DEPLOYMENT_NAME
+)
+
+agent = CodeAgent(tools=[], model=model)
+
+agent.run(
+    "Could you give me the 118th number in the Fibonacci sequence?",
+)
+```
+
+</hfoption>
+
+<hfoption id="OpenAI">
+
+You could use OpenAI API with either `LiteLLMModel` or `OpenAIServerModel`.
+
+For usage with `LiteLLMModel`, you need to set the environment variable `OPENAI_API_KEY` or pass the key into the `api_key` param.
+
+```python
+from smolagents import CodeAgent, LiteLLMModel
+import os
+
+# from dotenv import load_dotenv # Use this module to easily set env var with .env file
+# load_dotenv()
+
+os.environ["OPENAI_API_KEY"] = "" # OPENAI_KEY
+
+model = LiteLLMModel(
+    model_id="gpt-3.5-turbo"
+    )
+
+agent = CodeAgent(tools=[], model=model, add_base_tools=True)
+
+agent.run(
+    "Could you give me the 118th number in the Fibonacci sequence?",
+)
+```
+
+Similarly with `OpenAIServerModel`:
+
+```python
+from smolagents import CodeAgent, OpenAIServerModel
+import os
+
+# from dotenv import load_dotenv # Use this module to easily set env var with .env file
+# load_dotenv()
+
+os.environ["OPENAI_API_KEY"] = "" # OPENAI_KEY
+
+model = OpenAIServerModel(model_id = "gpt-3.5-turbo")
+
+agent = CodeAgent(tools=[], model=model, add_base_tools=True)
+
+agent.run(
+    "Could you give me the 118th number in the Fibonacci sequence?",
+)
+```
+
 </hfoption>
 </hfoptions>
 

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -453,9 +453,9 @@ class OpenAIServerModel(Model):
     Parameters:
         model_id (`str`):
             The model identifier to use on the server (e.g. "gpt-3.5-turbo").
-        api_base (`str`):
+        api_base (`str`, *optional*, defaults to None):
             The base URL of the OpenAI-compatible API server.
-        api_key (`str`):
+        api_key (`str`, *optional*, defaults to None):
             The API key to use for authentication.
         temperature (`float`, *optional*, defaults to 0.7):
             Controls randomness in the model's responses. Values between 0 and 2.
@@ -466,16 +466,20 @@ class OpenAIServerModel(Model):
     def __init__(
         self,
         model_id: str,
-        api_base: str,
-        api_key: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        organization: Optional[str] = None,
+        project: str | None = None,
         temperature: float = 0.7,
         **kwargs,
     ):
         super().__init__()
         self.model_id = model_id
         self.client = openai.OpenAI(
-            base_url=api_base,
+            base_url=base_url,
             api_key=api_key,
+            organization=organization,
+            project=project
         )
         self.temperature = temperature
         self.kwargs = kwargs

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -452,15 +452,25 @@ class OpenAIServerModel(Model):
 
     Parameters:
         model_id (`str`):
-            The model identifier to use on the server (e.g. "gpt-3.5-turbo").
-        api_base (`str`, *optional*, defaults to None):
-            The base URL of the OpenAI-compatible API server.
-        api_key (`str`, *optional*, defaults to None):
-            The API key to use for authentication.
-        temperature (`float`, *optional*, defaults to 0.7):
-            Controls randomness in the model's responses. Values between 0 and 2.
+            The identifier of the model to use on the OpenAI-compatible server.
+            For example, "gpt-3.5-turbo" or "text-davinci-003".
+        api_key (`str`, optional, defaults to None):
+            The API key for authenticating requests to the server. If not provided, 
+            it must be set as an environment variable.
+        base_url (`str`, optional, defaults to None):
+            The base URL of the OpenAI-compatible API server. Typically used for 
+            custom deployments or non-default endpoints. For example:
+            "https://api.openai.com/v1/".
+        organization (`str`, optional, defaults to None):
+            The organization ID to use when interacting with the OpenAI API, 
+            if applicable.
+        project (`str`, optional, defaults to None):
+            The project ID to use when interacting with the OpenAI API, if applicable.
+        temperature (`float`, optional, defaults to 0.7):
+            A value that controls the randomness of responses. 
         **kwargs:
-            Additional keyword arguments to pass to the OpenAI API.
+            Additional optional arguments that will be passed directly to the 
+            OpenAI API client, allowing for further customization.
     """
 
     def __init__(

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -519,90 +519,6 @@ class OpenAIServerModel(Model):
         self.last_output_token_count = response.usage.completion_tokens
         return response.choices[0].message
 
-class AzureOpenAIServerModel(Model):
-    """
-    This engine connects to an Azure OpenAI-compatible API server.
-
-    To use this class, you must have a deployed model on Azure OpenAI. Use `model_id`
-    in the constructor to refer to the "Model deployment name" in the Azure portal.
-
-    The following parameters can be provided explicitly or via environment variables:
-    - `AZURE_OPENAI_API_KEY`
-    - `AZURE_OPENAI_ENDPOINT`
-    - `OPENAI_API_VERSION`
-
-    Example:
-
-    .. code-block:: python
-
-        model = AzureOpenAIServerModel(
-            model_id="azure-turbo-dev",
-        )
-    """
-
-    def __init__(
-        self,
-        model_id: str,
-        api_key: Optional[str] = None,
-        azure_endpoint: Optional[str] = None,
-        api_version: Optional[str] = None,
-        azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[str] = None,
-        organization: Optional[str] = None,
-        temperature: float = 0.7,
-        **kwargs,
-    ):
-        super().__init__()
-        self.model_id = model_id
-        self.temperature = temperature
-        self.kwargs = kwargs
-
-        # Initialize the Azure OpenAI client
-        self.client = openai.AzureOpenAI(
-            azure_endpoint=azure_endpoint,
-            azure_deployment=self.model_id,
-            api_key=api_key,
-            api_version=api_version,
-            azure_ad_token=azure_ad_token,
-            azure_ad_token_provider=azure_ad_token_provider,
-            organization=organization,
-        )
-
-    def __call__(
-        self,
-        messages: List[Dict[str, str]],
-        stop_sequences: Optional[List[str]] = None,
-        grammar: Optional[str] = None,
-        max_tokens: int = 1500,
-        tools_to_call_from: Optional[List[Tool]] = None,
-    ) -> ChatCompletionOutputMessage:
-        messages = get_clean_message_list(
-            messages, role_conversions=tool_role_conversions
-        )
-        if tools_to_call_from:
-            response = self.client.chat_completions.create(
-                deployment_id=self.model_id,
-                messages=messages,
-                stop=stop_sequences,
-                max_tokens=max_tokens,
-                temperature=self.temperature,
-                tools=[get_json_schema(tool) for tool in tools_to_call_from],
-                tool_choice="auto",
-                **self.kwargs,
-            )
-        else:
-            response = self.client.chat_completions.create(
-                deployment_id=self.model_id,
-                messages=messages,
-                stop=stop_sequences,
-                max_tokens=max_tokens,
-                temperature=self.temperature,
-                **self.kwargs,
-            )
-        self.last_input_token_count = response.usage.prompt_tokens
-        self.last_output_token_count = response.usage.completion_tokens
-        return response.choices[0].message
-
 
 __all__ = [
     "MessageRole",
@@ -613,5 +529,4 @@ __all__ = [
     "HfApiModel",
     "LiteLLMModel",
     "OpenAIServerModel",
-    "AzureOpenAIServerModel"
 ]


### PR DESCRIPTION
I tried to add Azure API but realized it is supported with LiteLLM. 
OpenAI model also are support by both LiteLLM and OpenAIServer class. For OpenAIServer class api_key and api_base are should be optional as they could be replaced with usage of env var. 
