### PR TITLE
Delete prompts_path argument and use prompt_templates

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -88,6 +88,7 @@ class MultiStepAgent:
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
+        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
@@ -106,6 +107,7 @@ class MultiStepAgent:
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
+        prompts_path: Optional[str] = None,
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
@@ -631,6 +633,7 @@ class ToolCallingAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
+        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         **kwargs: Additional keyword arguments.
     """
@@ -639,6 +642,7 @@ class ToolCallingAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
+        prompts_path: Optional[str] = None,
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
@@ -648,6 +652,7 @@ class ToolCallingAgent(MultiStepAgent):
         super().__init__(
             tools=tools,
             model=model,
+            prompts_path=prompts_path,
             planning_interval=planning_interval,
             **kwargs,
         )
@@ -750,6 +755,7 @@ class CodeAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
+        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
@@ -763,6 +769,7 @@ class CodeAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
+        prompts_path: Optional[str] = None,
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -88,7 +88,6 @@ class MultiStepAgent:
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
@@ -107,7 +106,6 @@ class MultiStepAgent:
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
@@ -633,7 +631,6 @@ class ToolCallingAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         **kwargs: Additional keyword arguments.
     """
@@ -642,7 +639,6 @@ class ToolCallingAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
@@ -652,7 +648,6 @@ class ToolCallingAgent(MultiStepAgent):
         super().__init__(
             tools=tools,
             model=model,
-            prompts_path=prompts_path,
             planning_interval=planning_interval,
             **kwargs,
         )
@@ -755,7 +750,6 @@ class CodeAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
@@ -769,7 +763,6 @@ class CodeAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -88,7 +88,7 @@ class MultiStepAgent:
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
+        prompt_templates (`dict`, *optional*): Prompt templates.
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
@@ -107,7 +107,7 @@ class MultiStepAgent:
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_templates_path: Optional[str] = None,
+        prompt_templates: Optional[dict] = None,
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
@@ -125,7 +125,7 @@ class MultiStepAgent:
             tool_parser = parse_json_tool_call
         self.agent_name = self.__class__.__name__
         self.model = model
-        self.prompt_templates_path = prompt_templates_path
+        self.prompt_templates = prompt_templates or {}
         self.max_steps = max_steps
         self.step_number: int = 0
         self.tool_parser = tool_parser
@@ -135,12 +135,6 @@ class MultiStepAgent:
         self.name = name
         self.description = description
         self.provide_run_summary = provide_run_summary
-
-        if prompt_templates_path is not None:
-            with open(prompt_templates_path, "r") as f:
-                self.prompt_templates = yaml.safe_load(f)
-        else:
-            self.prompt_templates = {}
 
         self.managed_agents = {}
         if managed_agents is not None:
@@ -640,7 +634,7 @@ class ToolCallingAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
+        prompt_templates (`dict`, *optional*): Prompt templates.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         **kwargs: Additional keyword arguments.
     """
@@ -649,17 +643,17 @@ class ToolCallingAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_templates_path: Optional[str] = None,
+        prompt_templates: Optional[dict] = None,
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
-        prompt_templates_path = (
-            prompt_templates_path or importlib.resources.files("smolagents.prompts") / "toolcalling_agent.yaml"
+        prompt_templates = prompt_templates or yaml.safe_load(
+            importlib.resources.read_text("smolagents.prompts", "toolcalling_agent.yaml")
         )
         super().__init__(
             tools=tools,
             model=model,
-            prompt_templates_path=prompt_templates_path,
+            prompt_templates=prompt_templates,
             planning_interval=planning_interval,
             **kwargs,
         )
@@ -762,7 +756,7 @@ class CodeAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
+        prompt_templates (`dict`, *optional*): Prompt templates.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
@@ -776,7 +770,7 @@ class CodeAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_templates_path: Optional[str] = None,
+        prompt_templates: Optional[dict] = None,
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,
@@ -786,13 +780,13 @@ class CodeAgent(MultiStepAgent):
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
-        prompt_templates_path = (
-            prompt_templates_path or importlib.resources.files("smolagents.prompts") / "code_agent.yaml"
+        prompt_templates = prompt_templates or yaml.safe_load(
+            importlib.resources.read_text("smolagents.prompts", "code_agent.yaml")
         )
         super().__init__(
             tools=tools,
             model=model,
-            prompt_templates_path=prompt_templates_path,
+            prompt_templates=prompt_templates,
             grammar=grammar,
             planning_interval=planning_interval,
             **kwargs,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -136,6 +136,12 @@ class MultiStepAgent:
         self.description = description
         self.provide_run_summary = provide_run_summary
 
+        if prompt_path is not None:
+            with open(prompt_path, "r") as f:
+                self.prompt_templates = yaml.safe_load(f)
+        else:
+            self.prompt_templates = {}
+
         self.managed_agents = {}
         if managed_agents is not None:
             for managed_agent in managed_agents:
@@ -648,8 +654,6 @@ class ToolCallingAgent(MultiStepAgent):
         **kwargs,
     ):
         prompt_path = prompt_path or os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
-        with open(prompt_path, "r") as f:
-            self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
             model=model,
@@ -781,8 +785,6 @@ class CodeAgent(MultiStepAgent):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
         prompt_path = prompt_path or os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
-        with open(prompt_path, "r") as f:
-            self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
             model=model,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -88,7 +88,7 @@ class MultiStepAgent:
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
@@ -107,7 +107,7 @@ class MultiStepAgent:
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_path: Optional[str] = None,
+        prompt_templates_path: Optional[str] = None,
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
@@ -125,7 +125,7 @@ class MultiStepAgent:
             tool_parser = parse_json_tool_call
         self.agent_name = self.__class__.__name__
         self.model = model
-        self.prompt_path = prompt_path
+        self.prompt_templates_path = prompt_templates_path
         self.max_steps = max_steps
         self.step_number: int = 0
         self.tool_parser = tool_parser
@@ -136,8 +136,8 @@ class MultiStepAgent:
         self.description = description
         self.provide_run_summary = provide_run_summary
 
-        if prompt_path is not None:
-            with open(prompt_path, "r") as f:
+        if prompt_templates_path is not None:
+            with open(prompt_templates_path, "r") as f:
                 self.prompt_templates = yaml.safe_load(f)
         else:
             self.prompt_templates = {}
@@ -640,7 +640,7 @@ class ToolCallingAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         **kwargs: Additional keyword arguments.
     """
@@ -649,15 +649,17 @@ class ToolCallingAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_path: Optional[str] = None,
+        prompt_templates_path: Optional[str] = None,
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
-        prompt_path = prompt_path or importlib.resources.files("smolagents.prompts") / "toolcalling_agent.yaml"
+        prompt_templates_path = (
+            prompt_templates_path or importlib.resources.files("smolagents.prompts") / "toolcalling_agent.yaml"
+        )
         super().__init__(
             tools=tools,
             model=model,
-            prompt_path=prompt_path,
+            prompt_templates_path=prompt_templates_path,
             planning_interval=planning_interval,
             **kwargs,
         )
@@ -760,7 +762,7 @@ class CodeAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_templates_path (`str`, *optional*): Path from which to load this agent's prompt templates.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
@@ -774,7 +776,7 @@ class CodeAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompt_path: Optional[str] = None,
+        prompt_templates_path: Optional[str] = None,
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,
@@ -784,11 +786,13 @@ class CodeAgent(MultiStepAgent):
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
-        prompt_path = prompt_path or importlib.resources.files("smolagents.prompts") / "code_agent.yaml"
+        prompt_templates_path = (
+            prompt_templates_path or importlib.resources.files("smolagents.prompts") / "code_agent.yaml"
+        )
         super().__init__(
             tools=tools,
             model=model,
-            prompt_path=prompt_path,
+            prompt_templates_path=prompt_templates_path,
             grammar=grammar,
             planning_interval=planning_interval,
             **kwargs,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -125,6 +125,7 @@ class MultiStepAgent:
             tool_parser = parse_json_tool_call
         self.agent_name = self.__class__.__name__
         self.model = model
+        self.prompts_path = prompts_path
         self.max_steps = max_steps
         self.step_number: int = 0
         self.tool_parser = tool_parser
@@ -646,8 +647,8 @@ class ToolCallingAgent(MultiStepAgent):
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
-        yaml_path = os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
-        with open(yaml_path, "r") as f:
+        prompts_path = prompts_path or os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
+        with open(prompts_path, "r") as f:
             self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
@@ -779,12 +780,13 @@ class CodeAgent(MultiStepAgent):
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
-        yaml_path = os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
-        with open(yaml_path, "r") as f:
+        prompts_path = prompts_path or os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
+        with open(prompts_path, "r") as f:
             self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
             model=model,
+            prompts_path=prompts_path,
             grammar=grammar,
             planning_interval=planning_interval,
             **kwargs,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -88,7 +88,7 @@ class MultiStepAgent:
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         max_steps (`int`, default `6`): Maximum number of steps the agent can take to solve the task.
         tool_parser (`Callable`, *optional*): Function used to parse the tool calls from the LLM output.
         add_base_tools (`bool`, default `False`): Whether to add the base tools to the agent's tools.
@@ -107,7 +107,7 @@ class MultiStepAgent:
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
+        prompt_path: Optional[str] = None,
         max_steps: int = 6,
         tool_parser: Optional[Callable] = None,
         add_base_tools: bool = False,
@@ -125,7 +125,7 @@ class MultiStepAgent:
             tool_parser = parse_json_tool_call
         self.agent_name = self.__class__.__name__
         self.model = model
-        self.prompts_path = prompts_path
+        self.prompt_path = prompt_path
         self.max_steps = max_steps
         self.step_number: int = 0
         self.tool_parser = tool_parser
@@ -634,7 +634,7 @@ class ToolCallingAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         **kwargs: Additional keyword arguments.
     """
@@ -643,17 +643,17 @@ class ToolCallingAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
+        prompt_path: Optional[str] = None,
         planning_interval: Optional[int] = None,
         **kwargs,
     ):
-        prompts_path = prompts_path or os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
-        with open(prompts_path, "r") as f:
+        prompt_path = prompt_path or os.path.join(os.path.dirname(__file__), "prompts", "toolcalling_agent.yaml")
+        with open(prompt_path, "r") as f:
             self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
             model=model,
-            prompts_path=prompts_path,
+            prompt_path=prompt_path,
             planning_interval=planning_interval,
             **kwargs,
         )
@@ -756,7 +756,7 @@ class CodeAgent(MultiStepAgent):
     Args:
         tools (`list[Tool]`): [`Tool`]s that the agent can use.
         model (`Callable[[list[dict[str, str]]], ChatMessage]`): Model that will generate the agent's actions.
-        prompts_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
+        prompt_path (`str`, *optional*): The path from which to load this agent's prompt dictionary.
         grammar (`dict[str, str]`, *optional*): Grammar used to parse the LLM output.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
@@ -770,7 +770,7 @@ class CodeAgent(MultiStepAgent):
         self,
         tools: List[Tool],
         model: Callable[[List[Dict[str, str]]], ChatMessage],
-        prompts_path: Optional[str] = None,
+        prompt_path: Optional[str] = None,
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,
@@ -780,13 +780,13 @@ class CodeAgent(MultiStepAgent):
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
-        prompts_path = prompts_path or os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
-        with open(prompts_path, "r") as f:
+        prompt_path = prompt_path or os.path.join(os.path.dirname(__file__), "prompts", "code_agent.yaml")
+        with open(prompt_path, "r") as f:
             self.prompt_templates = yaml.safe_load(f)
         super().__init__(
             tools=tools,
             model=model,
-            prompts_path=prompts_path,
+            prompt_path=prompt_path,
             grammar=grammar,
             planning_interval=planning_interval,
             **kwargs,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -671,9 +671,9 @@ class TestMultiStepAgent:
         agent = MultiStepAgent(tools=[], model=fake_model)
         assert agent.logger.level == -1, "logging to terminal should be disabled for testing using a fixture"
 
-    def test_instantiation_with_prompt_path(self, prompt_path):
-        agent = MultiStepAgent(tools=[], model=MagicMock(), prompt_path=prompt_path)
-        assert agent.prompt_path == prompt_path
+    def test_instantiation_with_prompt_templates_path(self, prompt_templates_path):
+        agent = MultiStepAgent(tools=[], model=MagicMock(), prompt_templates_path=prompt_templates_path)
+        assert agent.prompt_templates_path == prompt_templates_path
         assert agent.prompt_templates["system_prompt"] == "This is a test system prompt."
         assert "managed_agent" in agent.prompt_templates
         assert agent.prompt_templates["managed_agent"]["task"] == "Task for {{name}}: {{task}}"
@@ -737,12 +737,12 @@ class TestMultiStepAgent:
 
 
 @pytest.fixture
-def prompt_path(tmp_path):
-    prompt_data = {
+def prompt_templates_path(tmp_path):
+    prompt_templates_data = {
         "system_prompt": "This is a test system prompt.",
         "managed_agent": {"task": "Task for {{name}}: {{task}}", "report": "Report for {{name}}: {{final_answer}}"},
     }
-    prompt_file = tmp_path / "prompt.yaml"
-    with open(prompt_file, "w") as f:
-        yaml.dump(prompt_data, f)
-    return str(prompt_file)
+    prompt_templates_file = tmp_path / "prompt.yaml"
+    with open(prompt_templates_file, "w") as f:
+        yaml.dump(prompt_templates_data, f)
+    return str(prompt_templates_file)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -19,6 +19,8 @@ import uuid
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+import yaml
 from transformers.testing_utils import get_tests_dir
 
 from smolagents.agent_types import AgentImage, AgentText
@@ -664,10 +666,18 @@ nested_answer()
 
 
 class TestMultiStepAgent:
-    def test_logging_to_terminal_is_disabled(self):
+    def test_instantiation_disables_logging_to_terminal(self):
         fake_model = MagicMock()
         agent = MultiStepAgent(tools=[], model=fake_model)
         assert agent.logger.level == -1, "logging to terminal should be disabled for testing using a fixture"
+
+    def test_instantiation_with_prompt_path(self, prompt_path):
+        agent = MultiStepAgent(tools=[], model=MagicMock(), prompt_path=prompt_path)
+        assert agent.prompt_path == prompt_path
+        assert agent.prompt_templates["system_prompt"] == "This is a test system prompt."
+        assert "managed_agent" in agent.prompt_templates
+        assert agent.prompt_templates["managed_agent"]["task"] == "Task for {{name}}: {{task}}"
+        assert agent.prompt_templates["managed_agent"]["report"] == "Report for {{name}}: {{final_answer}}"
 
     def test_step_number(self):
         fake_model = MagicMock()
@@ -724,3 +734,15 @@ class TestMultiStepAgent:
                     assert isinstance(content, dict)
                     assert "type" in content
                     assert "text" in content
+
+
+@pytest.fixture
+def prompt_path(tmp_path):
+    prompt_data = {
+        "system_prompt": "This is a test system prompt.",
+        "managed_agent": {"task": "Task for {{name}}: {{task}}", "report": "Report for {{name}}: {{final_answer}}"},
+    }
+    prompt_file = tmp_path / "prompt.yaml"
+    with open(prompt_file, "w") as f:
+        yaml.dump(prompt_data, f)
+    return str(prompt_file)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import yaml
 from transformers.testing_utils import get_tests_dir
 
 from smolagents.agent_types import AgentImage, AgentText
@@ -671,9 +670,9 @@ class TestMultiStepAgent:
         agent = MultiStepAgent(tools=[], model=fake_model)
         assert agent.logger.level == -1, "logging to terminal should be disabled for testing using a fixture"
 
-    def test_instantiation_with_prompt_templates_path(self, prompt_templates_path):
-        agent = MultiStepAgent(tools=[], model=MagicMock(), prompt_templates_path=prompt_templates_path)
-        assert agent.prompt_templates_path == prompt_templates_path
+    def test_instantiation_with_prompt_templates(self, prompt_templates):
+        agent = MultiStepAgent(tools=[], model=MagicMock(), prompt_templates=prompt_templates)
+        assert agent.prompt_templates == prompt_templates
         assert agent.prompt_templates["system_prompt"] == "This is a test system prompt."
         assert "managed_agent" in agent.prompt_templates
         assert agent.prompt_templates["managed_agent"]["task"] == "Task for {{name}}: {{task}}"
@@ -737,12 +736,8 @@ class TestMultiStepAgent:
 
 
 @pytest.fixture
-def prompt_templates_path(tmp_path):
-    prompt_templates_data = {
+def prompt_templates():
+    return {
         "system_prompt": "This is a test system prompt.",
         "managed_agent": {"task": "Task for {{name}}: {{task}}", "report": "Report for {{name}}: {{final_answer}}"},
     }
-    prompt_templates_file = tmp_path / "prompt.yaml"
-    with open(prompt_templates_file, "w") as f:
-        yaml.dump(prompt_templates_data, f)
-    return str(prompt_templates_file)


### PR DESCRIPTION
EDIT:
Remove unused `prompts_path` argument and use `prompt_templates` instead.

EDIT:
~~Use `prompt_path` argument, previously introduced but not used.~~

~~Remove unused `prompts_path` argument.~~

This argument was introduced (but not used) in:
- #502

Or maybe you wanted to use it somehow? @aymeric-roucher 