### PR TITLE
Add huggingface-hub as required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+  "huggingface-hub>=0.24.0",
   "requests>=2.32.3",
   "rich>=13.9.4",
   "pandas>=2.2.3",


### PR DESCRIPTION
Add `huggingface-hub` as required dependency.

Fix #289.

CC: @Wauplin 