### PR TITLE
Pass managed_agent kwargs as additional_params

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -965,7 +965,7 @@ class ManagedAgent:
 
     def __call__(self, request, **kwargs):
         full_task = self.write_full_task(request)
-        output = self.agent.run(full_task, **kwargs)
+        output = self.agent.run(full_task, additional_args=kwargs)
         if self.provide_run_summary:
             answer = f"Here is the final answer from your managed agent '{self.name}':\n"
             answer += str(output)


### PR DESCRIPTION
Currently you can't pass any `kwargs` from the manager agent to the managed agent because MultiStepAgent.run method doesn't support kwargs but it does have `additional_params`, which is empty for managed agents. 

This allows the manager agent to pass variables to managed agents by setting the `additional_params` while calling the managed agent.