### PR TITLE
Fix Bug in from_langchain in tools.py

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -194,7 +194,7 @@ class Tool:
 
         assert getattr(self, "output_type", None) in AUTHORIZED_TYPES
 
-        # Validate forward function signature, except for Tools that use a "generic" signature (PipelineTool, SpaceToolWrapper)
+        # Validate forward function signature, except for Tools that use a "generic" signature (PipelineTool, SpaceToolWrapper, LangChainToolWrapper)
         if not (
             hasattr(self, "skip_forward_signature_validation")
             and getattr(self, "skip_forward_signature_validation") is True

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -697,6 +697,8 @@ class Tool:
         """
 
         class LangChainToolWrapper(Tool):
+            skip_forward_signature_validation = True
+
             def __init__(self, _langchain_tool):
                 self.name = _langchain_tool.name.lower()
                 self.description = _langchain_tool.description
@@ -707,6 +709,7 @@ class Tool:
                     input_content["description"] = ""
                 self.output_type = "string"
                 self.langchain_tool = _langchain_tool
+                self.is_initialized = True
 
             def forward(self, *args, **kwargs):
                 tool_input = kwargs.copy()


### PR DESCRIPTION
The `from_langchain` Tool example in the docs failed, because the implementation in the `LangChainToolWrapper` class did not skip the input validation (as implemented for `SpaceToolWrapper` and `PipelineTool`), so depending on the actual langchain tool spec it would fail. 
The langchain example in the "Tools - in depth guide" section currently yields:
_Exception: Tool's 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'._

After fixing this, the `LangChainToolWrapper` still failed because the `self.is_initialized` attribute was not set to `True` at the end of `__init__`. Also fixed. Should a from_langchain tool require longer loading of models etc, you could subclass it and implement a different behaviour in the `setup(self)` method. 