### PR TITLE
MINOR: Add 'uv' dependency for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
   "python-dotenv>=1.0.1", # For test_all_docs
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
+  "uv", # For test_import_smolagents_without_extras
 ]
 dev = [
   "smolagents[quality,test]",


### PR DESCRIPTION
Thanks for creating this awesome project! 
I've modified the dev setup to include `uv` when installing with `pip install -e ".[dev]"`. 
In my local environment, I encountered the following error during testing:

```
FAILED tests/test_import.py::test_import_smolagents_without_extras - FileNotFoundError: [Errno 2] No such file or directory: 'uv'
```

Thanks! 😊

Related Commit: https://github.com/huggingface/smolagents/commit/cc21135188837e7e40a551da7314212a2b969b8d