### PR TITLE
Remove unused api-base arg from Open DeepResearch example

### DIFF
--- a/examples/open_deep_research/run.py
+++ b/examples/open_deep_research/run.py
@@ -60,7 +60,6 @@ append_answer_lock = threading.Lock()
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model-id", type=str, default="o1")
-    parser.add_argument("--api-base", type=str, default=None)
     parser.add_argument(
         "--question", type=str, default="How many studio albums did Mercedes Sosa release before 2007?"
     )

--- a/examples/open_deep_research/run_gaia.py
+++ b/examples/open_deep_research/run_gaia.py
@@ -75,7 +75,6 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--concurrency", type=int, default=8)
     parser.add_argument("--model-id", type=str, default="o1")
-    parser.add_argument("--api-base", type=str, default=None)
     parser.add_argument("--run-name", type=str, required=True)
     return parser.parse_args()
 


### PR DESCRIPTION
Remove unused api-base arg from Open DeepResearch example.

Note that the `api-base` arg is never used.