### PR TITLE
Fix undefined `step_number` in single_step run

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -423,6 +423,7 @@ You have been provided with these additional arguments, that you can access usin
 
         self.memory.steps.append(TaskStep(task=self.task, task_images=images))
         if single_step:
+            self.step_number = 1
             step_start_time = time.time()
             memory_step = ActionStep(start_time=step_start_time, observations_images=images)
             memory_step.end_time = time.time()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -655,6 +655,13 @@ nested_answer()
 
 
 class TestMultiStepAgent:
+    def test_step_number(self):
+        fake_model = MagicMock()
+        agent = MultiStepAgent(tools=[], model=fake_model)
+        agent.run("Test task", single_step=True)
+        assert hasattr(agent, "step_number"), "step_number attribute should be defined"
+        assert agent.step_number == 1, "step_number should be set to 1 after run method is called"
+
     def test_planning_step_first_step(self):
         fake_model = MagicMock()
         agent = MultiStepAgent(


### PR DESCRIPTION
Currently, trying to run an agent with `single_step=True` and telemetry enabled causes an error: `AttributeError: 'ToolCallingAgent' object has no attribute 'step_number'`.
It happens because `step_number` is not initialized when `single_step=True` and the instrumentor tries to access it [here](https://github.com/Arize-ai/openinference/blob/2d93f4850df963394c3d7182a86f51b30924f167/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py#L148).
This PR simply sets it explicitly in that case.

To repro:
```python
from smolagents import ToolCallingAgent, HfApiModel
from smolagents import VisitWebpageTool

from opentelemetry.sdk.trace import TracerProvider
from openinference.instrumentation.smolagents import SmolagentsInstrumentor
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk.trace.export import SimpleSpanProcessor

arize_endpoint = "http://0.0.0.0:6006/v1/traces"
trace_provider = TracerProvider()
trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(arize_endpoint)))

SmolagentsInstrumentor().instrument(trace_provider=trace_provider)

model = HfApiModel()

agent = ToolCallingAgent(
    tools=[VisitWebpageTool()],
    model=model,
)

agent.run("Could you get me the title of the page at url 'https://huggingface.co/blog'?", single_step=True)
```