### PR TITLE
Fix Extra planning

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -265,14 +265,14 @@ class MultiStepAgent:
             elif isinstance(step_log, PlanningStep):
                 thought_message = {
                     "role": MessageRole.ASSISTANT,
-                    "content": [{"type": "text", "text":"[FACTS LIST]:\n" + step_log.facts.strip()}],
+                    "content": [{"type": "text", "text": "[FACTS LIST]:\n" + step_log.facts.strip()}],
                 }
                 memory.append(thought_message)
 
                 if not summary_mode:
                     thought_message = {
                         "role": MessageRole.ASSISTANT,
-                        "content": [{"type": "text", "text":"[PLAN]:\n" + step_log.plan.strip()}],
+                        "content": [{"type": "text", "text": "[PLAN]:\n" + step_log.plan.strip()}],
                     }
                     memory.append(thought_message)
 
@@ -719,12 +719,12 @@ Now begin!""",
                     {
                         "type": "text",
                         "text": USER_PROMPT_PLAN_UPDATE.format(
-                                    task=task,
-                                    tool_descriptions=get_tool_descriptions(self.tools, self.tool_description_template),
-                                    managed_agents_descriptions=(show_agents_descriptions(self.managed_agents)),
-                                    facts_update=facts_update,
-                                    remaining_steps=(self.max_steps - step),
-                                )
+                            task=task,
+                            tool_descriptions=get_tool_descriptions(self.tools, self.tool_description_template),
+                            managed_agents_descriptions=(show_agents_descriptions(self.managed_agents)),
+                            facts_update=facts_update,
+                            remaining_steps=(self.max_steps - step),
+                        ),
                     }
                 ],
             }

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -265,14 +265,14 @@ class MultiStepAgent:
             elif isinstance(step_log, PlanningStep):
                 thought_message = {
                     "role": MessageRole.ASSISTANT,
-                    "content": "[FACTS LIST]:\n" + step_log.facts.strip(),
+                    "content": [{"type": "text", "text":"[FACTS LIST]:\n" + step_log.facts.strip()}],
                 }
                 memory.append(thought_message)
 
                 if not summary_mode:
                     thought_message = {
                         "role": MessageRole.ASSISTANT,
-                        "content": "[PLAN]:\n" + step_log.plan.strip(),
+                        "content": [{"type": "text", "text":"[PLAN]:\n" + step_log.plan.strip()}],
                     }
                     memory.append(thought_message)
 
@@ -700,28 +700,33 @@ Now begin!""",
             # Redact updated facts
             facts_update_system_prompt = {
                 "role": MessageRole.SYSTEM,
-                "content": SYSTEM_PROMPT_FACTS_UPDATE,
+                "content": [{"type": "text", "text": SYSTEM_PROMPT_FACTS_UPDATE}],
             }
             facts_update_message = {
                 "role": MessageRole.USER,
-                "content": USER_PROMPT_FACTS_UPDATE,
+                "content": [{"type": "text", "text": USER_PROMPT_FACTS_UPDATE}],
             }
             facts_update = self.model([facts_update_system_prompt] + agent_memory + [facts_update_message]).content
 
             # Redact updated plan
             plan_update_message = {
                 "role": MessageRole.SYSTEM,
-                "content": SYSTEM_PROMPT_PLAN_UPDATE.format(task=task),
+                "content": [{"type": "text", "text": SYSTEM_PROMPT_PLAN_UPDATE.format(task=task)}],
             }
             plan_update_message_user = {
                 "role": MessageRole.USER,
-                "content": USER_PROMPT_PLAN_UPDATE.format(
-                    task=task,
-                    tool_descriptions=get_tool_descriptions(self.tools, self.tool_description_template),
-                    managed_agents_descriptions=(show_agents_descriptions(self.managed_agents)),
-                    facts_update=facts_update,
-                    remaining_steps=(self.max_steps - step),
-                ),
+                "content": [
+                    {
+                        "type": "text",
+                        "text": USER_PROMPT_PLAN_UPDATE.format(
+                                    task=task,
+                                    tool_descriptions=get_tool_descriptions(self.tools, self.tool_description_template),
+                                    managed_agents_descriptions=(show_agents_descriptions(self.managed_agents)),
+                                    facts_update=facts_update,
+                                    remaining_steps=(self.max_steps - step),
+                                )
+                    }
+                ],
             }
             plan_update = self.model(
                 [plan_update_message] + agent_memory + [plan_update_message_user],

--- a/src/smolagents/prompts.py
+++ b/src/smolagents/prompts.py
@@ -433,7 +433,7 @@ Now begin! Write your plan below."""
 
 SYSTEM_PROMPT_FACTS_UPDATE = """
 You are a world expert at gathering known and unknown facts based on a conversation.
-Below you will find a task, and ahistory of attempts made to solve the task. You will have to produce a list of these:
+Below you will find a task, and a history of attempts made to solve the task. You will have to produce a list of these:
 ### 1. Facts given in the task
 ### 2. Facts that we have learned
 ### 3. Facts still to look up


### PR DESCRIPTION
Code snippet to reproduce the bug:
```python
from smolagents import load_tool, CodeAgent, HfApiModel, DuckDuckGoSearchTool

# Import tool from Hub
image_generation_tool = load_tool("m-ric/text-to-image", trust_remote_code=True)

search_tool = DuckDuckGoSearchTool()

agent = CodeAgent(
    tools=[search_tool, image_generation_tool],
    model=HfApiModel("Qwen/Qwen2.5-Coder-32B-Instruct"),
    planning_interval=2 # This is where you activate planning!
)

# Run it!
result = agent.run(
    "How long would a cheetah at full speed take to run the length of Pont Alexandre III?",
)
```

Traceback:
```
[/usr/local/lib/python3.11/dist-packages/smolagents/models.py](https://localhost:8080/#) in get_clean_message_list(message_list, role_conversions, convert_images_to_image_urls, flatten_messages_as_text)
    227                 output_message_list[-1]["content"] += message["content"][0]["text"]
    228             else:
--> 229                 output_message_list[-1]["content"] += message["content"]
    230         else:
    231             if flatten_messages_as_text:

TypeError: can only concatenate str (not "list") to str
```

The error arises because `message["content"]` can take two different formats, a list or a string. To resolve this, convert `message["content"]` into a list.