### PR TITLE
Check authorized imports in LocalPythonInterpreter constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ style:
 # Run smolagents tests
 test:
 	pytest ./tests/
+
+test-no-docs:
+	pytest ./tests/ --ignore ./tests/test_all_docs.py

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -21,6 +21,7 @@ import math
 import re
 from collections.abc import Mapping
 from importlib import import_module
+from importlib.util import find_spec
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -1530,6 +1531,11 @@ class LocalPythonInterpreter:
             **BASE_PYTHON_TOOLS.copy(),
         }
         # TODO: assert self.authorized imports are all installed locally
+        missing_modules = [imp for imp in self.authorized_imports if find_spec(imp) is None]
+        if missing_modules:
+            raise InterpreterError(
+                f"The authrorized modules {missing_modules} are not installed on this system.")
+
 
     def __call__(
         self, code_action: str, additional_variables: Dict

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1530,7 +1530,7 @@ class LocalPythonInterpreter:
             **tools,
             **BASE_PYTHON_TOOLS.copy(),
         }
-        # TODO: assert self.authorized imports are all installed locally
+        # assert self.authorized imports are all installed locally
         missing_modules = [imp for imp in self.authorized_imports if find_spec(imp) is None]
         if missing_modules:
             raise InterpreterError(

--- a/tests/test_python_interpreter.py
+++ b/tests/test_python_interpreter.py
@@ -23,6 +23,7 @@ from smolagents.local_python_executor import (
     InterpreterError,
     evaluate_python_code,
     fix_final_answer_code,
+    LocalPythonInterpreter,
 )
 
 
@@ -453,6 +454,19 @@ if char.isalpha():
         evaluate_python_code(code, authorized_imports=["*"], state={})
         with pytest.raises(InterpreterError):
             evaluate_python_code(code, authorized_imports=["random"], state={})
+
+    def test_uninstalled_imports(self):
+        assert LocalPythonInterpreter(additional_authorized_imports=["math"], tools={})
+        with pytest.raises(InterpreterError):
+            LocalPythonInterpreter(
+                additional_authorized_imports=["i_do_not_exist"],
+                tools={}
+            )
+        with pytest.raises(InterpreterError):
+            LocalPythonInterpreter(
+                additional_authorized_imports=["math", "i_do_not_exist", "os"],
+                tools={}
+            )
 
     def test_multiple_comparators(self):
         code = "0 <= -1 < 4 and 0 <= -5 < 4"


### PR DESCRIPTION
Checking if authorized_imports exist was marked as TODO in the comment.
This MR implements this functionality and adds tests.
Also adds a test option to the makefile to skip the tests of DocStrings, which require API keys.