### PR TITLE
Docs Bug - fix tool example with additional args

### DIFF
--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -131,7 +131,7 @@ And voilà, here's your image! 🏖️
 
 <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/sunny_beach.webp">
 
-Then you can use this tool just like any other tool.  For example, let's improve the prompt  `a rabbit wearing a space suit` and generate an image of it.
+Then you can use this tool just like any other tool.  For example, let's improve the prompt  `a rabbit wearing a space suit` and generate an image of it. This example also shows how you can pass additional arguments to the agent.
 
 ```python
 from smolagents import CodeAgent, HfApiModel
@@ -140,7 +140,7 @@ model = HfApiModel("Qwen/Qwen2.5-Coder-32B-Instruct")
 agent = CodeAgent(tools=[image_generation_tool], model=model)
 
 agent.run(
-    "Improve this prompt, then generate an image of it.", prompt='A rabbit wearing a space suit'
+    "Improve this prompt, then generate an image of it.", additional_args={'user_prompt': 'A rabbit wearing a space suit'}
 )
 ```
 


### PR DESCRIPTION
Love your work! I am going to fix a couple of bugs in the docs to get going, here is the first one 🤗

The current example for generating an image with an improved prompt fails with:
"TypeError: MultiStepAgent.run() got an unexpected keyword argument 'prompt'" (both in 1.3.0 and the version before)

Seems like the way to pass additional args was changed to use a dict with the name additional_args. Looked it up in the code, changed it accordingly, tested it, works. 
I have also included a hint to the additional_args option in the text and renamed 'prompt' to 'user_prompt' to make the example easier to understand.