### PR TITLE
Improve missing toolcall exception

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -130,8 +130,9 @@ def parse_json_if_needed(arguments: Union[str, dict]) -> Union[str, dict]:
 
 
 def parse_tool_args_if_needed(message: ChatMessage) -> ChatMessage:
-    for tool_call in message.tool_calls:
-        tool_call.function.arguments = parse_json_if_needed(tool_call.function.arguments)
+    if message.tool_calls is not None:
+        for tool_call in message.tool_calls:
+            tool_call.function.arguments = parse_json_if_needed(tool_call.function.arguments)
     return message
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,7 +87,7 @@ class ModelTests(unittest.TestCase):
         assert output == "Hello! How can"
 
     def test_parse_tool_args_if_needed(self):
-        original_message = ChatMessage(role='user', content=[{'type': 'text', 'text': 'Hello!'}])
+        original_message = ChatMessage(role="user", content=[{"type": "text", "text": "Hello!"}])
         parsed_message = models.parse_tool_args_if_needed(original_message)
         assert parsed_message == original_message
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -86,6 +86,11 @@ class ModelTests(unittest.TestCase):
         output = model(messages, stop_sequences=["great"]).content
         assert output == "Hello! How can"
 
+    def test_parse_tool_args_if_needed(self):
+        original_message = ChatMessage(role='user', content=[{'type': 'text', 'text': 'Hello!'}])
+        parsed_message = models.parse_tool_args_if_needed(original_message)
+        assert parsed_message == original_message
+
     def test_parse_json_if_needed(self):
         args = "abc"
         parsed_args = parse_json_if_needed(args)


### PR DESCRIPTION
When the model is given a tool, but ignores the instruction to make a tool call and just returns text, the "NoneType is not iterable" exception message isn't explicit.

The code will now reach the more useful exception for this scenario:
https://github.com/huggingface/smolagents/blob/a17f915f61931a7f0a85f097fc19e7eca8fed536/src/smolagents/agents.py#L706-L707

Personally I hit this a fair amount when using OpenAIServerModel with local models (e.g. 32B distilled deepseek in LM Studio)
I've added a very simple throwaway test of the fix.

**Out of scope**

* It seems to me like the logic should be part of constructing ChatMessage rather than a fixup that callers have to remember to do afterwards.
* Testing/improving the integrated behaviour that the correct exception is actually what the model sees in its next step.

Thanks for the project, it's proving quite useful