### PR TITLE
Missing drivers and browser-start in vision_web_browser.py

### DIFF
--- a/docs/source/en/conceptual_guides/intro_agents.md
+++ b/docs/source/en/conceptual_guides/intro_agents.md
@@ -68,7 +68,7 @@ If that deterministic workflow fits all queries, by all means just code everythi
 
 But what if the workflow can't be determined that well in advance? 
 
-For instance, a user wants to ask : `"I can come on Monday, but I forgot my passport so risk being delayed to Wednesday, is it possible to take me and my stuff to surf on Tuesday morning, with a cancellation insurance?"` This question hinges on many factors, and probably none of the predetermined criteria above will suffice for this request.
+For instance, a user wants to ask: `"I can come on Monday, but I forgot my passport so risk being delayed to Wednesday, is it possible to take me and my stuff to surf on Tuesday morning, with a cancellation insurance?"` This question hinges on many factors, and probably none of the predetermined criteria above will suffice for this request.
 
 If the pre-determined workflow falls short too often, that means you need more flexibility.
 
@@ -106,7 +106,7 @@ In a multi-step agent, at each step, the LLM can write an action, in the form of
 
 The reason for this simply that *we crafted our code languages specifically to be the best possible way to express actions performed by a computer*. If JSON snippets were a better expression, JSON would be the top programming language and programming would be hell on earth.
 
-The figure below, taken from [Executable Code Actions Elicit Better LLM Agents](https://huggingface.co/papers/2402.01030), illustrate some advantages of writing actions in code:
+The figure below, taken from [Executable Code Actions Elicit Better LLM Agents](https://huggingface.co/papers/2402.01030), illustrates some advantages of writing actions in code:
 
 <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/code_vs_json_actions.png">
 
@@ -115,4 +115,4 @@ Writing actions in code rather than JSON-like snippets provides better:
 - **Composability:** could you nest JSON actions within each other, or define a set of JSON actions to re-use later, the same way you could just define a python function?
 - **Object management:** how do you store the output of an action like `generate_image` in JSON?
 - **Generality:** code is built to express simply anything you can have a computer do.
-- **Representation in LLM training data:** plenty of quality code actions is already included in LLMs’ training data which means they’re already trained for this!
+- **Representation in LLM training data:** plenty of quality code actions are already included in LLMs’ training data which means they’re already trained for this!

--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 [[open-in-colab]]
 
 There's a world of difference between building an agent that works and one that doesn't.
-How can we build agents that fall into the latter category?
+How can we build agents that fall into the former category?
 In this guide, we're going to talk about best practices for building agents.
 
 > [!TIP]

--- a/src/smolagents/vision_web_browser.py
+++ b/src/smolagents/vision_web_browser.py
@@ -61,11 +61,11 @@ def save_screenshot(memory_step: ActionStep, agent: CodeAgent) -> None:
         print(f"Captured a browser screenshot: {image.size} pixels")
         memory_step.observations_images = [image.copy()]  # Create a copy to ensure it persists, important!
 
-    # Update observations with current URL
-    url_info = f"Current url: {driver.current_url}"
-    memory_step.observations = (
-        url_info if memory_step.observations is None else memory_step.observations + "\n" + url_info
-    )
+        # Update observations with current URL
+        url_info = f"Current url: {driver.current_url}"
+        memory_step.observations = (
+            url_info if memory_step.observations is None else memory_step.observations + "\n" + url_info
+        )
     return
 
 
@@ -77,6 +77,7 @@ def search_item_ctrl_f(text: str, nth_result: int = 1) -> str:
         text: The text to search for
         nth_result: Which occurrence to jump to (default: 1)
     """
+    driver = helium.get_driver()
     elements = driver.find_elements(By.XPATH, f"//*[contains(text(), '{text}')]")
     if nth_result > len(elements):
         raise Exception(f"Match n°{nth_result} not found (only {len(elements)} matches found)")
@@ -90,6 +91,7 @@ def search_item_ctrl_f(text: str, nth_result: int = 1) -> str:
 @tool
 def go_back() -> None:
     """Goes back to previous page."""
+    driver = helium.get_driver()
     driver.back()
 
 
@@ -98,6 +100,7 @@ def close_popups() -> str:
     """
     Closes any visible modal or pop-up on the page. Use this to dismiss pop-up windows! This does not work on cookie consent banners.
     """
+    driver = helium.get_driver()
     webdriver.ActionChains(driver).send_keys(Keys.ESCAPE).perform()
 
 
@@ -131,6 +134,8 @@ We've already ran "from helium import *"
 Then you can go to pages!
 Code:
 ```py
+# do not forget to start a browser session first!
+start_chrome()
 go_to('github.com/trending')
 ```<end_code>
 


### PR DESCRIPTION
These change make the vision_web_browser a lot more stable:
- several helium functions rely on the existance of a global driver object, which does not exist by default, sometimes the LLM might create one, but much better to make sure it is there
- if there is no bowser to start with, you can't browse. Explaining this in the prompt made it really stable for me
- in the callback, sometimes there is not yet a URL or driver depending on what the LLM wants to do, so we can only update if the driver is not None