### PR TITLE
Fix issue #635. Corrected installation instructions for open_deep_research

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 And install smolagents dev version
 ```bash
-pip install -e smolagents[dev]
+pip install -e ../../[dev]
 ```
 
 Then you're good to go! Run the run.py script, as in:

--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 And install smolagents dev version
 ```bash
-pip install -e ../../[dev]
+pip install smolagents[dev]
 ```
 
 Then you're good to go! Run the run.py script, as in:


### PR DESCRIPTION
This PR addresses issue #635 and correctly builds smolagents from smolagents/examples/open_deep_research.