### PR TITLE
Remove unused ChatMessageToolCall raw argument

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -78,7 +78,7 @@ class ChatMessageToolCall:
     type: str
 
     @classmethod
-    def from_hf_api(cls, tool_call, raw) -> "ChatMessageToolCall":
+    def from_hf_api(cls, tool_call) -> "ChatMessageToolCall":
         return cls(
             function=ChatMessageToolCallDefinition.from_hf_api(tool_call.function),
             id=tool_call.id,


### PR DESCRIPTION
Remove unused `ChatMessageToolCall` raw argument.

Again, contrary to `ChatMessage.raw`, `ChatMessageToolCall` has no `raw` attribute, and therefore it makes no sense to pass the `raw` argument to its class method: the `raw` argument was ignored.

See similar issue with `MemoryStep.raw`:
- #432