### PR TITLE
fix tool code generation in case of multiline descriptions

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -444,7 +444,7 @@ class TransformersModel(Model):
     ```python
     >>> engine = TransformersModel(
     ...     model_id="Qwen/Qwen2.5-Coder-32B-Instruct",
-    ...     device="cuda"
+    ...     device="cuda",
     ...     max_new_tokens=5000,
     ... )
     >>> messages = [{"role": "user", "content": "Explain quantum mechanics in simple terms."}]

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -444,7 +444,7 @@ class TransformersModel(Model):
     ```python
     >>> engine = TransformersModel(
     ...     model_id="Qwen/Qwen2.5-Coder-32B-Instruct",
-    ...     device="cuda",
+    ...     device="cuda"
     ...     max_new_tokens=5000,
     ... )
     >>> messages = [{"role": "user", "content": "Explain quantum mechanics in simple terms."}]

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -235,10 +235,10 @@ class Tool:
             from typing import Optional
 
             class {class_name}(Tool):
-                name = "{self.name}"
-                description = "{self.description}"
+                name = {json.dumps(self.name)}
+                description = {json.dumps(textwrap.dedent(self.description).strip())}
                 inputs = {json.dumps(self.inputs, separators=(",", ":"))}
-                output_type = "{self.output_type}"
+                output_type = {json.dumps(self.output_type)}
             """
             ).strip()
             import re

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -235,10 +235,10 @@ class Tool:
             from typing import Optional
 
             class {class_name}(Tool):
-                name = {json.dumps(self.name)}
+                name = "{self.name}"
                 description = {json.dumps(textwrap.dedent(self.description).strip())}
                 inputs = {json.dumps(self.inputs, separators=(",", ":"))}
-                output_type = {json.dumps(self.output_type)}
+                output_type = "{self.output_type}"
             """
             ).strip()
             import re

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -298,10 +298,12 @@ def instance_to_source(instance, base_cls=None):
 
     for name, value in class_attrs.items():
         if isinstance(value, str):
+            # multiline value
             if "\n" in value:
-                class_lines.append(f'    {name} = """{value}"""')
+                escaped_value = value.replace('"""', r"\"\"\"")  # Escape triple quotes
+                class_lines.append(f'    {name} = """{escaped_value}"""')
             else:
-                class_lines.append(f'    {name} = "{value}"')
+                class_lines.append(f"    {name} = {json.dumps(value)}")
         else:
             class_lines.append(f"    {name} = {repr(value)}")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -419,6 +420,46 @@ class ToolTests(unittest.TestCase):
 
         assert get_weather.inputs["locations"]["type"] == "array"
         assert get_weather.inputs["months"]["type"] == "array"
+
+    def test_saving_tool_produces_valid_pyhon_code_with_multiline_description(self):
+        @tool
+        def get_weather(location: Any) -> None:
+            """
+            Get weather in the next days at given location.
+            And works pretty well.
+
+            Args:
+                location: The location to get the weather for.
+            """
+            return
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            get_weather.save(tmp_dir)
+            with open(os.path.join(tmp_dir, "tool.py"), "r", encoding="utf-8") as f:
+                source_code = f.read()
+                compile(source_code, f.name, "exec")
+
+    def test_saving_tool_produces_valid_python_code_with_complex_name(self):
+        # Test one cannot save tool with additional args in init
+        class FailTool(Tool):
+            name = 'spe"\rcific'
+            description = """test \n\r
+            description"""
+            inputs = {"string_input": {"type": "string", "description": "input description"}}
+            output_type = "string"
+
+            def __init__(self):
+                super().__init__(self)
+
+            def forward(self, string_input):
+                return "foo"
+
+        fail_tool = FailTool()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fail_tool.save(tmp_dir)
+            with open(os.path.join(tmp_dir, "tool.py"), "r", encoding="utf-8") as f:
+                source_code = f.read()
+                compile(source_code, f.name, "exec")
 
 
 @pytest.fixture


### PR DESCRIPTION
If a tool decorated with `@tool` contains a multiline comment:
```py
@tool
def ssh_execute_command_with_agent(host: str, port: int, username: str, command: str) -> str:
    """This tool connects to a specified SSH server using the SSH agent for authentication
    and executes a given command on the server. It returns the output of the command
    or any errors encountered during execution.

    Args:
        host: The hostname or IP address of the server.
        port: The SSH port to connect to (default is 22).
        username: The SSH username for authentication.
        command: The command to execute on the server.

    Returns:
        A string containing the command's output or any errors encountered.

    """
```
It breaks `to_dict`. It produces something like this:
```py
from smolagents import Tool
            from typing import Any, Optional

            class SimpleTool(Tool):
                name = "ssh_execute_command_with_agent"
                description = This tool connects to a specified SSH server using the SSH agent for authentication
and executes a given command on the server. It returns the output of the command
or any errors encountered during execution.
                inputs = {"host":{"type":"string","description":"The hostname or IP address of the server."},"port":{"type":"integer","description":"The SSH port to connect to (default is 22)."},"username":{"type":"string","description":"The SSH username for authentication."},"command":{"type":"string","description":"The command to execute on the server."}}
                output_type = "string"

    def forward(self, host: str, port: int, username: str, command: str) -> str:
```