### PR TITLE
Pin openinference-instrumentation-smolagents >= 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ telemetry = [
   "arize-phoenix",
   "opentelemetry-sdk", 
   "opentelemetry-exporter-otlp",
-  "openinference-instrumentation-smolagents>=0.1.1"
+  "openinference-instrumentation-smolagents>=0.1.4"
 ]
 quality = [
   "ruff>=0.9.0",


### PR DESCRIPTION
Pin openinference-instrumentation-smolagents >= 0.1.4 with fixes:
- https://github.com/Arize-ai/openinference/pull/1274
- https://github.com/Arize-ai/openinference/pull/1238