### PR TITLE
Make openai dependency optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 lint.ignore = ["F403"]
 
 [project.optional-dependencies]
+openai = ["openai>=1.58.1"]
 dev = [
   "openai>=1.58.1",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "duckduckgo-search>=6.3.7",
   "python-dotenv>=1.0.1",
   "e2b-code-interpreter>=1.0.3",
-  "openai>=1.58.1",
 ]
 
 [tool.ruff]
@@ -31,6 +30,7 @@ lint.ignore = ["F403"]
 
 [project.optional-dependencies]
 dev = [
+  "openai>=1.58.1",
   "torch",
   "torchaudio",
   "torchvision",
@@ -40,6 +40,7 @@ dev = [
   "litellm>=1.55.10",
 ]
 test = [
+  "openai>=1.58.1",
   "torch",
   "torchaudio",
   "torchvision",

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -34,8 +34,6 @@ from transformers import (
 )
 from transformers.utils.import_utils import _is_package_available
 
-import openai
-
 from .tools import Tool
 
 logger = logging.getLogger(__name__)
@@ -572,6 +570,12 @@ class OpenAIServerModel(Model):
         api_key: str,
         **kwargs,
     ):
+        try:
+            import openai
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "Please install 'openai' to use OpenAIServerModel: `pip install 'openai>=1.58.1'`"
+            ) from None
         super().__init__()
         self.model_id = model_id
         self.client = openai.OpenAI(

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -574,7 +574,7 @@ class OpenAIServerModel(Model):
             import openai
         except ModuleNotFoundError:
             raise ModuleNotFoundError(
-                "Please install 'openai' to use OpenAIServerModel: `pip install 'openai>=1.58.1'`"
+                "Please install 'openai' extra to use OpenAIServerModel: `pip install 'smolagents[openai]'`"
             ) from None
         super().__init__()
         self.model_id = model_id


### PR DESCRIPTION
Make `openai` dependency optional.

I think we could reduce the required dependencies upon installation of `smolagents` to some minimal set, and set all the other dependencies as optional:
- `openai` dependency could be made an optional dependency: only required if the user wants to use `OpenAIServerModel`
- I could also set other dependencies as optional
- eventually, we could provide some easy way to install optional dependencies by using extras
  - EDIT: In the line with this PR by @Wauplin (I just saw it)
    - #229

Let me know what you think, @aymeric-roucher.