### PR TITLE
Remove default max_tokens for all models

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -241,8 +241,6 @@ class Model:
     def __init__(self, **kwargs):
         self.last_input_token_count = None
         self.last_output_token_count = None
-        # Set default values for common parameters
-        kwargs.setdefault("max_tokens", 4096)
         self.kwargs = kwargs
 
     def _prepare_completion_kwargs(


### PR DESCRIPTION
Remove default max_tokens for all models.

Fix #468.