### PR TITLE
Fix ModuleNotFoundError: No module named 'cgi'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ gradio = [
 ]
 litellm = [
   "litellm>=1.55.10",
+  "legacy-cgi>=2.6.2",
 ]
 mcp = [
   "mcpadapt>=0.0.6",


### PR DESCRIPTION
This PR closes #441 