### PR TITLE
Pass notebook_folder to build notebook docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -20,6 +20,7 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: smolagents
       languages: en
+      notebook_folder: smolagents_doc
       # additional_args: --not_python_module # use this arg if repository is documentation only
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}


### PR DESCRIPTION
Pass `notebook_folder` to build notebook docs.

This argument is necessary if we want to automatically convert our documentation Guides to Notebooks.

Fix #647, fix #211, fix #113.