### PR TITLE
Remind users about the usage tier to call o1

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -20,3 +20,7 @@ Then you're good to go! Run the run.py script, as in:
 ```bash
 python run.py --model-id "o1" "Your question here!"
 ```
+
+<b>Note</b>: It needs the usage tier 5, which can be accessed to call the model 'o1'.
+
+You can check it at the bottom of [OpenAI platform](https://platform.openai.com/settings/organization/limits).


### PR DESCRIPTION
If user's tier is not 5. The terminal shows
```
    raise NotFoundError(
litellm.exceptions.NotFoundError: litellm.NotFoundError: OpenAIException - Error code: 404 - {'error': {'message': 'The model `o1` does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
```
So, it was added a paragraph to remind users.