### PR TITLE
Return textboxes on Gradio file upload errors

### DIFF
--- a/examples/gradio_upload.py
+++ b/examples/gradio_upload.py
@@ -5,7 +5,7 @@ from smolagents import (
 )
 
 agent = CodeAgent(
-    tools=[], model=HfApiModel(), max_steps=4, verbosity_level=0
+    tools=[], model=HfApiModel(), max_steps=4, verbosity_level=1
 )
 
 GradioUI(agent, file_upload_folder='./data').launch()

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -116,15 +116,21 @@ class GradioUI:
         """
 
         if file is None:
-            return "No file uploaded"
+            return gr.Textbox(
+                "No file uploaded", visible=True
+            ), file_uploads_log
 
         try:
             mime_type, _ = mimetypes.guess_type(file.name)
         except Exception as e:
-            return f"Error: {e}"
+            return gr.Textbox(
+                f"Error: {e}", visible=True
+            ), file_uploads_log
 
         if mime_type not in allowed_file_types:
-            return "File type disallowed"
+            return gr.Textbox(
+                "File type disallowed", visible=True
+            ), file_uploads_log
 
         # Sanitize file name
         original_name = os.path.basename(file.name)
@@ -177,7 +183,7 @@ class GradioUI:
             )
             # If an upload folder is provided, enable the upload feature
             if self.file_upload_folder is not None:
-                upload_file = gr.File(label="Upload a file", height=1)
+                upload_file = gr.File(label="Upload a file")
                 upload_status = gr.Textbox(
                     label="Upload Status", interactive=False, visible=False
                 )


### PR DESCRIPTION
With the release of v1.3.0, file upload errors (such as uploading a disallowed type) result in the following exception:
```
ValueError: A  function (upload_file) didn't return enough output values (needed: 2, returned: 1).
    Output components:
        [textbox, state]
    Output values returned:
        ["File type disallowed"]
```
This PR introduces the correct return values on error. Also upped verbosity in the example and remove the height=1 parameter so the box renders better in the browser :^).