### PR TITLE
Adding default parameter for max_new_tokens in TransformersModel

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -442,7 +442,7 @@ class MLXModel(Model):
     ... )
     >>> messages = [
     ...     {
-    ...         "role": "user", 
+    ...         "role": "user",
     ...         "content": [
     ...             {"type": "text", "text": "Explain quantum mechanics in simple terms."}
     ...         ]
@@ -598,7 +598,16 @@ class TransformersModel(Model):
             model_id = default_model_id
             logger.warning(f"`model_id`not provided, using this default tokenizer for token counts: '{model_id}'")
         self.model_id = model_id
+
+        default_max_tokens = 5000
+        max_new_tokens = kwargs.get("max_new_tokens") or kwargs.get("max_tokens")
+        if not max_new_tokens:
+            kwargs["max_new_tokens"] = default_max_tokens
+            logger.warning(
+                f"`max_new_tokens` not provided, using this default value for `max_new_tokens`: {default_max_tokens}"
+            )
         self.kwargs = kwargs
+
         if device_map is None:
             device_map = "cuda" if torch.cuda.is_available() else "cpu"
         logger.info(f"Using device: {device_map}")
@@ -674,13 +683,8 @@ class TransformersModel(Model):
             or self.kwargs.get("max_tokens")
         )
 
-        default_max_tokens = 5000
-        if not max_new_tokens:
-            max_new_tokens = default_max_tokens
-            logger.warning(
-                f"`max_new_tokens` or `max_tokens` not provided, using this default value for `max_new_tokens`: {max_new_tokens}"
-            )
-        completion_kwargs["max_new_tokens"] = max_new_tokens
+        if max_new_tokens:
+            completion_kwargs["max_new_tokens"] = max_new_tokens
 
         if hasattr(self, "processor"):
             images = [Image.open(image) for image in images] if images else None

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -551,8 +551,13 @@ class TransformersModel(Model):
             or self.kwargs.get("max_tokens")
         )
 
-        if max_new_tokens:
-            completion_kwargs["max_new_tokens"] = max_new_tokens
+        default_max_tokens = 5000
+        if not max_new_tokens:
+            max_new_tokens = default_max_tokens
+            logger.warning(
+                f"`max_new_tokens` or `max_tokens` not provided, using this default value for `max_new_tokens`: {max_new_tokens}"
+            )
+        completion_kwargs["max_new_tokens"] = max_new_tokens
 
         if hasattr(self, "processor"):
             images = [Image.open(image) for image in images] if images else None


### PR DESCRIPTION
Related to issue [#414](https://github.com/huggingface/smolagents/issues/414).
This PR adds a default value of 5000 tokens for `max_new_tokens` amd `max_tokens` to `TransformersModel.__call__` to avoid using the corresponding `transformers` default value (= 20 tokens) which is too low for agentic tasks.

Usage example:
Modify the last few lines of the [Text2SQL example](https://huggingface.co/docs/smolagents/examples/text_to_sql) to be
```
from smolagents import CodeAgent, TransformersModel

agent = CodeAgent(
    tools=[sql_engine],
    model=TransformersModel("meta-llama/Meta-Llama-3.1-8B-Instruct"),
    max_steps=5
)

agent.run("Can you give me the name of the client who got the most expensive receipt?")
```