### PR TITLE
Refactor AgentMemory and MultiStepAgent to Adapt to Gemma-2

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -205,7 +205,7 @@ class MultiStepAgent:
         self.system_prompt = self.initialize_system_prompt()
         self.input_messages = None
         self.task = None
-        self.memory = AgentMemory(system_prompt)
+        self.memory = AgentMemory([SystemPromptStep(system_prompt=self.system_prompt)])
         self.logger = AgentLogger(level=verbosity_level)
         self.monitor = Monitor(self.model, self.logger)
         self.step_callbacks = step_callbacks if step_callbacks is not None else []
@@ -216,7 +216,7 @@ class MultiStepAgent:
         logger.warning(
             "The 'logs' attribute is deprecated and will soon be removed. Please use 'self.memory.steps' instead."
         )
-        return [self.memory.system_prompt] + self.memory.steps
+        return self.memory.steps
 
     def initialize_system_prompt(self):
         system_prompt = format_prompt_with_tools(
@@ -236,7 +236,7 @@ class MultiStepAgent:
         that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
         the LLM.
         """
-        messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
+        messages = []
         for memory_step in self.memory.steps:
             messages.extend(memory_step.to_messages(summary_mode=summary_mode))
         return messages
@@ -409,8 +409,6 @@ class MultiStepAgent:
 You have been provided with these additional arguments, that you can access using the keys as variables in your python code:
 {str(additional_args)}."""
 
-        self.system_prompt = self.initialize_system_prompt()
-        self.memory.system_prompt = SystemPromptStep(system_prompt=self.system_prompt)
         if reset:
             self.memory.reset()
             self.monitor.reset()

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -190,12 +190,12 @@ class SystemPromptStep(MemoryStep):
 
 
 class AgentMemory:
-    def __init__(self, system_prompt: str):
-        self.system_prompt = SystemPromptStep(system_prompt=system_prompt)
-        self.steps: List[Union[TaskStep, ActionStep, PlanningStep]] = []
+    def __init__(self, init_steps: List[MemoryStep]):
+        self.init_steps = init_steps
+        self.steps: List[MemoryStep] = init_steps
 
     def reset(self):
-        self.steps = []
+        self.steps = self.init_steps
 
     def get_succinct_steps(self) -> list[dict]:
         return [


### PR DESCRIPTION
This pr refactored `AgentMemory`, so it no longer creates `SystemPromptStep` internally. Instead, `init_steps` (typically `SystemPromptStep`) are now created by the caller.

This pr was originally created to address the limitation that Gemma-2 does not support system prompts (Issue #224 ), but it also make few-shot possible.

Here is an example of how to use this pr to make Gemma-2 compatible:

``` python
class GemmaSystemPromptStep(SystemPromptStep):
    def to_messages(self, summary_mode: bool = False, **kwargs):
        if summary_mode:
            return []
        return [
            Message(role=MessageRole.USER, content=[{"type": "text", "text": self.system_prompt.strip()}]),
            Message(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": ""}]),
        ]


engine = TransformersModel(model_id="google/gemma-2-2b-it", device_map="auto")
tool = DuckDuckGoSearchTool()
agent = CodeAgent(
    model=engine,
    tools=[tool]
)
agent.memory.init_steps = [
    GemmaSystemPromptStep(agent.system_prompt)
]
agent.memory.reset()

agent.run("日本最古の神社はどこですか？")
```
