### PR TITLE
Remove pickle5 package from E2BExecutor

### DIFF
--- a/src/smolagents/e2b_executor.py
+++ b/src/smolagents/e2b_executor.py
@@ -54,7 +54,7 @@ class E2BExecutor:
         # )
         # print("Installation of agents package finished.")
         self.logger = logger
-        additional_imports = additional_imports + ["pickle5", "smolagents"]
+        additional_imports = additional_imports + ["smolagents"]
         if len(additional_imports) > 0:
             execution = self.sbx.commands.run("pip install " + " ".join(additional_imports))
             if execution.error:


### PR DESCRIPTION
Remove `pickle5` package from E2BExecutor.

The `pickle5` package is only necessary for Python 3.5, 3.6 and 3.7, but `smolagents` requires Python >= 3.10.