### PR TITLE
Fix evaluate_condition for non-bool result

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -740,7 +740,7 @@ def evaluate_condition(
             result = left not in right
         else:
             raise InterpreterError(f"Operator not supported: {op}")
-        if isinstance(result, bool) and not result:
+        if isinstance(result, bool) and result is False:
             break
         left = result
     return result

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -756,7 +756,7 @@ def evaluate_condition(
         if isinstance(result, bool) and not result:
             break
 
-    return result if isinstance(result, (bool, pd.Series)) else result.all()
+    return result
 
 
 def evaluate_if(

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -714,35 +714,38 @@ def evaluate_condition(
     custom_tools: Dict[str, Callable],
     authorized_imports: List[str],
 ) -> bool | object:
+    result = True
     left = evaluate_ast(condition.left, state, static_tools, custom_tools, authorized_imports)
-    for op, comparator in zip(condition.ops, condition.comparators):
+    for i, (op, comparator) in enumerate(zip(condition.ops, condition.comparators)):
         op = type(op)
         right = evaluate_ast(comparator, state, static_tools, custom_tools, authorized_imports)
         if op == ast.Eq:
-            result = left == right
+            current_result = left == right
         elif op == ast.NotEq:
-            result = left != right
+            current_result = left != right
         elif op == ast.Lt:
-            result = left < right
+            current_result = left < right
         elif op == ast.LtE:
-            result = left <= right
+            current_result = left <= right
         elif op == ast.Gt:
-            result = left > right
+            current_result = left > right
         elif op == ast.GtE:
-            result = left >= right
+            current_result = left >= right
         elif op == ast.Is:
-            result = left is right
+            current_result = left is right
         elif op == ast.IsNot:
-            result = left is not right
+            current_result = left is not right
         elif op == ast.In:
-            result = left in right
+            current_result = left in right
         elif op == ast.NotIn:
-            result = left not in right
+            current_result = left not in right
         else:
-            raise InterpreterError(f"Operator not supported: {op}")
-        if result is False:
-            break
-        left = result
+            raise InterpreterError(f"Unsupported comparison operator: {op}")
+
+        if current_result is False:
+            return False
+        result = current_result if i == 0 else (result and current_result)
+        left = right
     return result
 
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -715,47 +715,34 @@ def evaluate_condition(
     authorized_imports: List[str],
 ) -> bool | object:
     left = evaluate_ast(condition.left, state, static_tools, custom_tools, authorized_imports)
-    comparators = [
-        evaluate_ast(c, state, static_tools, custom_tools, authorized_imports) for c in condition.comparators
-    ]
-    ops = [type(op) for op in condition.ops]
-
-    result = True
-    current_left = left
-
-    for op, comparator in zip(ops, comparators):
+    for op, comparator in zip(condition.ops, condition.comparators):
+        op = type(op)
+        right = evaluate_ast(comparator, state, static_tools, custom_tools, authorized_imports)
         if op == ast.Eq:
-            current_result = current_left == comparator
+            result = left == right
         elif op == ast.NotEq:
-            current_result = current_left != comparator
+            result = left != right
         elif op == ast.Lt:
-            current_result = current_left < comparator
+            result = left < right
         elif op == ast.LtE:
-            current_result = current_left <= comparator
+            result = left <= right
         elif op == ast.Gt:
-            current_result = current_left > comparator
+            result = left > right
         elif op == ast.GtE:
-            current_result = current_left >= comparator
+            result = left >= right
         elif op == ast.Is:
-            current_result = current_left is comparator
+            result = left is right
         elif op == ast.IsNot:
-            current_result = current_left is not comparator
+            result = left is not right
         elif op == ast.In:
-            current_result = current_left in comparator
+            result = left in right
         elif op == ast.NotIn:
-            current_result = current_left not in comparator
+            result = left not in right
         else:
             raise InterpreterError(f"Operator not supported: {op}")
-
-        if not isinstance(current_result, bool):
-            return current_result
-
-        result = result & current_result
-        current_left = comparator
-
         if isinstance(result, bool) and not result:
             break
-
+        left = result
     return result
 
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -740,7 +740,7 @@ def evaluate_condition(
             result = left not in right
         else:
             raise InterpreterError(f"Operator not supported: {op}")
-        if isinstance(result, bool) and result is False:
+        if result is False:
             break
         left = result
     return result

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1291,6 +1291,8 @@ def test_non_standard_comparisons(expected_result):
                 self._right = right
             def __str__(self) -> str:
                 return f'{{self._left}} == {{self._right}}'
+            def __eq__(self, other):
+                return NonStdEqualsResult(self, other)
 
         class NonStdComparisonClass:
             def __init__(self, value: str ):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1189,7 +1189,7 @@ def test_evaluate_delete(code, state, expectation):
         ("a in b", {"a": 4, "b": [1, 2, 3]}, False),
         ("a not in b", {"a": 1, "b": [1, 2, 3]}, False),
         ("a not in b", {"a": 4, "b": [1, 2, 3]}, True),
-        # Composite conditions:
+        # Chained conditions:
         ("a == b == c", {"a": 1, "b": 1, "c": 1}, True),
         ("a == b == c", {"a": 1, "b": 2, "c": 1}, False),
         ("a == b < c", {"a": 1, "b": 1, "c": 1}, False),
@@ -1240,6 +1240,16 @@ def test_evaluate_condition(condition, state, expected_result):
             "a >= b",
             {"a": pd.DataFrame({"x": [1, 2], "y": [3, 4]}), "b": pd.DataFrame({"x": [2, 2], "y": [2, 2]})},
             pd.DataFrame({"x": [False, True], "y": [True, True]}),
+        ),
+        # Chained conditions:
+        (
+            "a == b == c",
+            {
+                "a": pd.Series([1, 2, 3]),
+                "b": pd.Series([2, 2, 2]),
+                "c": pd.Series([3, 3, 3]),
+            },
+            pd.Series([False, False, False]),
         ),
     ],
 )

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1267,13 +1267,24 @@ def test_evaluate_condition_with_pandas(condition, state, expected_result):
                 "The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()."
             ),
         ),
+        (
+            "a == b == c",
+            {
+                "a": pd.DataFrame({"x": [1, 2], "y": [3, 4]}),
+                "b": pd.DataFrame({"x": [2, 2], "y": [2, 2]}),
+                "c": pd.DataFrame({"x": [3, 3], "y": [3, 3]}),
+            },
+            ValueError(
+                "The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+            ),
+        ),
     ],
 )
 def test_evaluate_condition_with_pandas_exceptions(condition, state, expected_exception):
     condition_ast = ast.parse(condition, mode="eval").body
     with pytest.raises(type(expected_exception)) as exception_info:
         _ = evaluate_condition(condition_ast, state, {}, {}, [])
-        assert str(expected_exception) in str(exception_info.value)
+    assert str(expected_exception) in str(exception_info.value)
 
 
 def test_get_safe_module_handle_lazy_imports():

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1282,17 +1282,14 @@ def test_get_safe_module_handle_lazy_imports():
     assert getattr(safe_module, "non_lazy_attribute") == "ok"
 
 
-@pytest.mark.parametrize("expected_result", ["a == b", "a == b == c"])
-def test_non_standard_comparisons(expected_result):
-    code = dedent(f"""\
+def test_non_standard_comparisons():
+    code = dedent("""\
         class NonStdEqualsResult:
             def __init__(self, left:object, right:object):
                 self._left = left
                 self._right = right
             def __str__(self) -> str:
-                return f'{{self._left}} == {{self._right}}'
-            def __eq__(self, other):
-                return NonStdEqualsResult(self, other)
+                return f'{self._left} == {self._right}'
 
         class NonStdComparisonClass:
             def __init__(self, value: str ):
@@ -1303,12 +1300,11 @@ def test_non_standard_comparisons(expected_result):
                 return NonStdEqualsResult(self, other)
         a = NonStdComparisonClass("a")
         b = NonStdComparisonClass("b")
-        c = NonStdComparisonClass("c")
-        result = {expected_result}
+        result = a == b
         """)
     result, _ = evaluate_python_code(code, state={})
     assert not isinstance(result, bool)
-    assert str(result) == expected_result
+    assert str(result) == "a == b"
 
 
 class TestPrintContainer:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1192,8 +1192,8 @@ def test_evaluate_delete(code, state, expectation):
         # Chained conditions:
         ("a == b == c", {"a": 1, "b": 1, "c": 1}, True),
         ("a == b == c", {"a": 1, "b": 2, "c": 1}, False),
-        ("a == b < c", {"a": 1, "b": 1, "c": 1}, False),
-        ("a == b < c", {"a": 1, "b": 1, "c": 2}, True),
+        ("a == b < c", {"a": 2, "b": 2, "c": 2}, False),
+        ("a == b < c", {"a": 0, "b": 0, "c": 1}, True),
     ],
 )
 def test_evaluate_condition(condition, state, expected_result):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1272,29 +1272,31 @@ def test_get_safe_module_handle_lazy_imports():
     assert getattr(safe_module, "non_lazy_attribute") == "ok"
 
 
-def test_non_standard_comparisons():
-    code = """
-class NonStdEqualsResult:
-    def __init__(self, left:object, right:object):
-        self._left = left
-        self._right = right
-    def __str__(self) -> str:
-        return f'{self._left}=={self._right}'
+@pytest.mark.parametrize("expected_result", ["a == b", "a == b == c"])
+def test_non_standard_comparisons(expected_result):
+    code = dedent(f"""\
+        class NonStdEqualsResult:
+            def __init__(self, left:object, right:object):
+                self._left = left
+                self._right = right
+            def __str__(self) -> str:
+                return f'{{self._left}} == {{self._right}}'
 
-class NonStdComparisonClass:
-    def __init__(self, value: str ):
-        self._value = value
-    def __str__(self):
-        return self._value
-    def __eq__(self, other):
-        return NonStdEqualsResult(self, other)
-a = NonStdComparisonClass("a")
-b = NonStdComparisonClass("b")
-result = a == b
-    """
+        class NonStdComparisonClass:
+            def __init__(self, value: str ):
+                self._value = value
+            def __str__(self):
+                return self._value
+            def __eq__(self, other):
+                return NonStdEqualsResult(self, other)
+        a = NonStdComparisonClass("a")
+        b = NonStdComparisonClass("b")
+        c = NonStdComparisonClass("c")
+        result = {expected_result}
+        """)
     result, _ = evaluate_python_code(code, state={})
     assert not isinstance(result, bool)
-    assert str(result) == "a==b"
+    assert str(result) == expected_result
 
 
 class TestPrintContainer:


### PR DESCRIPTION
Fix evaluate_condition for non-bool result, as discussed in:
- #634

I think there are 2 bugs in `evaluate_condition`:
- The call to `.all()` method in: https://github.com/huggingface/smolagents/blob/b20da6a74781e41bb652699e7501f07509fddb56/src/smolagents/local_python_executor.py#L759
  - This should be called explicitly (when pertinent) by the calling code
  - A library may return a non-bool result that does not implement the `.all` method
- The early return in: https://github.com/huggingface/smolagents/blob/cfe599c54a81412ea334e1f9d1f17189772428ef/src/smolagents/local_python_executor.py#L750-L751
  - Introduced by:
    - #612
  - Gives a wrong result for: `pd.Series([1, 2, 3]) == pd.Series([2, 2, 2]) == pd.Series([3, 3, 3])`
    - It was returning: `pd.Series([False, True, False]`
    - Instead of raising a `ValueError("The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().")`