### PR TITLE
Refactor evaluate_augassign and test all operators

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -369,84 +369,45 @@ def evaluate_augassign(
         if isinstance(current_value, list):
             if not isinstance(value_to_add, list):
                 raise InterpreterError(f"Cannot add non-list value {value_to_add} to a list.")
-            try:
-                updated_value = current_value.__iadd__(value_to_add)
-            except AttributeError:
-                updated_value = current_value + value_to_add
+            current_value += value_to_add
         else:
-            try:
-                updated_value = current_value.__iadd__(value_to_add)
-            except AttributeError:
-                updated_value = current_value + value_to_add
+            current_value += value_to_add
     elif isinstance(expression.op, ast.Sub):
-        try:
-            updated_value = current_value.__isub__(value_to_add)
-        except AttributeError:
-            updated_value = current_value - value_to_add
+        current_value -= value_to_add
     elif isinstance(expression.op, ast.Mult):
-        try:
-            updated_value = current_value.__imul__(value_to_add)
-        except AttributeError:
-            updated_value = current_value * value_to_add
+        current_value *= value_to_add
     elif isinstance(expression.op, ast.Div):
-        try:
-            updated_value = current_value.__itruediv__(value_to_add)
-        except AttributeError:
-            updated_value = current_value / value_to_add
+        current_value /= value_to_add
     elif isinstance(expression.op, ast.Mod):
-        try:
-            updated_value = current_value.__imod__(value_to_add)
-        except AttributeError:
-            updated_value = current_value % value_to_add
+        current_value %= value_to_add
     elif isinstance(expression.op, ast.Pow):
-        try:
-            updated_value = current_value.__ipow__(value_to_add)
-        except AttributeError:
-            updated_value = current_value**value_to_add
+        current_value **= value_to_add
     elif isinstance(expression.op, ast.FloorDiv):
-        try:
-            updated_value = current_value.__ifloordiv__(value_to_add)
-        except AttributeError:
-            updated_value = current_value // value_to_add
+        current_value //= value_to_add
     elif isinstance(expression.op, ast.BitAnd):
-        try:
-            updated_value = current_value.__iand__(value_to_add)
-        except AttributeError:
-            updated_value = current_value & value_to_add
+        current_value &= value_to_add
     elif isinstance(expression.op, ast.BitOr):
-        try:
-            updated_value = current_value.__ior__(value_to_add)
-        except AttributeError:
-            updated_value = current_value | value_to_add
+        current_value |= value_to_add
     elif isinstance(expression.op, ast.BitXor):
-        try:
-            updated_value = current_value.__ixor__(value_to_add)
-        except AttributeError:
-            updated_value = current_value ^ value_to_add
+        current_value ^= value_to_add
     elif isinstance(expression.op, ast.LShift):
-        try:
-            updated_value = current_value.__ilshift__(value_to_add)
-        except AttributeError:
-            updated_value = current_value << value_to_add
+        current_value <<= value_to_add
     elif isinstance(expression.op, ast.RShift):
-        try:
-            updated_value = current_value.__irshift__(value_to_add)
-        except AttributeError:
-            updated_value = current_value >> value_to_add
+        current_value >>= value_to_add
     else:
         raise InterpreterError(f"Operation {type(expression.op).__name__} is not supported.")
 
-    # Update the state
+    # Update the state: current_value has been updated in-place
     set_value(
         expression.target,
-        updated_value,
+        current_value,
         state,
         static_tools,
         custom_tools,
         authorized_imports,
     )
 
-    return updated_value
+    return current_value
 
 
 def evaluate_boolop(


### PR DESCRIPTION
Refactor `evaluate_augassign` and test all operators.

This PR refactors the code (by making it simpler and equivalent) introduced by:
- #285