### PR TITLE
Allow for last_input_token_count=None

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -141,7 +141,7 @@ def stream_to_gradio(
 
     for step_log in agent.run(task, stream=True, reset=reset_agent_memory, additional_args=additional_args):
         # Track tokens if model provides them
-        if getattr(agent.model, "last_input_token_count", None):
+        if getattr(agent.model, "last_input_token_count", None) is not None:
             total_input_tokens += agent.model.last_input_token_count
             total_output_tokens += agent.model.last_output_token_count
             if isinstance(step_log, ActionStep):


### PR DESCRIPTION
A better test taken from monitoring.py because when using Ollama with MultiStepAgent for reasons I could not identify sometimes the value is still None as set in Model.__init__