### PR TITLE
Append unused error message to memory

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -294,10 +294,11 @@ class MultiStepAgent:
                         + str(step_log.error)
                         + "\nNow let's retry: take care not to repeat previous errors! If you have retried several times, try a completely different approach.\n"
                     )
-                    tool_response_message = {
+                    error_message = {
                         "role": MessageRole.ASSISTANT,
                         "content": message_content,
                     }
+                    memory.append(error_message)
                 if step_log.tool_calls is not None and (
                     step_log.error is not None or step_log.observations is not None
                 ):


### PR DESCRIPTION
Rename `tool_response_message` to `error_message` and append it to `messages`.

Currently, the variable `tool_response_message` in this conditional statement is not used: https://github.com/huggingface/smolagents/blob/fe2f4e735caae669949dae31905756ad70fcf63e/src/smolagents/agents.py#L291-L301

See related discussion in:
- https://github.com/huggingface/smolagents/pull/220#discussion_r1925897201