### PR TITLE
Fix for MLX Model when stop sequence is followed by any chars

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -442,7 +442,7 @@ class MLXModel(Model):
     ... )
     >>> messages = [
     ...     {
-    ...         "role": "user", 
+    ...         "role": "user",
     ...         "content": [
     ...             {"type": "text", "text": "Explain quantum mechanics in simple terms."}
     ...         ]
@@ -477,7 +477,7 @@ class MLXModel(Model):
 
     def _to_message(self, text, tools_to_call_from):
         if tools_to_call_from:
-            # tmp solution for extracting tool JSON without assuming a specific model output format
+            # solution for extracting tool JSON without assuming a specific model output format
             maybe_json = "{" + text.split("{", 1)[-1][::-1].split("}", 1)[-1][::-1] + "}"
             parsed_text = json.loads(maybe_json)
             tool_name = parsed_text.get(self.tool_name_key, None)
@@ -531,8 +531,8 @@ class MLXModel(Model):
             self.last_output_token_count += 1
             text += _.text
             for stop_sequence in prepared_stop_sequences:
-                if text.strip().endswith(stop_sequence):
-                    text = text[: -len(stop_sequence)]
+                if text.rstrip().endswith(stop_sequence):
+                    text = text.rstrip()[: -len(stop_sequence)]
                     return self._to_message(text, tools_to_call_from)
 
         return self._to_message(text, tools_to_call_from)

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -531,7 +531,7 @@ class MLXModel(Model):
             self.last_output_token_count += 1
             text += _.text
             for stop_sequence in prepared_stop_sequences:
-                stop_sequence_start = text.find(stop_sequence)
+                stop_sequence_start = text.rfind(stop_sequence)
                 if stop_sequence_start != -1:
                     text = text[:stop_sequence_start]
                     return self._to_message(text, tools_to_call_from)

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -531,8 +531,9 @@ class MLXModel(Model):
             self.last_output_token_count += 1
             text += _.text
             for stop_sequence in prepared_stop_sequences:
-                if text.rstrip().endswith(stop_sequence):
-                    text = text.rstrip()[: -len(stop_sequence)]
+                stop_sequence_start = text.find(stop_sequence)
+                if stop_sequence_start != -1:
+                    text = text[:stop_sequence_start]
                     return self._to_message(text, tools_to_call_from)
 
         return self._to_message(text, tools_to_call_from)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -74,12 +74,13 @@ class ModelTests(unittest.TestCase):
         # In this test HuggingFaceTB/SmolLM2-135M-Instruct generates the token ">'"
         # which is required to test capturing stop_sequences that have extra chars at the end.
         model = MLXModel(model_id="HuggingFaceTB/SmolLM2-135M-Instruct", max_tokens=100)
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Please print '>'"}]}]
+        stop_sequence = " print '>"
+        messages = [{"role": "user", "content": [{"type": "text", "text": f"Please{stop_sequence}'"}]}]
         # check our assumption that that ">" is followed by "'"
         assert model.tokenizer.vocab[">'"]
-        assert model(messages, stop_sequences=[]).content == "I'm ready to help you print '>'"
+        assert model(messages, stop_sequences=[]).content == f"I'm ready to help you{stop_sequence}'"
         # check stop_sequence capture when output has trailing chars
-        assert model(messages, stop_sequences=[" print '>"]).content == "I'm ready to help you"
+        assert model(messages, stop_sequences=[stop_sequence]).content == "I'm ready to help you"
 
     def test_transformers_message_no_tool(self):
         model = TransformersModel(


### PR DESCRIPTION
~~Fixes stop sequence removal from model output if there is white space after the stop sequence. Previously, not all stop sequence characters would have been removed.~~

It was possible that any stop sequence could be missed. For example if your stop sequence is `<end_code>` but the model vocab includes `>'`, the model could choose that token and then the stop sequence would be missed. This PR should address all those cases.