### PR TITLE
chore: Fix Typo by Calling is_torch_available() in AgentAudio Class

### DIFF
--- a/src/smolagents/types.py
+++ b/src/smolagents/types.py
@@ -172,7 +172,7 @@ class AgentAudio(AgentType, str):
     """
 
     def __init__(self, value, samplerate=16_000):
-        if not _is_package_available("soundfile") or not is_torch_available:
+        if not _is_package_available("soundfile") or not is_torch_available():
             raise ModuleNotFoundError(
                 "Please install 'audio' extra to use AgentAudio: `pip install 'smolagents[audio]'`"
             )


### PR DESCRIPTION
## Summary

Correct the conditional checks in the `AgentAudio` class by invoking the `is_torch_available` function. This prevents unintended `ImportError` when `torch` is not installed.

## Changes

* (typo) issue resolved: The `is_torch_available` function was referenced without parentheses, causing it to be treated as a variable rather than being executed. This led to incorrect evaluation of the condition and potential `ImportError` when `torch` is unavailable.