### PR TITLE
Fix get safe module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ test = [
   "python-dotenv>=1.0.1", # For test_all_docs
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
-  "six>=1.17.0", # Already a dependency of many packages, but to be explicit
 ]
 dev = [
   "smolagents[quality,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test = [
   "python-dotenv>=1.0.1", # For test_all_docs
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
+  "six>=1.17.0", # Already a dependency of many packages, but to be explicit
 ]
 dev = [
   "smolagents[quality,test]",

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -18,6 +18,7 @@ import ast
 import builtins
 import difflib
 import inspect
+import logging
 import math
 import re
 from collections.abc import Mapping
@@ -29,6 +30,9 @@ import numpy as np
 import pandas as pd
 
 from .utils import BASE_BUILTIN_MODULES, truncate_content
+
+
+logger = logging.getLogger(__name__)
 
 
 class InterpreterError(ValueError):
@@ -960,6 +964,7 @@ def get_safe_module(raw_module, dangerous_patterns, authorized_imports, visited=
             pattern in raw_module.__name__.split(".") + [attr_name] and pattern not in authorized_imports
             for pattern in dangerous_patterns
         ):
+            logger.info(f"Skipping dangerous attribute {raw_module.__name__}.{attr_name}")
             continue
 
         try:

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -962,8 +962,14 @@ def get_safe_module(raw_module, dangerous_patterns, authorized_imports, visited=
         ):
             continue
 
-        attr_value = getattr(raw_module, attr_name)
-
+        try:
+            attr_value = getattr(raw_module, attr_name)
+        except ImportError as e:
+            # lazy / dynamic loading module -> INFO log and skip
+            logger.info(
+                f"Skipping import error while copying {raw_module.__name__}.{attr_name}: {type(e).__name__} - {e}"
+            )
+            continue
         # Recursively process nested modules, passing visited set
         if isinstance(attr_value, ModuleType):
             attr_value = get_safe_module(attr_value, dangerous_patterns, authorized_imports, visited=visited)

--- a/tests/test_python_interpreter.py
+++ b/tests/test_python_interpreter.py
@@ -1073,7 +1073,11 @@ def test_evaluate_augassign_custom(operator, expected_result):
     assert result == expected_result
 
 
-def test_get_safe_module_raises():
-    with pytest.raises(ModuleNotFoundError):
-        get_safe_module(six.moves, [], [], set())
-    assert "dbm_gnu" in dir(six.moves)
+def test_get_safe_module_handle_lazy_imports():
+    # get_safe_module does not raise errors for lazy imports anymore
+    # six.moves is used here as an example because it is a built-in module that
+    # has several lazy imports which would raise errors if not handled properly
+    # see: https://github.com/huggingface/smolagents/issues/339
+    six_move_copy = get_safe_module(six.moves, [], [], set())
+    # dbm_gnu is one of the lazy imports of six.moves
+    assert not hasattr(six_move_copy, "dbm_gnu")

--- a/tests/test_python_interpreter.py
+++ b/tests/test_python_interpreter.py
@@ -18,12 +18,14 @@ from textwrap import dedent
 
 import numpy as np
 import pytest
+import six
 
 from smolagents.default_tools import BASE_PYTHON_TOOLS
 from smolagents.local_python_executor import (
     InterpreterError,
     evaluate_python_code,
     fix_final_answer_code,
+    get_safe_module,
 )
 
 
@@ -1069,3 +1071,9 @@ def test_evaluate_augassign_custom(operator, expected_result):
     state = {}
     result, _ = evaluate_python_code(code, {}, state=state)
     assert result == expected_result
+
+
+def test_get_safe_module_raises():
+    with pytest.raises(ModuleNotFoundError):
+        get_safe_module(six.moves, [], [], set())
+    assert "dbm_gnu" in dir(six.moves)


### PR DESCRIPTION
Fixes https://github.com/huggingface/smolagents/issues/339 and fixes https://github.com/huggingface/smolagents/issues/291

The current `get_safe_module` eagerly imports dynamic & lazy imports, even unwanted ones.

One way to solve this issue is to wrap the `getattr` with a `try... except ImportError` and log.
Another way, less agressive, is to use `__dict__` instead of `dir` so that to not import dynamically added modules.. at the cost of missing dynamically added modules.

One can test the following, using uv:  
```bash
echo '# /// script
# requires-python = ">=3.10"
# dependencies = [
#   "matplotlib",
#   "smolagents@git+https://github.com/antoinejeannot/smolagents.git@fix-get-safe-module",
# ]
# ///

import smolagents


interpreter = smolagents.LocalPythonInterpreter(additional_authorized_imports=["matplotlib"], tools={})
interpreter("import matplotlib.pyplot as plt", {})' | uv run -
```

You are free to read per commit!

Thanks for reviewing @aymeric-roucher @albertvillanova 