### PR TITLE
Fix installation instruction for GradioUI in error message

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -181,7 +181,7 @@ class GradioUI:
     def __init__(self, agent: MultiStepAgent, file_upload_folder: str | None = None):
         if not _is_package_available("gradio"):
             raise ModuleNotFoundError(
-                "Please install 'gradio' extra to use the GradioUI: `pip install 'smolagents[audio]'`"
+                "Please install 'gradio' extra to use the GradioUI: `pip install 'smolagents[gradio]'`"
             )
         self.agent = agent
         self.file_upload_folder = file_upload_folder


### PR DESCRIPTION
Fix: error message for missing gradio package refers to smolagents[audio] instead of smolagents[gradio] package.