### PR TITLE
Fix missing python modules in CodeAgent system prompt

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -912,7 +912,7 @@ class CodeAgent(MultiStepAgent):
                 "Caution: you set an authorization for all imports, meaning your agent can decide to import any package it deems necessary. This might raise issues if the package is not installed in your environment.",
                 0,
             )
-            
+
         super().__init__(
             tools=tools,
             model=model,
@@ -938,7 +938,7 @@ class CodeAgent(MultiStepAgent):
                 self.additional_authorized_imports,
                 all_tools,
             )
-            
+
     def initialize_system_prompt(self):
         super().initialize_system_prompt()
         self.system_prompt = self.system_prompt.replace(
@@ -946,9 +946,9 @@ class CodeAgent(MultiStepAgent):
             "You can import from any package you want."
             if "*" in self.authorized_imports
             else str(self.authorized_imports),
-        ) 
+        )
         return self.system_prompt
-    
+
     def step(self, log_entry: ActionStep) -> Union[None, Any]:
         """
         Perform one step in the ReAct framework: the agent thinks, acts, and observes the result.

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -490,7 +490,6 @@ class MultiStepAgent:
 You have been provided with these additional arguments, that you can access using the keys as variables in your python code:
 {str(additional_args)}."""
 
-        self.initialize_system_prompt()
         system_prompt_step = SystemPromptStep(system_prompt=self.system_prompt)
 
         if reset:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -380,8 +380,8 @@ class AgentTests(unittest.TestCase):
         agent = CodeAgent(tools=[tool], model=fake_code_model)
         agent.run("Empty task")
         assert tool.name in agent.system_prompt
-        assert tool.description in agent.system_prompt        
-    
+        assert tool.description in agent.system_prompt
+
     def test_module_imports_get_baked_in_system_prompt(self):
         agent = CodeAgent(tools=[], model=fake_code_model)
         agent.run("Empty task")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -35,6 +35,7 @@ from smolagents.models import (
     ChatMessageToolCall,
     ChatMessageToolCallDefinition,
 )
+from smolagents.utils import BASE_BUILTIN_MODULES
 
 
 def get_new_path(suffix="") -> str:
@@ -379,7 +380,13 @@ class AgentTests(unittest.TestCase):
         agent = CodeAgent(tools=[tool], model=fake_code_model)
         agent.run("Empty task")
         assert tool.name in agent.system_prompt
-        assert tool.description in agent.system_prompt
+        assert tool.description in agent.system_prompt        
+    
+    def test_module_imports_get_baked_in_system_prompt(self):
+        agent = CodeAgent(tools=[], model=fake_code_model)
+        agent.run("Empty task")
+        for module in BASE_BUILTIN_MODULES:
+            assert module in agent.system_prompt
 
     def test_init_agent_with_different_toolsets(self):
         toolset_1 = []


### PR DESCRIPTION
Should resolve #223 , I went with removing `self.initialize_system_prompt()` from the step method, as it is already called in `__init__`. Although there may be side effects of not including this in `agent.run()` ?