### PR TITLE
Minor fix for agent_from_any_llm.py example

### DIFF
--- a/examples/agent_from_any_llm.py
+++ b/examples/agent_from_any_llm.py
@@ -22,6 +22,7 @@ elif chosen_inference == "ollama":
         model_id="ollama_chat/llama3.2",
         api_base="http://localhost:11434",  # replace with remote open-ai compatible server if necessary
         api_key="your-api-key",  # replace with API key if necessary
+        num_ctx=8192 # ollama default is 2048 which will often fail horribly. 8192 works for easy tasks, more is better. Check https://huggingface.co/spaces/NyxKrage/LLM-Model-VRAM-Calculator to calculate how much VRAM this will need for the selected model.
     )
 
 elif chosen_inference == "litellm":
@@ -48,4 +49,4 @@ print("ToolCallingAgent:", agent.run("What's the weather like in Paris?"))
 
 agent = CodeAgent(tools=[get_weather], model=model)
 
-print("ToolCallingAgent:", agent.run("What's the weather like in Paris?"))
+print("CodeAgent:", agent.run("What's the weather like in Paris?"))


### PR DESCRIPTION
Again setting the num_ctx higher than the default 2048 is important,otherwise after more than 2 steps it will start to look for the age of the pope no matter what 😂
And minor error in the las print message which prints the wrong agent.