### PR TITLE
add self.logger = logger for e2b_executor

### DIFF
--- a/src/smolagents/e2b_executor.py
+++ b/src/smolagents/e2b_executor.py
@@ -38,6 +38,7 @@ except ModuleNotFoundError:
 
 class E2BExecutor:
     def __init__(self, additional_imports: List[str], tools: List[Tool], logger):
+        self.logger = logger
         try:
             from e2b_code_interpreter import Sandbox
         except ModuleNotFoundError:
@@ -58,7 +59,6 @@ class E2BExecutor:
         #     timeout=300
         # )
         # print("Installation of agents package finished.")
-        self.logger = logger
         additional_imports = additional_imports + ["smolagents"]
         if len(additional_imports) > 0:
             execution = self.sbx.commands.run("pip install " + " ".join(additional_imports))


### PR DESCRIPTION
Hello, while trying e2b_executor example,
```
File "/Users/femtozheng/python-project/smolagents/src/smolagents/e2b_executor.py", line 48, in __init__

self.logger.log("Initializing E2B executor, hold on...")

^^^^^^^^^^^

AttributeError: 'E2BExecutor' object has no attribute 'logger'

python-BaseException
```
seemed pass in logger doesn't get set to self.logger,
so I added one.