### PR TITLE
Make question arg required in Open DeepResearch example

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -18,5 +18,5 @@ pip install -e .[dev]
 
 Then you're good to go! Run the run.py script, as in:
 ```bash
-python run.py --model-id "o1" --question "Your question here!"
+python run.py --model-id "o1" "Your question here!"
 ```

--- a/examples/open_deep_research/run.py
+++ b/examples/open_deep_research/run.py
@@ -59,11 +59,11 @@ append_answer_lock = threading.Lock()
 
 def parse_args():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "question", type=str, help="for example: 'How many studio albums did Mercedes Sosa release before 2007?'"
+    )
     parser.add_argument("--model-id", type=str, default="o1")
     parser.add_argument("--api-base", type=str, default=None)
-    parser.add_argument(
-        "--question", type=str, default="How many studio albums did Mercedes Sosa release before 2007?"
-    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
Make question arg required in Open DeepResearch example.

```
$ python run.py -h

usage: run.py [-h] [--model-id MODEL_ID] [--api-base API_BASE] question

positional arguments:
  question             for example: 'How many studio albums did Mercedes Sosa release before 2007?'

options:
  -h, --help           show this help message and exit
  --model-id MODEL_ID
  --api-base API_BASE
```