### PR TITLE
[DRAFT] allow decorator to enforce stong typing with agent friendly type error messages

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -98,6 +98,43 @@ class ToolTesterMixin:
 
 
 class ToolTests(unittest.TestCase):
+    def test_tool_force_types(self):
+        @tool(force_types=True)
+        def add_numbers(a: int, b: int) -> int:
+            """
+            Adds two numbers.
+
+            Args:
+                a: First number
+                b: Second number
+            """
+            return a + b
+
+        # Valid call should work
+        assert add_numbers(1, 2) == 3
+
+        # Invalid types should raise TypeError
+        with pytest.raises(TypeError) as e:
+            add_numbers("1", 2)
+        assert "expected type int" in str(e)
+        assert "got str" in str(e)
+        assert "Argument 'a'" in str(e)
+
+        # Now test with type checking disabled
+        @tool(force_types=False)
+        def add_numbers_no_check(a: int, b: int) -> int:
+            """
+            Adds two numbers.
+
+            Args:
+                a: First number
+                b: Second number
+            """
+            return a + b
+
+        result = add_numbers_no_check(1.2, 2)
+        assert result == 3.2
+
     def test_tool_init_with_decorator(self):
         @tool
         def coolfunc(a: str, b: int) -> float:


### PR DESCRIPTION
Some times agents will try calling a tool incorrectly despite the type hints. This issue is exacerbated in the following circumstances:

1. The backbone agent model is relatively weak
2. There are many tools and we have trouble remembering type hints for all of them
3. The signatures and their typing becomes complicated

Those type errors can lead to different behavior. They could lead to a straight forward runtime error like trying to add a `str` to an `int`. In this case the agent has a chance to fix the issue by reading the error message, but it still sub-optimal because that message won't reveal the root cause.

Even worse, type issues can result to running code that returns something very wrong, but then its hard for the agent to tell that something even went wrong. E.g. an error I have observed often is a tool signature expecting `List[str]` and when the agent wants to pass a single item it might pass a string instead a list with only that string in it. That won't immediately raise anything and instead treat the string as a list of characters.

As such I often find myself starting every tool definition with several assertions. This can be generalised in the tool decorator. Here is a sample implementation of that.

Im interested to know if the community faces this issue as well and whether the decorator approach seems promising.