### PR TITLE
Move torchvision to the torch extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ dependencies = [
   "pillow>=11.0.0",
   "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
-  "torchvision"
 ]
 
 [project.optional-dependencies]
 torch = [
   "torch",
+  "torchvision",
 ]
 audio = [
   "soundfile",


### PR DESCRIPTION
With `torchvision` being made a requirement, installing `smolagents` doesn't feel like installing something "smol". `torch` is an extra and `torchvision` should be put there too.