### PR TITLE
Remove deprecated resume_download arg in from_hub

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -926,7 +926,6 @@ You have been provided with these additional arguments, that you can access usin
             for key in [
                 "cache_dir",
                 "force_download",
-                "resume_download",
                 "proxies",
                 "revision",
                 "local_files_only",

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -406,7 +406,6 @@ class Tool:
             repo_type="space",
             cache_dir=kwargs.get("cache_dir"),
             force_download=kwargs.get("force_download"),
-            resume_download=kwargs.get("resume_download"),
             proxies=kwargs.get("proxies"),
             revision=kwargs.get("revision"),
             subfolder=kwargs.get("subfolder"),


### PR DESCRIPTION
Remove deprecated `resume_download` arg in from_hub.

Note that the `resume_download` param was deprecated in huggingface-hub 0.23 (May 2, 2024): https://github.com/huggingface/huggingface_hub/releases/tag/v0.23.0
- passing the parameter is just ignored