### PR TITLE
fix tool validation of defining var in list comp

### DIFF
--- a/src/smolagents/e2b_executor.py
+++ b/src/smolagents/e2b_executor.py
@@ -38,6 +38,7 @@ except ModuleNotFoundError:
 
 class E2BExecutor:
     def __init__(self, additional_imports: List[str], tools: List[Tool], logger):
+        self.logger = logger
         try:
             from e2b_code_interpreter import Sandbox
         except ModuleNotFoundError:
@@ -58,7 +59,6 @@ class E2BExecutor:
         #     timeout=300
         # )
         # print("Installation of agents package finished.")
-        self.logger = logger
         additional_imports = additional_imports + ["smolagents"]
         if len(additional_imports) > 0:
             execution = self.sbx.commands.run("pip install " + " ".join(additional_imports))


### PR DESCRIPTION
This one is related to #579,
when validate_tool_attributes, 
```
postprocessed_results = [f"[{result['title']}]({result['href']})\n{result['body']}" for result in results]
```
this line raises error for result var defined in list comp.
so I added visit_ListComp for MethodChecker

you can use the following code to test:
```
agent = CodeAgent(
    tools=[DuckDuckGoSearchTool()],  # 这里使用 DuckDuckGo 搜索工具作为示例
    model=model,
use_e2b_executor=True
)
```

I leave the validates __init__ untouched, that seemed have a pr going on.
this one only fixes about list comp.
