### PR TITLE
Minor fix: adding a 60 seconds timeout to the visit webpage tool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -225,8 +225,8 @@ class VisitWebpageTool(Tool):
                 "You must install packages `markdownify` and `requests` to run this tool: for instance run `pip install markdownify requests`."
             ) from e
         try:
-            # Send a GET request to the URL with a 60-second timeout
-            response = requests.get(url, timeout=60)
+            # Send a GET request to the URL with a 20-second timeout
+            response = requests.get(url, timeout=20)
             response.raise_for_status()  # Raise an exception for bad status codes
 
             # Convert the HTML content to Markdown

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -225,8 +225,8 @@ class VisitWebpageTool(Tool):
                 "You must install packages `markdownify` and `requests` to run this tool: for instance run `pip install markdownify requests`."
             ) from e
         try:
-            # Send a GET request to the URL
-            response = requests.get(url)
+            # Send a GET request to the URL with a 60-second timeout
+            response = requests.get(url, timeout=60)
             response.raise_for_status()  # Raise an exception for bad status codes
 
             # Convert the HTML content to Markdown
@@ -237,6 +237,8 @@ class VisitWebpageTool(Tool):
 
             return truncate_content(markdown_content, 10000)
 
+        except requests.exceptions.Timeout:
+            return "The request timed out. Please try again later or check the URL."
         except RequestException as e:
             return f"Error fetching the webpage: {str(e)}"
         except Exception as e:


### PR DESCRIPTION
Some site may be unresponsive and leave the agent hanging for a while. Adding a 60 seconds time cutoff for the request to url to conclude in the visit_webpage tool