### PR TITLE
Remove non-existent subfolder arg in MultiStepAgent.from_hub

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -925,7 +925,6 @@ You have been provided with these additional arguments, that you can access usin
                 "resume_download",
                 "proxies",
                 "revision",
-                "subfolder",
                 "local_files_only",
             ]
             if key in kwargs


### PR DESCRIPTION
Remove non-existent `subfolder` arg in `MultiStepAgent.from_hub`.

Currently a TypeError is raised if the `subfolder` arg is passed:
> TypeError: snapshot_download() got an unexpected keyword argument 'subfolder'
```python
CodeAgent.from_hub(repo_id, trust_remote_code=True, subfolder="tools")

src/smolagents/agents.py:934: in from_hub
    download_folder = Path(snapshot_download(repo_id=repo_id, **download_kwargs))
E       TypeError: snapshot_download() got an unexpected keyword argument 'subfolder'

venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py:114: TypeError
```