### PR TITLE
Change math.pow -> pow

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -85,7 +85,7 @@ BASE_PYTHON_TOOLS = {
     "atan2": math.atan2,
     "degrees": math.degrees,
     "radians": math.radians,
-    "pow": math.pow,
+    "pow": pow,
     "sqrt": math.sqrt,
     "len": len,
     "sum": sum,


### PR DESCRIPTION
Hello,

here is a simple replacement of `math.po2` to built-in `pow` function, where the third argument can be used by an agent.
Please tell me if a unit test is needed or so, 
Closes #546