### PR TITLE
enable pre-commit

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,26 +5,9 @@ on: [pull_request]
 jobs:
   check_code_quality:
     runs-on: ubuntu-latest
-    env:
-      UV_HTTP_TIMEOUT: 600 # max 10min to install deps
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-
-      # Setup venv
-      - name: Setup venv + uv
-        run: |
-          pip install --upgrade uv
-          uv venv
-
-      - name: Install dependencies
-        run: uv pip install "smolagents[quality] @ ."
-
-      # Equivalent of "make quality" but step by step
-      - run: uv run ruff check examples src tests utils # linter
-      - run: uv run ruff format --check examples src tests utils # formatter
-      - run: uv run python utils/check_tests_in_ci.py
+          python-version: "3.10"  # lower bound of the supported Python versions
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,26 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.9.4
     hooks:
       - id: ruff
         args:
           - --fix
       - id: ruff-format
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+
+  - repo: local
     hooks:
-      - id: check-merge-conflict
-      - id: check-yaml
+      - id: check-tests-in-ci
+        name: check tests listed in ci
+        entry: .pre-commit-hooks/check_tests_in_ci.py
+        language: python
+        always_run: true
+        pass_filenames: false
+        types: [python, yaml]
+        files: ^tests/.*\.py$|^\.github/workflows/tests\.yml$

--- a/.pre-commit-hooks/check_tests_in_ci.py
+++ b/.pre-commit-hooks/check_tests_in_ci.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # coding=utf-8
 # Copyright 2025-present, the HuggingFace Inc. team.
 #

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-.PHONY: quality style test docs utils
+.PHONY: quality style test
 
-check_dirs := examples src tests utils
+# quality and style targets are redundant
+# they are kept not to introduce a breaking change in users' workflows.
+# though style target is being deprecated and will be removed in the future.
 
 # Check code quality of the source code
 quality:
-	ruff check $(check_dirs)
-	ruff format --check $(check_dirs)
-	python utils/check_tests_in_ci.py
+	pre-commit run --all-files --show-diff-on-failure --color always
 
 # Format source code automatically
 style:
-	ruff check $(check_dirs) --fix
-	ruff format $(check_dirs)
-	
+	pre-commit run --all-files --show-diff-on-failure --color always
+	echo "\nDeprecated target. Use 'make quality' instead."
+
 # Run smolagents tests
 test:
-	pytest ./tests/
+	pytest

--- a/README.md
+++ b/README.md
@@ -99,24 +99,22 @@ At any moment, feel welcome to open an issue, citing your exact error traces and
 It's often even better to open a PR with your proposed fixes/changes!
 
 To install dev dependencies, run:
-```
+
+```bash
 pip install -e ".[dev]"
 ```
 
 When making changes to the codebase, please check that it follows the repo's code quality requirements by running:
-To check code quality of the source code:
-```
+
+```bash
 make quality
 ```
 
-If the checks fail, you can run the formatter with:
-```
-make style
-```
-
-And commit the changes.
+If any issues are found, some of them will get fixed automatically, some will need manual intervention.
+Once all issues are fixed, you can commit your changes!
 
 To run tests locally, run this command:
+
 ```bash
 make test
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,9 @@ openai = [
 ]
 telemetry = [
   "arize-phoenix",
-  "opentelemetry-sdk", 
+  "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
   "openinference-instrumentation-smolagents>=0.1.1"
-]
-quality = [
-  "ruff>=0.9.0",
 ]
 all = [
   "smolagents[accelerate,audio,e2b,gradio,litellm,mcp,openai,transformers,telemetry]",
@@ -74,8 +71,10 @@ test = [
   "rank-bm25", # For test_all_docs
 ]
 dev = [
-  "smolagents[quality,test]",
+  "smolagents[test]",
   "sqlalchemy", # for ./examples
+  "ruff==0.9.4", # for editor, synced with .pre-commit-config.yaml version
+  "pre-commit>=4.1.0",
 ]
 
 [tool.pytest.ini_options]
@@ -84,11 +83,19 @@ addopts = "-sv --durations=0"
 
 [tool.ruff]
 line-length = 119
-lint.ignore = [
-  "F403", # undefined-local-with-import-star
-  "E501", # line-too-long
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "W",   # pycodestyle warnings
 ]
-lint.select = ["E", "F", "I", "W"]
+
+ignore = [
+    "E501",    # Line too long (handled by formatter)
+    "F403", # undefined-local-with-import-star
+]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = [


### PR DESCRIPTION
This PR (re)enables pre-commit!

It has been discussed in a few issues & PRs now (https://github.com/huggingface/smolagents/issues/120, https://github.com/huggingface/smolagents/pull/119, https://github.com/huggingface/smolagents/pull/431), with good reason since it definitely improves the developer's workflow.

I've already ran into a few linting & formating issues myself with just a few PRs 😅

A few points:
- to share the same behavior locally and in the CI (which leads to pain), ruff was pinned in both the `pyproject.yaml` and `.pre-commit-config.toml`, let's bump it from time to time or setup a dependabot
- to assess quality, only pre-commit is used (more robust thanks to its dependencies isolation), but is iso-functional with a plain `ruff xyz` since both rely on the `pyproject.toml` for configuration
- ruff is still mentioned in `pyproject.toml` so that the developer and its editor code editor can pick it up from the virtualenv and apply linting / formating
- `make style` is redundant with `make quality`, so I deprecated it with a log for those who use it
- the quality workflow, thanks to some caching, can save up to 15s per run (when cache hit), this might definitely help the tests workflow as well
- ruff is now configured with the lower bound of supported versions (3.10, instead of 3.12) as recommended, which probably led to some flaky linting & formating issues
- the check tests in ci is now a `.pre-commit` hook 

[I have another PR](https://github.com/antoinejeannot/smolagents/pull/4/commits/4be7133d51e8307a07821cecd295eddf07915709) which adds a few needed additional rules to the linter but will lead to major merge conflicts across all opened PRs lol I'll open it in a second time.

Thanks for reviewing @aymeric-roucher @albertvillanova