### PR TITLE
Fix deprecation warning from importlib.resources.read_text

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -648,7 +648,7 @@ class ToolCallingAgent(MultiStepAgent):
         **kwargs,
     ):
         prompt_templates = prompt_templates or yaml.safe_load(
-            importlib.resources.read_text("smolagents.prompts", "toolcalling_agent.yaml")
+            importlib.resources.files("smolagents.prompts").joinpath("toolcalling_agent.yaml").read_text()
         )
         super().__init__(
             tools=tools,
@@ -781,7 +781,7 @@ class CodeAgent(MultiStepAgent):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
         self.authorized_imports = list(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
         prompt_templates = prompt_templates or yaml.safe_load(
-            importlib.resources.read_text("smolagents.prompts", "code_agent.yaml")
+            importlib.resources.files("smolagents.prompts").joinpath("code_agent.yaml").read_text()
         )
         super().__init__(
             tools=tools,


### PR DESCRIPTION
Fix deprecation warning from importlib.resources.read_text:
```
huggingface/smolagents/src/smolagents/agents.py:784: DeprecationWarning: read_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    importlib.resources.read_text("smolagents.prompts", "code_agent.yaml")
```