### PR TITLE
fix: adjust tools dict merge order

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1324,8 +1324,8 @@ class LocalPythonInterpreter:
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
         # Add base trusted tools to list
         self.static_tools = {
-            **tools,
             **BASE_PYTHON_TOOLS.copy(),
+            **tools
         }
         # TODO: assert self.authorized imports are all installed locally
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1323,10 +1323,7 @@ class LocalPythonInterpreter:
         self.additional_authorized_imports = additional_authorized_imports
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
         # Add base trusted tools to list
-        self.static_tools = {
-            **BASE_PYTHON_TOOLS.copy(),
-            **tools
-        }
+        self.static_tools = {**BASE_PYTHON_TOOLS.copy(), **tools}
         # TODO: assert self.authorized imports are all installed locally
 
     def __call__(self, code_action: str, additional_variables: Dict) -> Tuple[Any, str, bool]:


### PR DESCRIPTION
# Adjust Tools Dictionary Merge Order

## Problem
Currently, when merging `tools` and `BASE_PYTHON_TOOLS` dictionaries in `LocalPythonInterpreter.__init__`, base tools take precedence over custom tools. This prevents users from effectively overriding default tool implementations.

## Solution
Reversed the merge order of dictionaries to ensure custom tools have higher priority:
```python
self.static_tools = {
    **BASE_PYTHON_TOOLS.copy(),
    **tools,  # Now custom tools can override base tools
}
```