### PR TITLE
Respect formatting in ast.FormattedValue for local_python_executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1230,8 +1230,23 @@ def evaluate_ast(
         # For loop -> execute the loop
         return evaluate_for(expression, state, static_tools, custom_tools, authorized_imports)
     elif isinstance(expression, ast.FormattedValue):
-        # Formatted value (part of f-string) -> evaluate the content and return
-        return evaluate_ast(expression.value, state, static_tools, custom_tools, authorized_imports)
+        # Formatted value (part of f-string) -> evaluate the content and format it
+        value = evaluate_ast(expression.value, state, static_tools, custom_tools, authorized_imports)
+        # Get the format spec if it exists
+        format_spec = None
+        if expression.format_spec:
+            format_spec = (
+                "".join(
+                    str(evaluate_ast(v, state, static_tools, custom_tools, authorized_imports))
+                    for v in expression.format_spec.values
+                )
+                if isinstance(expression.format_spec, ast.JoinedStr)
+                else expression.format_spec.value
+            )
+        # Apply formatting if format_spec exists
+        if format_spec is not None:
+            return format(value, format_spec)
+        return value
     elif isinstance(expression, ast.If):
         # If -> execute the right branch
         return evaluate_if(expression, state, static_tools, custom_tools, authorized_imports)

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -122,6 +122,24 @@ class PythonInterpreterTester(unittest.TestCase):
         assert result == "This is x: 3."
         self.assertDictEqualNoPrint(state, {"x": 3, "text": "This is x: 3.", "_operations_count": 6})
 
+    def test_evaluate_f_string_with_format(self):
+        code = "text = f'This is x: {x:.2f}.'"
+        state = {"x": 3.336}
+        result, _ = evaluate_python_code(code, {}, state=state)
+        # evaluate returns the value of the last assignment.
+        assert result == "This is x: 3.34."
+        self.assertDictEqualNoPrint(state, {"x": 3.336, "text": "This is x: 3.34.", "_operations_count": 7})
+
+    def test_evaluate_f_string_with_complex_format(self):
+        code = "text = f'This is x: {x:>{width}.{precision}f}.'"
+        state = {"x": 3.336, "width": 10, "precision": 2}
+        result, _ = evaluate_python_code(code, {}, state=state)
+        # evaluate returns the value of the last assignment.
+        assert result == "This is x:       3.34."
+        self.assertDictEqualNoPrint(
+            state, {"x": 3.336, "width": 10, "precision": 2, "text": "This is x:       3.34.", "_operations_count": 13}
+        )
+
     def test_evaluate_if(self):
         code = "if x <= 3:\n    y = 2\nelse:\n    y = 5"
         state = {"x": 3}


### PR DESCRIPTION
Current implementation of local_python_executor ommits formatting parameters in f-strings, eg:

```
    f'This is x: {3.336:.2f}.'
```
will produce 
```
    'This is x: 3.336.'
```

This pull request enables support of formatting values making produced value as expected:
```
    'This is x: 3.34.'
``` 

and even complex formats like this

```
    f'This is x: {x:>{width}.{precision}f}.'
```