### PR TITLE
Align step numbers in monitoring logging

### DIFF
--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -59,7 +59,7 @@ class Monitor:
         """
         step_duration = step_log.duration
         self.step_durations.append(step_duration)
-        console_outputs = f"[Step {len(self.step_durations) - 1}: Duration {step_duration:.2f} seconds"
+        console_outputs = f"[Step {len(self.step_durations)}: Duration {step_duration:.2f} seconds"
 
         if getattr(self.tracked_model, "last_input_token_count", None) is not None:
             self.total_input_token_count += self.tracked_model.last_input_token_count


### PR DESCRIPTION
Change-Id: I751c96e2dac113303006d1636b7122150ca165e8

![WechatIMG174](https://github.com/user-attachments/assets/86b3ffa9-ecf3-4ee1-bef8-28c84e6d1be2)

Adjust the Monitor class in src/smolagents/monitoring.py. Adjust the following code:
`console_outputs = f"[Step {len(self.step_durations)-1}: Duration {step_duration:.2f} seconds"`
Modify the step counter so that it can match the main title in each block, reducing confusion.