### PR TITLE
Adding support to authenticate AzureOpenAI via Microsoft Entra ID.

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -834,7 +834,7 @@ class AzureOpenAIServerModel(OpenAIServerModel):
         if api_key is None:
             api_key = os.environ.get("AZURE_OPENAI_API_KEY")
 
-        super().__init__(model_id=model_id, api_key=api_key, azure_ad_token_provider=azure_ad_token_provider, custom_role_conversions=custom_role_conversions, **kwargs)
+        super().__init__(model_id=model_id, api_key=api_key, custom_role_conversions=custom_role_conversions, **kwargs)
         # if we've reached this point, it means the openai package is available (checked in baseclass) so go ahead and import it
         import openai
 


### PR DESCRIPTION
## Motivation
Many enterprise users access Azure OpenAI Service through their organization's Microsoft Entra ID credentials rather than API keys. This authentication method:
- Provides better security by eliminating the need to manage and rotate API keys
- Enables centralized access control and audit logging through Microsoft Entra ID
- Aligns with enterprise security policies that prohibit API key usage
- Allows seamless integration with existing Azure workflows and CI/CD pipelines

Currently, users need to manage API keys manually, which creates additional security overhead and doesn't align with enterprise security best practices. Adding Microsoft Entra ID support would make smolagents more accessible to enterprise users and teams already using Azure OpenAI Service.

## Feature Description
The proposed feature would add support for Microsoft Entra ID authentication in smolagents, allowing users to authenticate using:
- Managed Identities (for applications running in Azure)
- Service Principals (for automated workflows)
- Interactive browser-based authentication (for local development)

The authentication flow would integrate with the Azure Identity library (`@azure/identity` in JavaScript/TypeScript) to handle token acquisition and renewal transparently.

## Code Example
```python
import os
from smolagents.models import AzureOpenAIServerModel
from azure.identity import DefaultAzureCredential, get_bearer_token_provider

    token_provider = get_bearer_token_provider(
        DefaultAzureCredential(),
         "https://cognitiveservices.azure.com/.default")

   
    model = AzureOpenAIServerModel(
        args.model_id,
        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
        azure_deployment=os.getenv("AZURE_DEPLOPYMENT_NAME"),
        azure_ad_token_provider=token_provider,
        api_version=os.getenv("AZURE_API_VERSION"),
        custom_role_conversions=custom_role_conversions,
        max_completion_tokens=8192,
        reasoning_effort="high",
    )   
```

Reference to issue: #590 