### PR TITLE
Fix vanilla model answer in example benchmark

### DIFF
--- a/examples/benchmark.ipynb
+++ b/examples/benchmark.ipynb
@@ -253,7 +253,7 @@
     "\n",
     "            if is_vanilla_llm:\n",
     "                llm = agent\n",
-    "                answer = str(llm([{\"role\": \"user\", \"content\": question}]))\n",
+    "                answer = str(llm([{\"role\": \"user\", \"content\": question}]).content)\n",
     "                token_count = {\"input\": llm.last_input_token_count, \"output\": llm.last_output_token_count}\n",
     "                intermediate_steps = str([])\n",
     "            else:\n",


### PR DESCRIPTION
Fix vanilla model answer in example benchmark, by returning `ChatMessage.content` instead of `ChatMessage`:
- Return: `"answer": "80"`
- Instead of: `"answer": "ChatMessage(role='assistant', content='80', tool_calls=None)"`