### PR TITLE
Raise exception if max tokens exceeded

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1090,6 +1090,8 @@ class ToolCallingAgent(MultiStepAgent):
                 tools_to_call_from=list(self.tools.values()),
                 stop_sequences=["Observation:"],
             )
+            if model_message.finish_reason == "length":
+                raise Exception("Max tokens exceeded.")
             memory_step.model_output_message = model_message
             if model_message.tool_calls is None or len(model_message.tool_calls) == 0:
                 raise Exception("Model did not call any tools. Call `final_answer` tool to return a final answer.")
@@ -1258,11 +1260,14 @@ class CodeAgent(MultiStepAgent):
                 stop_sequences=["<end_code>", "Observation:"],
                 **additional_args,
             )
+            if chat_message.finish_reason == "length":
+                raise Exception("Max tokens exceeded.")
             memory_step.model_output_message = chat_message
             model_output = chat_message.content
             memory_step.model_output = model_output
         except Exception as e:
             raise AgentGenerationError(f"Error in generating model output:\n{e}", self.logger) from e
+
 
         self.logger.log_markdown(
             content=model_output,


### PR DESCRIPTION
I've seen a few issues reported that were resolved by raising max tokens. The aim of this PR is to avoid misleading error messages and report if tokens are exhausted. It also provides the ground work for stopping agent execution early if there are no tokens left as I believe that is an unrecoverable situation.

Currently the PR only applies to MLX models but should be easy to apply to other model types if the proposed solution is accepted. @aymeric-roucher can you take a quick look and let me know what you think?

Closes #607 

### Before

<img width="1024" alt="Screenshot 2025-02-17 at 10 11 21 AM" src="https://github.com/user-attachments/assets/7eae201c-5979-4dab-9aad-2b4308bc5ed4" />

### After
<img width="1024" alt="Screenshot 2025-02-17 at 10 15 01 AM" src="https://github.com/user-attachments/assets/83ae62c9-00b6-4a13-9a8b-3317cd75779a" />
