### PR TITLE
Docs: Text to sql example - minor naming / dedupe

### DIFF
--- a/docs/source/en/examples/text_to_sql.md
+++ b/docs/source/en/examples/text_to_sql.md
@@ -45,7 +45,6 @@ from sqlalchemy import (
 engine = create_engine("sqlite:///:memory:")
 metadata_obj = MetaData()
 
-# create city SQL table
 table_name = "receipts"
 receipts = Table(
     table_name,
@@ -63,10 +62,14 @@ rows = [
     {"receipt_id": 3, "customer_name": "Woodrow Wilson", "price": 53.43, "tip": 5.43},
     {"receipt_id": 4, "customer_name": "Margaret James", "price": 21.11, "tip": 1.00},
 ]
-for row in rows:
-    stmt = insert(receipts).values(**row)
-    with engine.begin() as connection:
-        cursor = connection.execute(stmt)
+
+def insert_rows(engine, table, rows):
+    for row in rows:
+        stmt = insert(table).values(**row)
+        with engine.begin() as connection:
+            connection.execute(stmt)
+
+insert_rows(engine, receipts, rows)
 ```
 
 ### Build our agent
@@ -144,7 +147,7 @@ So let’s make a second table recording the names of waiters for each receipt_i
 
 ```py
 table_name = "waiters"
-receipts = Table(
+waiters = Table(
     table_name,
     metadata_obj,
     Column("receipt_id", Integer, primary_key=True),
@@ -158,10 +161,8 @@ rows = [
     {"receipt_id": 3, "waiter_name": "Michael Watts"},
     {"receipt_id": 4, "waiter_name": "Margaret James"},
 ]
-for row in rows:
-    stmt = insert(receipts).values(**row)
-    with engine.begin() as connection:
-        cursor = connection.execute(stmt)
+
+insert_rows(engine, waiters, rows)
 ```
 Since we changed the table, we update the `SQLExecutorTool` with this table’s description to let the LLM properly leverage information from this table.
 

--- a/docs/source/en/examples/text_to_sql.md
+++ b/docs/source/en/examples/text_to_sql.md
@@ -45,6 +45,12 @@ from sqlalchemy import (
 engine = create_engine("sqlite:///:memory:")
 metadata_obj = MetaData()
 
+def insert_rows_into_table(rows, table, engine=engine):
+    for row in rows:
+        stmt = insert(table).values(**row)
+        with engine.begin() as connection:
+            connection.execute(stmt)
+
 table_name = "receipts"
 receipts = Table(
     table_name,
@@ -62,14 +68,7 @@ rows = [
     {"receipt_id": 3, "customer_name": "Woodrow Wilson", "price": 53.43, "tip": 5.43},
     {"receipt_id": 4, "customer_name": "Margaret James", "price": 21.11, "tip": 1.00},
 ]
-
-def insert_rows(engine, table, rows):
-    for row in rows:
-        stmt = insert(table).values(**row)
-        with engine.begin() as connection:
-            connection.execute(stmt)
-
-insert_rows(engine, receipts, rows)
+insert_rows_into_table(rows, receipts)
 ```
 
 ### Build our agent
@@ -161,8 +160,7 @@ rows = [
     {"receipt_id": 3, "waiter_name": "Michael Watts"},
     {"receipt_id": 4, "waiter_name": "Margaret James"},
 ]
-
-insert_rows(engine, waiters, rows)
+insert_rows_into_table(rows, waiters)
 ```
 Since we changed the table, we update the `SQLExecutorTool` with this table’s description to let the LLM properly leverage information from this table.
 


### PR DESCRIPTION
1. Fix name to waiters for second table
2. Remove incorrect comment
3. Dedupe insert row logic - it's not central to the example so shouldn't be repeated

Thanks for the library, it looks great so far.

If not useful, happy to iterate, or feel free to close the PR and fix this up a different way