### PR TITLE
Fix tool collection from hub

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -27,6 +27,12 @@ from rich.rule import Rule
 from rich.syntax import Syntax
 from rich.text import Text
 
+
+try:
+    from transformers.agents.tools import Tool as transformers_Tool
+except ImportError:
+    raise ImportError("The 'transformers' library is not installed. Please install it with: pip install transformers.")
+
 from .default_tools import TOOL_MAPPING, FinalAnswerTool
 from .e2b_executor import E2BExecutor
 from .local_python_executor import (
@@ -217,7 +223,10 @@ class MultiStepAgent:
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
         for tool in tools:
-            assert isinstance(tool, Tool), f"This element is not of class Tool: {str(tool)}"
+            if isinstance(tool, Tool) or isinstance(tool, transformers_Tool):
+                continue
+            else:
+                raise AssertionError(f"This element is not of class Tool or Pool: {str(tool)}")
         self.tools = {tool.name: tool for tool in tools}
         if add_base_tools:
             for tool_name, tool_class in TOOL_MAPPING.items():

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -31,7 +31,7 @@ from rich.text import Text
 try:
     from transformers.agents.tools import Tool as transformers_Tool
 except ImportError:
-    raise ImportError("The 'transformers' library is not installed. Please install it with: pip install transformers.")
+    transformers_Tool = None
 
 from .default_tools import TOOL_MAPPING, FinalAnswerTool
 from .e2b_executor import E2BExecutor
@@ -223,10 +223,10 @@ class MultiStepAgent:
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
         for tool in tools:
-            if isinstance(tool, Tool) or isinstance(tool, transformers_Tool):
+            if isinstance(tool, Tool) or (transformers_Tool is not None and isinstance(tool, transformers_Tool)):
                 continue
             else:
-                raise AssertionError(f"This element is not of class Tool or Pool: {str(tool)}")
+                raise AssertionError(f"This element is not of class Tool {str(tool)}")
         self.tools = {tool.name: tool for tool in tools}
         if add_base_tools:
             for tool_name, tool_class in TOOL_MAPPING.items():

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -38,6 +38,12 @@ from huggingface_hub import (
 from huggingface_hub.utils import is_torch_available
 from packaging import version
 
+
+try:
+    from transformers.agents.tools import Tool as transformers_Tool
+except ImportError:
+    raise ImportError("The 'transformers' library is not installed. Please install it with: pip install transformers.")
+
 from ._function_type_hints_utils import (
     TypeHintParsingException,
     _convert_type_hints_to_json_schema,
@@ -401,7 +407,7 @@ class Tool:
         # Get the tool's tool.py file.
         tool_file = hf_hub_download(
             repo_id,
-            "tool.py",
+            repo_id.split("/")[-1].replace("-", "_") + ".py",
             token=token,
             repo_type="space",
             cache_dir=kwargs.get("cache_dir"),
@@ -432,7 +438,7 @@ class Tool:
             # Find and instantiate the Tool class
             for item_name in dir(module):
                 item = getattr(module, item_name)
-                if isinstance(item, type) and issubclass(item, Tool) and item != Tool:
+                if isinstance(item, type) and issubclass(item, transformers_Tool) and item != Tool:
                     tool_class = item
                     break
 


### PR DESCRIPTION
Closes #154 

I think we can close #154, as I don't think this is an issue anymore. However, the example in the issue and the documentation currently do not run because the tool file name is different from `tool.py`. If we change the tool file name, the example in the docs will reference the Tool class from `transformers.agents.tools` and it will not run.

This PR builds upon the issue and adds support for running tools from the `transformers.agents.tools`. I’m not sure if we want to add support for `transformers.agents.tools`. Please let me know if any further changes are required.