### PR TITLE
The call.func parameter type of the local_python_executor.evaluate_call function might be ast.Subscript 

### DIFF
--- a/tests/test_python_interpreter.py
+++ b/tests/test_python_interpreter.py
@@ -60,6 +60,14 @@ class PythonInterpreterTester(unittest.TestCase):
             in str(e)
         )
 
+    def test_subscript_call(self):
+        code = """def foo(x,y):return x*y\n\ndef boo(y):\n\treturn y**3\nfun = [foo, boo]\nresult_foo = fun[0](4,2)\nresult_boo = fun[1](4)"""
+        state = {}
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state=state)
+        assert result == 64
+        assert state["result_foo"] == 8
+        assert state["result_boo"] == 64
+
     def test_evaluate_call(self):
         code = "y = add_two(x)"
         state = {"x": 3}


### PR DESCRIPTION
fix for #181.
btw:
```python
   elif name.id in custom_tools:
        return custom_tools[name.id]
 ```
 to allow a list of objects, like : 
```python
def my_func():
    do_smth()
list = [my_func, my_func] 
```
Now we get the error: 
**The variable `my_func` is not defined.**