### PR TITLE
Fix and test MemoryStep

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -37,6 +37,7 @@ class ToolCall:
         }
 
 
+@dataclass
 class MemoryStep:
     raw: Any  # This is a placeholder for the raw data that the agent logs
 

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -39,8 +39,6 @@ class ToolCall:
 
 @dataclass
 class MemoryStep:
-    # raw: Any  # This is a placeholder for the raw data that the agent logs
-
     def dict(self):
         return asdict(self)
 

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -39,7 +39,7 @@ class ToolCall:
 
 @dataclass
 class MemoryStep:
-    raw: Any  # This is a placeholder for the raw data that the agent logs
+    # raw: Any  # This is a placeholder for the raw data that the agent logs
 
     def dict(self):
         return asdict(self)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,7 +1,10 @@
+import pytest
+
 from smolagents.memory import (
     ActionStep,
     AgentMemory,
     ChatMessage,
+    MemoryStep,
     Message,
     MessageRole,
     PlanningStep,
@@ -16,6 +19,21 @@ class TestAgentMemory:
         memory = AgentMemory(system_prompt=system_prompt)
         assert memory.system_prompt.system_prompt == system_prompt
         assert memory.steps == []
+
+
+class TestMemoryStep:
+    def test_initialization(self):
+        step = MemoryStep()
+        assert isinstance(step, MemoryStep)
+
+    def test_dict(self):
+        step = MemoryStep()
+        assert step.dict() == {}
+
+    def test_to_messages(self):
+        step = MemoryStep()
+        with pytest.raises(NotImplementedError):
+            step.to_messages()
 
 
 def test_action_step_to_messages():


### PR DESCRIPTION
Fix and test MemoryStep.

Note:
- .dict method was raising: TypeError: asdict() should be called on dataclass instances
- .raw attribute is never used
  - Why was this attribute added? CC: @clefourrier @aymeric-roucher 

TODO:
- [x] Decide about the .raw attribute