### PR TITLE
Add http client for custom OpenAI deployments

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -23,6 +23,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import httpx
 from huggingface_hub import InferenceClient
 from huggingface_hub.utils import is_torch_available
 from PIL import Image
@@ -743,6 +744,7 @@ class OpenAIServerModel(Model):
         organization: Optional[str] | None = None,
         project: Optional[str] | None = None,
         custom_role_conversions: Optional[Dict[str, str]] = None,
+        http_client: httpx.Client | None = None,
         **kwargs,
     ):
         try:
@@ -759,6 +761,7 @@ class OpenAIServerModel(Model):
             api_key=api_key,
             organization=organization,
             project=project,
+            http_client=http_client,
         )
         self.custom_role_conversions = custom_role_conversions
 

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -732,6 +732,8 @@ class OpenAIServerModel(Model):
         custom_role_conversions (`dict[str, str]`, *optional*):
             Custom role conversion mapping to convert message roles in others.
             Useful for specific models that do not support specific message roles like "system".
+        http_client (`httpx.Client`, *optional*):
+            A HTTPx client to use for the API requests.
         **kwargs:
             Additional keyword arguments to pass to the OpenAI API.
     """


### PR DESCRIPTION
Title: Add `http_client` Parameter to `OpenAIServerModel` for Enhanced Compatibility


This Pull Request introduces an optional `http_client` parameter to the `OpenAIServerModel` class, enabling users to specify a custom `httpx.Client` instance for API requests. This enhancement facilitates compatibility with OpenAI-compatible servers deployed in diverse environments, offering greater flexibility in network configurations and customisations.

Key Changes:


  - Added an optional `http_client` parameter to the constructor:

    def __init__(
        self,
        model_id: str,
        api_base: Optional[str] = None,
        api_key: Optional[str] = None,
        organization: Optional[str] = None,
        project: Optional[str] = None,
        custom_role_conversions: Optional[Dict[str, str]] = None,
        http_client: Optional[httpx.Client] = None,  # New parameter
        **kwargs,
    ):
        ...

  - Passed the `http_client` parameter to the `openai.OpenAI` client initialisation:

    self.client = openai.OpenAI(
        base_url=api_base,
        api_key=api_key,
        organization=organization,
        project=project,
        http_client=http_client,  # Passed to OpenAI client
    )


**Rationale:**

The current implementation of `OpenAIServerModel` does not provide a mechanism to specify a custom HTTP client, which can be essential for:

- Routing Requests: Directing API calls through specific proxies or network paths.
- Custom Configuration: Setting custom timeouts, headers, or other HTTP client configurations.
- Enhanced Compatibility: Ensuring seamless integration with OpenAI-compatible servers hosted in various environments.

By allowing the injection of a custom `httpx.Client`, users gain fine-grained control over the HTTP behaviour of the `OpenAIServerModel`, enhancing its adaptability to diverse deployment scenarios.

References:

- [HTTPX Documentation: Client Instances](https://www.python-httpx.org/api/#client)
