### PR TITLE
Add resizeable option to Gradio UI component for better usabilty

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -184,6 +184,7 @@ class GradioUI:
                     None,
                     "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/mascot_smol.png",
                 ),
+                resizeable=True,
             )
             # If an upload folder is provided, enable the upload feature
             if self.file_upload_folder is not None:


### PR DESCRIPTION
A small change with huge impact. Allows the user of the Chat UI to resize the chat box. This is especially helpful when the Agent creates long outputs and there is screen estate left.