### PR TITLE
Fixed Readme that is missing run.py call

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -18,5 +18,5 @@ pip install -e .[dev]
 
 Then you're good to go! Run the run.py script, as in:
 ```bash
-python --model-id "o1" --question "Your question here!"
+python run.py --model-id "o1" --question "Your question here!"
 ```


### PR DESCRIPTION
In the readme, python is not executing the program run.py.  Added run.py to the command line call to fix this. 