### PR TITLE
Add pip install datasets to RAG example

### DIFF
--- a/docs/source/en/examples/rag.md
+++ b/docs/source/en/examples/rag.md
@@ -35,7 +35,7 @@ Let's build this system. 🛠️
 
 Run the line below to install required dependencies:
 ```bash
-!pip install smolagents pandas langchain langchain-community sentence-transformers rank_bm25 --upgrade -q
+!pip install smolagents pandas langchain langchain-community sentence-transformers datasets rank_bm25 --upgrade -q
 ```
 To call the HF Inference API, you will need a valid token as your environment variable `HF_TOKEN`.
 We use python-dotenv to load it.


### PR DESCRIPTION
datasets is used in the code later and would throw an error

in the below code: 

```python
import datasets
from langchain.docstore.document import Document
from langchain.text_splitter import RecursiveCharacterTextSplitter
from langchain_community.retrievers import BM25Retriever

knowledge_base = datasets.load_dataset("m-ric/huggingface_doc", split="train")
knowledge_base = knowledge_base.filter(lambda row: row["source"].startswith("huggingface/transformers"))

source_docs = [
    Document(page_content=doc["text"], metadata={"source": doc["source"].split("/")[1]})
    for doc in knowledge_base
]

text_splitter = RecursiveCharacterTextSplitter(
    chunk_size=500,
    chunk_overlap=50,
    add_start_index=True,
    strip_whitespace=True,
    separators=["\n\n", "\n", ".", " ", ""],
)
docs_processed = text_splitter.split_documents(source_docs)
```