### PR TITLE
docs: update installation command in inspect_runs tutorial

### DIFF
--- a/docs/source/en/tutorials/inspect_runs.md
+++ b/docs/source/en/tutorials/inspect_runs.md
@@ -38,7 +38,7 @@ Here's how it goes:
 First install the required packages. Here we install [Phoenix by Arize AI](https://github.com/Arize-ai/phoenix) because that's a good solution to collect and inspect the logs, but there are other OpenTelemetry-compatible platforms that you could use for this collection & inspection part.
 
 ```shell
-pip install smolagents arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp
+pip install smolagents arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp openinference-instrumentation-smolagents
 ```
 
 Then run the collector in the background.


### PR DESCRIPTION
According to openinference's instructions on smolagents [OpenInference smolagents Instrumentation](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-smolagents/README.md), the package 'openinference-instrumentation-smolagents` is required:

```sh
pip install openinference-instrumentation-smolagents
```