### PR TITLE
Fix classes to make doc-builder works again

### DIFF
--- a/docs/source/en/reference/tools.md
+++ b/docs/source/en/reference/tools.md
@@ -96,12 +96,12 @@ These types have three specific purposes:
 
 ### AgentText
 
-[[autodoc]] smolagents.agent_types.AgentText
+[[autodoc]] smolagents.AgentText
 
 ### AgentImage
 
-[[autodoc]] smolagents.agent_types.AgentImage
+[[autodoc]] smolagents.AgentImage
 
 ### AgentAudio
 
-[[autodoc]] smolagents.agent_types.AgentAudio
+[[autodoc]] smolagents.AgentAudio


### PR DESCRIPTION
Fix error:
  File ".venv/lib/python3.10/site-packages/doc_builder/autodoc.py", lin
e 378, in document_object                                                            
    raise ValueError(                                                                
ValueError: Unable to find smolagents.agent_types.AgentImage in smolagents. Make sure
 the path to that object is correct.                                                 
