### PR TITLE
Update README and documentation to clarify Hub integrations with Gradio Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ limitations under the License.
 🧑‍💻 **First-class support for Code Agents**, i.e. agents that write their actions in code (as opposed to "agents being used to write code"). To make it secure, we support executing in sandboxed environments via [E2B](https://e2b.dev/).
  - On top of this [`CodeAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.CodeAgent) class, we still support the standard [`ToolCallingAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.ToolCallingAgent) that writes actions as JSON/text blobs.
 
-🤗 **Hub integrations**: you can share and load tools to/from the Hub, and more is to come!
+🤗 **Hub integrations**: you can share and load Gradio Spaces as tools to/from the Hub, and more is to come!
 
 🌐 **Support for any LLM**: it supports models hosted on the Hub loaded in their `transformers` version or through our inference API, but also supports models from OpenAI, Anthropic and many others via our [LiteLLM](https://www.litellm.ai/) integration.
 
 Full documentation can be found [here](https://huggingface.co/docs/smolagents/index).
 
-> [!NOTE]  
+> [!NOTE]
 > Check the our [launch blog post](https://huggingface.co/blog/smolagents) to learn more about `smolagents`!
 
 ## Quick demo
@@ -54,7 +54,7 @@ pip install smolagents
 ```
 Then define your agent, give it the tools it needs and run it!
 ```py
-from smolagents import CodeAgent, DuckDuckGoSearchTool, HfApiModel
+from smolagents import CodeAgent, DuckDuckGoSearchTool, HfApiModel,
 
 agent = CodeAgent(tools=[DuckDuckGoSearchTool()], model=HfApiModel())
 

--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -29,7 +29,7 @@ This library offers:
 
 🧑‍💻 **First-class support for Code Agents**, i.e. agents that write their actions in code (as opposed to "agents being used to write code"), [read more here](tutorials/secure_code_execution).
 
-🤗 **Hub integrations**: you can share and load tools to/from the Hub, and more is to come!
+🤗 **Hub integrations**: you can share and load Gradio Spaces as tools to/from the Hub, and more is to come!
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">


### PR DESCRIPTION
- Changed the description of Hub integrations to specify the sharing and loading of Gradio Spaces as tools.
- Fixed a formatting issue in the code snippet by removing an extraneous comma in the import statement.