### PR TITLE
Doc grammar fix

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 [[open-in-colab]]
 
 There's a world of difference between building an agent that works and one that doesn't.
-How can we build agents that fall into the latter category?
+How can we build agents that fall into the former category?
 In this guide, we're going to talk about best practices for building agents.
 
 > [!TIP]


### PR DESCRIPTION
Very small/simple nit fix where the right word to use should be "former" rather than "latter" as "latter" means the last in the list which here refers to a "bad agent".