### PR TITLE
Pin transformers < 4.49.0 to fix TypeError: LlavaProcessor: got multiple values for keyword argument 'images'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ telemetry = [
 ]
 transformers = [
   "accelerate",
-  "transformers>=4.0.0",
+  "transformers>=4.0.0,<4.49.0",
   "smolagents[torch]",
 ]
 all = [


### PR DESCRIPTION
Pin transformers < 4.49.0 to fix TypeError: LlavaProcessor: got multiple values for keyword argument 'images'.

Fix #692.