### PR TITLE
Local interpreter security: prevent builtins functions from being used if they have not been added as tools

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -17,6 +17,7 @@
 import ast
 import builtins
 import difflib
+import inspect
 import math
 import re
 from collections.abc import Mapping
@@ -643,8 +644,14 @@ def evaluate_call(
             # cap the number of lines
             return None
         else:  # Assume it's a callable object
-            if (func in [eval, compile, exec]) and (func not in static_tools.values()):
-                raise InterpreterError(f"Invoking eval, compile or exec is not allowed ({func_name}).")
+            if (
+                (inspect.getmodule(func) == builtins)
+                and inspect.isbuiltin(func)
+                and (func not in static_tools.values())
+            ):
+                raise InterpreterError(
+                    f"Invoking a builtin function that has not been explicitly added as a tool is not allowed ({func_name})."
+                )
             return func(*args, **kwargs)
 
 


### PR DESCRIPTION
#274  blocked eval, compile and exec from being invoked through the ```__self__```attribute, but there are several other functions in ```builtins``` that may be dangerous (for instance ```breakpoint```, ```open```, ```__import__```). This PR would prevent any ```builtins``` function from being invoked if it has not been explicitely added as a tool.