### PR TITLE
Fix installation with data files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ lint.select = ["E", "F", "I", "W"]
 known-first-party = ["smolagents"]
 lines-after-imports = 2
 
+[tool.setuptools.package-data]
+"smolagents.prompts" = ["*.yaml"]
+
 [project.scripts]
 smolagent = "smolagents.cli:main"
 webagent = "smolagents.vision_web_browser:main"

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -25,7 +25,6 @@ from .local_python_executor import *
 from .memory import *
 from .models import *
 from .monitoring import *
-from .prompts import *
 from .tools import *
 from .utils import *
 from .cli import *

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -14,8 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib.resources
 import inspect
-import os
 import re
 import textwrap
 import time
@@ -646,9 +646,9 @@ class ToolCallingAgent(MultiStepAgent):
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
-        yaml_path = os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
-        with open(yaml_path, "r") as f:
-            self.prompt_templates = yaml.safe_load(f)
+        self.prompt_templates = yaml.safe_load(
+            importlib.resources.read_text("smolagents.prompts", "toolcalling_agent.yaml")
+        )
         super().__init__(
             tools=tools,
             model=model,
@@ -779,9 +779,7 @@ class CodeAgent(MultiStepAgent):
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
-        yaml_path = os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
-        with open(yaml_path, "r") as f:
-            self.prompt_templates = yaml.safe_load(f)
+        self.prompt_templates = yaml.safe_load(importlib.resources.read_text("smolagents.prompts", "code_agent.yaml"))
         super().__init__(
             tools=tools,
             model=model,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,7 +4,7 @@ import subprocess
 def test_import_smolagents_without_extras():
     # Run the import statement in an isolated virtual environment
     result = subprocess.run(
-        ["uv", "run", "--isolated", "-"], input="import smolagents", text=True, capture_output=True
+        ["uv", "run", "--isolated", "--no-editable", "-"], input="import smolagents", text=True, capture_output=True
     )
     # Check if the import was successful
     assert result.returncode == 0, (


### PR DESCRIPTION
Fix installation with data files: ModuleNotFoundError: No module named 'smolagents.prompts'
```python
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/runner/.cache/uv/builds-v0/.tmp1eGz4Z/lib/python3.10/site-packages/smolagents/__init__.py", line 28, in <module>
      from .prompts import *
  ModuleNotFoundError: No module named 'smolagents.prompts'
```

After PR:
- #502