### PR TITLE
Fix: source code inspection in interactive shells

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ all = [
   "smolagents[accelerate,audio,gradio,litellm,mcp,openai,transformers]",
 ]
 test = [
-  "ipython",  # for interactive environment tests
+  "ipython>=8.31.0", # for interactive environment tests
   "pytest>=8.1.0",
   "smolagents[all]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ all = [
   "smolagents[accelerate,audio,gradio,litellm,mcp,openai,transformers]",
 ]
 test = [
+  "ipython",  # for interactive environment tests
   "pytest>=8.1.0",
   "smolagents[all]",
 ]

--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -1,10 +1,9 @@
 import ast
 import builtins
 import inspect
-import textwrap
 from typing import Set
 
-from .utils import BASE_BUILTIN_MODULES
+from .utils import BASE_BUILTIN_MODULES, get_source
 
 
 _BUILTIN_NAMES = set(vars(builtins))
@@ -132,7 +131,7 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
     """
     errors = []
 
-    source = textwrap.dedent(inspect.getsource(cls))
+    source = get_source(cls)
 
     tree = ast.parse(source)
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -46,7 +46,7 @@ from ._transformers_utils import (
 )
 from .tool_validation import MethodChecker, validate_tool_attributes
 from .types import handle_agent_input_types, handle_agent_output_types
-from .utils import _is_package_available, _is_pillow_available, instance_to_source
+from .utils import _is_package_available, _is_pillow_available, get_source, instance_to_source
 
 
 logger = logging.getLogger(__name__)
@@ -229,8 +229,8 @@ class Tool:
         # Save tool file
         if type(self).__name__ == "SimpleTool":
             # Check that imports are self-contained
-            source_code = inspect.getsource(self.forward).replace("@tool", "")
-            forward_node = ast.parse(textwrap.dedent(source_code))
+            source_code = get_source(self.forward).replace("@tool", "")
+            forward_node = ast.parse(source_code)
             # If tool was created using '@tool' decorator, it has only a forward pass, so it's simpler to just get its code
             method_checker = MethodChecker(set())
             method_checker.visit(forward_node)
@@ -238,7 +238,7 @@ class Tool:
             if len(method_checker.errors) > 0:
                 raise (ValueError("\n".join(method_checker.errors)))
 
-            forward_source_code = inspect.getsource(self.forward)
+            forward_source_code = get_source(self.forward)
             tool_code = textwrap.dedent(
                 f"""
             from smolagents import Tool

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -20,6 +20,7 @@ import importlib.util
 import inspect
 import json
 import re
+import textwrap
 import types
 from functools import lru_cache
 from typing import Dict, Tuple, Union
@@ -204,7 +205,7 @@ def get_method_source(method):
     """Get source code for a method, including bound methods."""
     if isinstance(method, types.MethodType):
         method = method.__func__
-    return inspect.getsource(method).strip()
+    return get_source(method)
 
 
 def is_same_method(method1, method2):
@@ -278,7 +279,7 @@ def instance_to_source(instance, base_cls=None):
     }
 
     for name, method in methods.items():
-        method_source = inspect.getsource(method)
+        method_source = get_source(method)
         # Clean up the indentation
         method_lines = method_source.split("\n")
         first_line = method_lines[0]
@@ -311,6 +312,58 @@ def instance_to_source(instance, base_cls=None):
     final_lines.extend(class_lines)
 
     return "\n".join(final_lines)
+
+
+def get_source(obj) -> str:
+    """Get the source code of a class or callable object (e.g.: function, method).
+    First attempts to get the source code using `inspect.getsource`.
+    In a dynamic environment (e.g.: Jupyter, IPython), if this fails,
+    falls back to retrieving the source code from the current interactive shell session.
+
+    Args:
+        obj: A class or callable object (e.g.: function, method)
+
+    Returns:
+        str: The source code of the object, dedented and stripped
+
+    Raises:
+        TypeError: If object is not a class or callable
+        OSError: If source code cannot be retrieved from any source
+        ValueError: If source cannot be found in IPython history
+
+    Note:
+        TODO: handle Python standard REPL
+    """
+    if not (isinstance(obj, type) or callable(obj)):
+        raise TypeError(f"Expected class or callable, got {type(obj)}")
+
+    inspect_error = None
+    try:
+        return textwrap.dedent(inspect.getsource(obj)).strip()
+    except OSError as e:
+        # let's keep track of the exception to raise it if all further methods fail
+        inspect_error = e
+    try:
+        import IPython
+
+        shell = IPython.get_ipython()
+        if not shell:
+            raise ImportError("No active IPython shell found")
+        all_cells = "\n".join(shell.user_ns.get("In", [])).strip()
+        if not all_cells:
+            raise ValueError("No code cells found in IPython session")
+
+        tree = ast.parse(all_cells)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name == obj.__name__:
+                return textwrap.dedent("\n".join(all_cells.split("\n")[node.lineno - 1 : node.end_lineno])).strip()
+        raise ValueError(f"Could not find source code for {obj.__name__} in IPython history")
+    except ImportError:
+        # IPython is not available, let's just raise the original inspect error
+        raise inspect_error
+    except ValueError as e:
+        # IPython is available but we couldn't find the source code, let's raise the error
+        raise e from inspect_error
 
 
 __all__ = ["AgentError"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,7 +147,7 @@ def test_e2e_class_tool_save():
     test_tool = TestTool()
     with tempfile.TemporaryDirectory() as tmp_dir:
         test_tool.save(tmp_dir)
-        assert os.listdir(tmp_dir) == ["requirements.txt", "app.py", "tool.py"]
+        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
         assert (
             pathlib.Path(tmp_dir, "tool.py").read_text()
             == """from smolagents.tools import Tool
@@ -204,7 +204,7 @@ def test_e2e_ipython_class_tool_save():
         TestTool().save("{tmp_dir}")
     """)
         assert shell.run_cell(code_blob, store_history=True).success
-        assert os.listdir(tmp_dir) == ["requirements.txt", "app.py", "tool.py"]
+        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
         assert (
             pathlib.Path(tmp_dir, "tool.py").read_text()
             == """from smolagents.tools import Tool
@@ -255,7 +255,7 @@ def test_e2e_function_tool_save():
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         test_tool.save(tmp_dir)
-        assert os.listdir(tmp_dir) == ["requirements.txt", "app.py", "tool.py"]
+        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
         assert (
             pathlib.Path(tmp_dir, "tool.py").read_text()
             == """from smolagents import Tool
@@ -314,7 +314,7 @@ def test_e2e_ipython_function_tool_save():
         test_tool.save("{tmp_dir}")
         """)
         assert shell.run_cell(code_blob, store_history=True).success
-        assert os.listdir(tmp_dir) == ["requirements.txt", "app.py", "tool.py"]
+        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
         assert (
             pathlib.Path(tmp_dir, "tool.py").read_text()
             == """from smolagents import Tool

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,7 @@ def multiply(a, b):
 def ipython_shell():
     """Reset IPython shell before and after each test."""
     shell = InteractiveShell.instance()
+    shell.reset()  # Clean before test
     yield shell
     shell.reset()  # Clean after test
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,10 +84,9 @@ def ipython_shell():
     ],
 )
 def test_get_source_ipython(ipython_shell, obj_name, code_blob):
-    test_code = textwrap.dedent(code_blob).strip()
-    ipython_shell.user_ns["In"] = ["", test_code]
-    exec(test_code)
-    assert get_source(locals()[obj_name]) == code_blob
+    ipython_shell.run_cell(code_blob, store_history=True)
+    obj = ipython_shell.user_ns[obj_name]
+    assert get_source(obj) == code_blob
 
 
 def test_get_source_standard_class():


### PR DESCRIPTION
Hi 👋 This is my first contribution to smolagents, hope this helps!

This PR fixes source code inspection in interactive shells (IPython, Jupyter). Currently, using smolagents in these environments results in an `OSError` when `inspect.getsource` tries to find a source file that doesn't exist in interactive sessions.

The solution:
- Get code from current shell session
- Parse it using `ast`
- Walk through to find matching class/function definitions

Fixes #250 by @MoritzLaurer

Changes:
- Added source code extraction from IPython shells
- Added unit tests
- Added `ipython` as test dependency
- Nit: clean the source code as well (dedent & strip)

Tested in ipython & jupyter lab environments, as well as using a standard python invocation.
Tests & Lint seem to pass as well.

I'd be happy to add end-to-end tests if desired!

Thanks for your time and review! 🙏