### PR TITLE
Improve static tools initialization safety

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1267,7 +1267,7 @@ def evaluate_python_code(
     if state is None:
         state = {}
     static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools.copy() if custom_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
     result = None
     global PRINT_OUTPUTS
     PRINT_OUTPUTS = ""

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1266,10 +1266,8 @@ def evaluate_python_code(
 
     if state is None:
         state = {}
-    if static_tools is None:
-        static_tools = {}
-    if custom_tools is None:
-        custom_tools = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools.copy() if custom_tools is not None else {}
     result = None
     global PRINT_OUTPUTS
     PRINT_OUTPUTS = ""


### PR DESCRIPTION
Create a copy of static_tools to avoid modifying the original object.