### PR TITLE
Fix 429 Client Error: Too Many Requests in CI test

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,6 +49,7 @@ class ModelTests(unittest.TestCase):
         data = json.loads(message.model_dump_json())
         assert data["content"] == [{"type": "text", "text": "Hello!"}]
 
+    @pytest.mark.skipif(not os.getenv("RUN_ALL"), reason="RUN_ALL environment variable not set")
     def test_get_hfapi_message_no_tool(self):
         model = HfApiModel(max_tokens=10)
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]


### PR DESCRIPTION
Fix 429 Client Error: Too Many Requests for test_get_hfapi_message_no_tool: https://github.com/huggingface/smolagents/actions/runs/13258491319/job/37009590754?pr=499
```
=========================== short test summary info ============================
FAILED tests/test_models.py::ModelTests::test_get_hfapi_message_no_tool - huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://api-inference.huggingface.co/models/Qwen/Qwen2.5-Coder-32B-Instruct/v1/chat/completions (Request ID: BBblp7)
```
- Test get_hfapi_message_no_tool only if RUN_ALL