### PR TITLE
Support disabling logging to terminal

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -135,7 +135,7 @@ class MultiStepAgent:
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
-        verbosity_level (`int`, default `1`): Level of verbosity of the agent's logs.
+        verbosity_level (`LogLevel`, default `LogLevel.INFO`): Level of verbosity of the agent's logs.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         managed_agents (`list`, *optional*): Managed agents that the agent can call.
         step_callbacks (`list[Callable]`, *optional*): Callbacks that will be called at each step.
@@ -155,7 +155,7 @@ class MultiStepAgent:
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
-        verbosity_level: int = 1,
+        verbosity_level: LogLevel = LogLevel.INFO,
         grammar: Optional[Dict[str, str]] = None,
         managed_agents: Optional[List] = None,
         step_callbacks: Optional[List[Callable]] = None,

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -28,6 +28,9 @@ from rich.text import Text
 from rich.tree import Tree
 
 
+__all__ = ["AgentLogger", "LogLevel", "Monitor"]
+
+
 class Monitor:
     def __init__(self, tracked_model, logger):
         self.step_durations = []
@@ -201,6 +204,3 @@ class AgentLogger:
         main_tree = Tree(f"[bold {YELLOW_HEX}]{agent.__class__.__name__}")
         build_agent_tree(main_tree, agent)
         self.console.print(main_tree)
-
-
-__all__ = ["AgentLogger", "Monitor"]

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -69,6 +69,7 @@ class Monitor:
 
 
 class LogLevel(IntEnum):
+    OFF = -1  # No output
     ERROR = 0  # Only errors
     INFO = 1  # Normal output (default)
     DEBUG = 2  # Detailed output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from smolagents.agents import MultiStepAgent
+from smolagents.monitoring import LogLevel
 
 
 original_multi_step_agent_init = MultiStepAgent.__init__
@@ -12,7 +13,7 @@ original_multi_step_agent_init = MultiStepAgent.__init__
 def patch_multi_step_agent_with_suppressed_logging():
     with patch.object(MultiStepAgent, "__init__", autospec=True) as mock_init:
 
-        def init_with_suppressed_logging(self, *args, verbosity_level=-1, **kwargs):
+        def init_with_suppressed_logging(self, *args, verbosity_level=LogLevel.OFF, **kwargs):
             original_multi_step_agent_init(self, *args, verbosity_level=verbosity_level, **kwargs)
 
         mock_init.side_effect = init_with_suppressed_logging


### PR DESCRIPTION
Support disabling logging to terminal, with `LogLevel.OFF`.

Use case: when the running is done for benchmarks/evaluations or tests, the user might want to disable logging to the terminal.

Related to:
- #504