### PR TITLE
Add quantization_config support to TransformersModel

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -491,7 +491,7 @@ class TransformersModel(Model):
         except ValueError as e:
             if "Unrecognized configuration class" in str(e):
                 self.model = AutoModelForImageTextToText.from_pretrained(
-                    model_id, 
+                    model_id,
                     device_map=device_map,
                     torch_dtype=torch_dtype,
                     quantization_config=quantization_config,
@@ -507,9 +507,9 @@ class TransformersModel(Model):
             self.model_id = default_model_id
             self.tokenizer = AutoTokenizer.from_pretrained(default_model_id)
             self.model = AutoModelForCausalLM.from_pretrained(
-                model_id, 
-                device_map=device_map, 
-                torch_dtype=torch_dtype, 
+                model_id,
+                device_map=device_map,
+                torch_dtype=torch_dtype,
                 quantization_config=quantization_config,
             )
 


### PR DESCRIPTION
## Add quantization_config support to TransformersModel

Hi, this PR adds support for using basic [quantization](https://huggingface.co/docs/transformers/main_classes/quantization#quantization) functionality from transformers with `TransformersModel` class.

### Motivation
Provide an easy way to load and quantize models using native features from transformers. This allows users to test models locally without needing to load their pre-quantized versions.

Another way to achieve this, would be to allow `TransformersModel` class to be initialized from models and tokenizers from transformers directly, but if we need to keep it small and consistent with other model classes in smolagents, this is probably the preferred way to do it.

### Example usage
```python
import torch

from smolagents import TransformersModel
from transformers import BitsAndBytesConfig


quantization_config = BitsAndBytesConfig(load_in_4bit=True)
model = TransformersModel(
    "Qwen/Qwen2.5-7B-Instruct",
    device_map="auto", 
    torch_dtype=torch.bfloat16, 
    max_new_tokens=4096, 
    quantization_config=quantization_config,
)
```
-----
P.S. _This is my first PR on GitHub, so, please, guide me if anything is amiss._