### PR TITLE
Set `tool_choice` to "auto"

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -287,7 +287,7 @@ class Model:
             completion_kwargs.update(
                 {
                     "tools": [get_tool_json_schema(tool) for tool in tools_to_call_from],
-                    "tool_choice": "required",
+                    "tool_choice": "auto",
                 }
             )
 


### PR DESCRIPTION
Currently, `tool_choice` is set to "required".
According to OpenAI specs:
> Auto: (Default) Call zero, one, or multiple functions.
> Required: Call one or more functions.

This PR sets `tool_choice` to "auto" instead. It is interesting for 2 reasons:
1. It is the default, and intuitively it makes sense to give the model the ability to choose when to call a tool
2. Currently, vLLM doesn't support `tool_choice="required"` https://github.com/vllm-project/vllm/issues/10526

Looking at this repo's history, I see that at one point both options coexisted: https://github.com/huggingface/smolagents/blob/117014d2e1544a2a5c4ca28c1e223745bd204911/src/smolagents/models.py#L295
I couldn't find any discussion on why it was ultimately decided to go with "required" instead of "auto".

Moreover, since `tool_choice` is explicitly set in `_prepare_completion_kwargs()`, it has priority over `self.kwargs` and can't be overridden by passing it to `Model`.

## Alternatives
- Make `tool_choice` an explicit positional argument of `Model`, allowing the user to set it at initialization
- Remove the explicit declaration of `tool_choice` in `_prepare_completion_kwargs()`, letting the LLM API engine decide on the default to use (most likely "auto" if it follows OpenAI specs) and allowing the user to override it through `self.kwargs` 
- Change the logic of `_prepare_completion_kwargs()` to allow `tool_choice` in particular to be overridden (this would be the hardest to maintain imo)