### PR TITLE
Allow Gradio share parameter passthrough

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -395,6 +395,12 @@ agent = CodeAgent(tools=[image_generation_tool], model=model)
 GradioUI(agent).launch()
 ```
 
+If you prefer to keep this private and not accessible via a public link, you can set `share=False`:
+
+```py
+GradioUI(agent).launch(share=False)
+```
+
 Under the hood, when the user types a new answer, the agent is launched with `agent.run(user_request, reset=False)`.
 The `reset=False` flag means the agent's memory is not flushed before launching this new task, which lets the conversation go on.
 

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -395,12 +395,6 @@ agent = CodeAgent(tools=[image_generation_tool], model=model)
 GradioUI(agent).launch()
 ```
 
-If you prefer to keep this private and not accessible via a public link, you can set `share=False`:
-
-```py
-GradioUI(agent).launch(share=False)
-```
-
 Under the hood, when the user types a new answer, the agent is launched with `agent.run(user_request, reset=False)`.
 The `reset=False` flag means the agent's memory is not flushed before launching this new task, which lets the conversation go on.
 

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -258,7 +258,7 @@ class GradioUI:
             "",
         )
 
-    def launch(self, **kwargs):
+    def launch(self, share: bool = True, **kwargs):
         import gradio as gr
 
         with gr.Blocks(fill_height=True) as demo:
@@ -290,7 +290,7 @@ class GradioUI:
                 [stored_messages, text_input],
             ).then(self.interact_with_agent, [stored_messages, chatbot], [chatbot])
 
-        demo.launch(debug=True, share=True, **kwargs)
+        demo.launch(debug=True, share=share, **kwargs)
 
 
 __all__ = ["stream_to_gradio", "GradioUI"]

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -258,7 +258,7 @@ class GradioUI:
             "",
         )
 
-    def launch(self, share: bool = True, **kwargs):
+    def launch(self, share: bool = False, **kwargs):
         import gradio as gr
 
         with gr.Blocks(fill_height=True) as demo:


### PR DESCRIPTION
Fixes https://github.com/huggingface/smolagents/issues/489

Honestly, I would have set this to `False` by default. But not to break the public API preserved the default behaviour by settings it to `True`.

Obviously if you prefer we can keep the same interface:
```py
def launch(**kwargs):
   # ...
    demo.launch(**({"share": True, "debug": True} | kwargs))
```
But that is a bit excessive to me.
