### PR TITLE
Suppress terminal logging in CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+import pytest
+
+from smolagents.agents import MultiStepAgent
+
+
+original_init = MultiStepAgent.__init__
+
+
+@pytest.fixture(autouse=True)
+def patch_multi_step_agent():
+    with patch.object(MultiStepAgent, "__init__", autospec=True) as mock_init:
+
+        def init_with_verbosity(self, *args, verbosity_level=-1, **kwargs):
+            # kwargs['verbosity_level'] = -1
+            original_init(self, *args, verbosity_level=verbosity_level, **kwargs)
+
+        mock_init.side_effect = init_with_verbosity
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,16 +5,15 @@ import pytest
 from smolagents.agents import MultiStepAgent
 
 
-original_init = MultiStepAgent.__init__
+original_multi_step_agent_init = MultiStepAgent.__init__
 
 
 @pytest.fixture(autouse=True)
-def patch_multi_step_agent():
+def patch_multi_step_agent_with_suppressed_logging():
     with patch.object(MultiStepAgent, "__init__", autospec=True) as mock_init:
 
-        def init_with_verbosity(self, *args, verbosity_level=-1, **kwargs):
-            # kwargs['verbosity_level'] = -1
-            original_init(self, *args, verbosity_level=verbosity_level, **kwargs)
+        def init_with_suppressed_logging(self, *args, verbosity_level=-1, **kwargs):
+            original_multi_step_agent_init(self, *args, verbosity_level=verbosity_level, **kwargs)
 
-        mock_init.side_effect = init_with_verbosity
+        mock_init.side_effect = init_with_suppressed_logging
         yield

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -655,6 +655,11 @@ nested_answer()
 
 
 class TestMultiStepAgent:
+    def test_logging_to_terminal_is_disabled(self):
+        fake_model = MagicMock()
+        agent = MultiStepAgent(tools=[], model=fake_model)
+        assert agent.logger.level == -1, "logging to terminal should be disabled for testing using a fixture"
+
     def test_step_number(self):
         fake_model = MagicMock()
         agent = MultiStepAgent(tools=[], model=fake_model)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -481,7 +481,8 @@ class AgentTests(unittest.TestCase):
         assert "You can also give requests to team members." in manager_agent.system_prompt
 
     def test_code_agent_missing_import_triggers_advice_in_error_log(self):
-        agent = CodeAgent(tools=[], model=fake_code_model_import)
+        # Set explicit verbosity level to 1 to override the default verbosity level of -1 set in CI fixture
+        agent = CodeAgent(tools=[], model=fake_code_model_import, verbosity_level=1)
 
         with agent.logger.console.capture() as capture:
             agent.run("Count to 3")


### PR DESCRIPTION
Suppress terminal logging in CI tests.

The approached I followed: I set logger.level = -1 for CI tests.

Fix #503.

Agent tests:
- Before:
````
tests/test_agents.py::TestMultiStepAgent::test_logging_to_terminal_is_disabled FAILED
tests/test_agents.py::TestMultiStepAgent::test_step_number ╭────────────────────────────────── New run ───────────────────────────────────╮
│                                                                              │
│ Test task                                                                    │
│                                                                              │
╰─ MagicMock - <MagicMock name='mock.model_id' id='140456269450064'> ──────────╯
PASSED
tests/test_agents.py::TestMultiStepAgent::test_planning_step_first_step ───────────────────────────────── Initial plan ─────────────────────────────────
Here is the plan of action that I will follow to solve the task:
```
<MagicMock name='mock().content' id='140456269040704'>
```
PASSED
````
- With this PR:
```
tests/test_agents.py::TestMultiStepAgent::test_logging_to_terminal_is_disabled PASSED
tests/test_agents.py::TestMultiStepAgent::test_step_number PASSED
tests/test_agents.py::TestMultiStepAgent::test_planning_step_first_step PASSED
```