### PR TITLE
chore: unset console width, utilize auto detect feature

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -31,7 +31,7 @@ def is_pygments_available():
     return _pygments_available
 
 
-console = Console(width=200)
+console = Console()
 
 BASE_BUILTIN_MODULES = [
     "collections",


### PR DESCRIPTION
Better handling `Console` size based on current terminal setup, no need to be fixed to 200
<img width="869" alt="Screenshot 2025-01-15 at 13 53 42" src="https://github.com/user-attachments/assets/425434ce-6113-413b-888e-74ba2f532db0" />
