### PR TITLE
bug fix: fix string concatenation bug in GradioUI.log_user_message

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -155,9 +155,9 @@ class GradioUI:
     def log_user_message(self, text_input, file_uploads_log):
         return (
             text_input
-            + f"\nYou have been provided with these files, which might be helpful or not: {file_uploads_log}"
+            + (f"\nYou have been provided with these files, which might be helpful or not: {file_uploads_log}"
             if len(file_uploads_log) > 0
-            else "",
+            else ""),
             "",
         )
 


### PR DESCRIPTION
File: src/smolagents/gradio_ui.py

Bug impact:
When no files are uploaded, the Gradio UI completely ignores user's text input
due to incorrect string concatenation precedence.

Changes:
- Add parentheses to ensure correct operator precedence in string concatenation
- Fix text_input being ignored when file_uploads_log is empty