### PR TITLE
Fix test docs

### DIFF
--- a/tests/test_all_docs.py
+++ b/tests/test_all_docs.py
@@ -94,7 +94,7 @@ class TestDocs:
 
         load_dotenv()
 
-        cls.md_files = list(cls.docs_dir.rglob("*.md"))
+        cls.md_files = list(cls.docs_dir.rglob("*.mdx"))
         if not cls.md_files:
             raise ValueError(f"No markdown files found in {cls.docs_dir}")
 


### PR DESCRIPTION
Fix test docs: glob `.mdx` (instead of `.md`) doc files once that the file extensions have been renamed.

Issue introduced by:
- #691

CC: @accupham