### PR TITLE
Add authorized_local_functions parameter to CodeAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -883,6 +883,7 @@ class CodeAgent(MultiStepAgent):
         planning_interval: Optional[int] = None,
         use_e2b_executor: bool = False,
         max_print_outputs_length: Optional[int] = None,
+        authorized_local_functions: Optional[Dict[str, Callable]] = None,
         **kwargs,
     ):
         if system_prompt is None:
@@ -919,6 +920,9 @@ class CodeAgent(MultiStepAgent):
                 self.logger,
             )
         else:
+            if authorized_local_functions:
+                all_tools = {**all_tools, **authorized_local_functions}
+
             self.python_executor = LocalPythonInterpreter(
                 self.additional_authorized_imports,
                 all_tools,


### PR DESCRIPTION
# Add `authorized_local_functions` parameter to `CodeAgent`

## Problem
Currently, `LocalPythonInterpreter `supports custom tools through the tools parameter, but these tools must be of `Tool` type. In some scenarios, we need to use basic Python functions (like `open`, etc.) in the `LocalPythonInterpreter` code execution environment, but there is no straightforward way to achieve this.

## Solution
Add an `authorized_local_functions` parameter that allows users to specify which Python functions can be used in the `LocalPythonInterpreter ` code execution environment. This change:

1. Adds `authorized_local_functions` parameter to `CodeAgent`

## Usage Example
```python
agent = CodeAgent(
    tools=[...],
    model=model,
    authorized_local_functions={"open": open}  # Allow using open function in LocalPythonInterpreter
)
```