### PR TITLE
Fix validate_tool_attributes for non-literal defaults

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -1,6 +1,6 @@
 import ast
 import builtins
-import inspect
+from itertools import zip_longest
 from typing import Set
 
 from .utils import BASE_BUILTIN_MODULES, get_source
@@ -157,41 +157,19 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
 
     Raises all errors encountered, if no error returns None.
     """
-    errors = []
-
-    source = get_source(cls)
-
-    tree = ast.parse(source)
-
-    if not isinstance(tree.body[0], ast.ClassDef):
-        raise ValueError("Source code must define a class")
-
-    # Check that __init__ method only has arguments with defaults
-    if not cls.__init__.__qualname__ == "Tool.__init__":
-        sig = inspect.signature(cls.__init__)
-        non_default_params = [
-            arg_name
-            for arg_name, param in sig.parameters.items()
-            if arg_name != "self"
-            and param.default == inspect.Parameter.empty
-            and param.kind != inspect.Parameter.VAR_KEYWORD  # Excludes **kwargs
-        ]
-        if non_default_params:
-            errors.append(
-                f"This tool has required arguments in __init__: {non_default_params}. "
-                "All parameters of __init__ must have default values!"
-            )
-
-    class_node = tree.body[0]
 
     class ClassLevelChecker(ast.NodeVisitor):
         def __init__(self):
             self.imported_names = set()
             self.complex_attributes = set()
             self.class_attributes = set()
+            self.non_defaults = set()
+            self.non_literal_defaults = set()
             self.in_method = False
 
         def visit_FunctionDef(self, node):
+            if node.name == "__init__":
+                self._check_init_function_parameters(node)
             old_context = self.in_method
             self.in_method = True
             self.generic_visit(node)
@@ -214,13 +192,38 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
                     if isinstance(target, ast.Name):
                         self.complex_attributes.add(target.id)
 
+        def _check_init_function_parameters(self, node):
+            # Check defaults in parameters
+            for arg, default in reversed(list(zip_longest(reversed(node.args.args), reversed(node.args.defaults)))):
+                if default is None:
+                    if arg.arg != "self":
+                        self.non_defaults.add(arg.arg)
+                elif not isinstance(default, (ast.Str, ast.Num, ast.Constant, ast.Dict, ast.List, ast.Set)):
+                    self.non_literal_defaults.add(arg.arg)
+
     class_level_checker = ClassLevelChecker()
+    source = get_source(cls)
+    tree = ast.parse(source)
+    class_node = tree.body[0]
+    if not isinstance(class_node, ast.ClassDef):
+        raise ValueError("Source code must define a class")
     class_level_checker.visit(class_node)
 
+    errors = []
     if class_level_checker.complex_attributes:
         errors.append(
             f"Complex attributes should be defined in __init__, not as class attributes: "
             f"{', '.join(class_level_checker.complex_attributes)}"
+        )
+    if class_level_checker.non_defaults:
+        errors.append(
+            f"Parameters in __init__ must have default values, found required parameters: "
+            f"{', '.join(class_level_checker.non_defaults)}"
+        )
+    if class_level_checker.non_literal_defaults:
+        errors.append(
+            f"Parameters in __init__ must have literal default values, found non-literal defaults: "
+            f"{', '.join(class_level_checker.non_literal_defaults)}"
         )
 
     # Run checks on all methods

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -88,10 +88,13 @@ class InvalidToolNonLiteralDefaultParam(Tool):
 @pytest.mark.parametrize(
     "tool_class, expected_error",
     [
-        (InvalidToolRequiredParams, "required arguments in __init__"),
-        (InvalidToolComplexAttrs, "Complex attributes should be defined in __init"),
+        (InvalidToolComplexAttrs, "Complex attributes should be defined in __init__, not as class attributes"),
+        (InvalidToolRequiredParams, "Parameters in __init__ must have default values, found required parameters"),
+        (
+            InvalidToolNonLiteralDefaultParam,
+            "Parameters in __init__ must have literal default values, found non-literal defaults",
+        ),
         (InvalidToolUndefinedNames, "Name 'undefined_variable' is undefined"),
-        (InvalidToolNonLiteralDefaultParam, "Tool validation failed"),  # TODO: Improve error message
     ],
 )
 def test_validate_tool_attributes_exceptions(tool_class, expected_error):

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -5,6 +5,9 @@ from smolagents.tool_validation import validate_tool_attributes
 from smolagents.tools import Tool
 
 
+UNDEFINED_VARIABLE = "undefined_variable"
+
+
 @pytest.mark.parametrize("tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool])
 def test_validate_tool_attributes_with_default_tools(tool_class):
     assert validate_tool_attributes(tool_class) is None, f"failed for {tool_class.name} tool"
@@ -30,20 +33,6 @@ def test_validate_tool_attributes_valid():
     assert validate_tool_attributes(ValidTool) is None
 
 
-class InvalidToolRequiredParams(Tool):
-    name = "invalid_tool"
-    description = "Tool with required params"
-    inputs = {"input": {"type": "string", "description": "input"}}
-    output_type = "string"
-
-    def __init__(self, required_param):  # No default value
-        super().__init__()
-        self.param = required_param
-
-    def forward(self, input: str) -> str:
-        return input
-
-
 class InvalidToolComplexAttrs(Tool):
     name = "invalid_tool"
     description = "Tool with complex class attributes"
@@ -58,7 +47,32 @@ class InvalidToolComplexAttrs(Tool):
         return input
 
 
-undefined_variable = "undefined_variable"
+class InvalidToolRequiredParams(Tool):
+    name = "invalid_tool"
+    description = "Tool with required params"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+
+    def __init__(self, required_param, kwarg1=1):  # No default value
+        super().__init__()
+        self.param = required_param
+
+    def forward(self, input: str) -> str:
+        return input
+
+
+class InvalidToolNonLiteralDefaultParam(Tool):
+    name = "invalid_tool"
+    description = "Tool with non-literal default parameter value"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+
+    def __init__(self, default_param=UNDEFINED_VARIABLE):  # UNDEFINED_VARIABLE as default is non-literal
+        super().__init__()
+        self.default_param = default_param
+
+    def forward(self, input: str) -> str:
+        return input
 
 
 class InvalidToolUndefinedNames(Tool):
@@ -68,21 +82,7 @@ class InvalidToolUndefinedNames(Tool):
     output_type = "string"
 
     def forward(self, input: str) -> str:
-        return undefined_variable  # Undefined name
-
-
-class InvalidToolNonLiteralDefaultParam(Tool):
-    name = "invalid_tool"
-    description = "Tool with non-literal default parameter value"
-    inputs = {"input": {"type": "string", "description": "input"}}
-    output_type = "string"
-
-    def __init__(self, default_param=undefined_variable):  # undefined_variable as default is non-literal
-        super().__init__()
-        self.default_param = default_param
-
-    def forward(self, input: str) -> str:
-        return input
+        return UNDEFINED_VARIABLE  # Undefined name
 
 
 @pytest.mark.parametrize(
@@ -94,7 +94,7 @@ class InvalidToolNonLiteralDefaultParam(Tool):
             InvalidToolNonLiteralDefaultParam,
             "Parameters in __init__ must have literal default values, found non-literal defaults",
         ),
-        (InvalidToolUndefinedNames, "Name 'undefined_variable' is undefined"),
+        (InvalidToolUndefinedNames, "Name 'UNDEFINED_VARIABLE' is undefined"),
     ],
 )
 def test_validate_tool_attributes_exceptions(tool_class, expected_error):

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -6,24 +6,94 @@ from smolagents.tools import Tool
 
 
 @pytest.mark.parametrize("tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool])
-def test_validate_tool_attributes(tool_class):
+def test_validate_tool_attributes_with_default_tools(tool_class):
     assert validate_tool_attributes(tool_class) is None, f"failed for {tool_class.name} tool"
 
 
-class DummyTool(Tool):
-    name = "DummyTool"
-    description = "A dummy tool for testing"
-    inputs = {"output_string": {"type": "string", "description": "The string to output."}}
+class ValidTool(Tool):
+    name = "valid_tool"
+    description = "A valid tool"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+    simple_attr = "string"
+    dict_attr = {"key": "value"}
+
+    def __init__(self, optional_param="default"):
+        super().__init__()
+        self.param = optional_param
+
+    def forward(self, input: str) -> str:
+        return input.upper()
+
+
+def test_validate_tool_attributes_valid():
+    assert validate_tool_attributes(ValidTool) is None
+
+
+class InvalidToolRequiredParams(Tool):
+    name = "invalid_tool"
+    description = "Tool with required params"
+    inputs = {"input": {"type": "string", "description": "input"}}
     output_type = "string"
 
-    def __init__(self, tool_class=Tool):
+    def __init__(self, required_param):  # No default value
         super().__init__()
-        self.tool_class = tool_class
+        self.param = required_param
 
-    def forward(self, output_string: str) -> str:
-        return "dummy output: " + output_string
+    def forward(self, input: str) -> str:
+        return input
 
 
-def test_validate_tool_attributes_exceptions():
-    with pytest.raises(ValueError):
-        validate_tool_attributes(DummyTool)
+class InvalidToolComplexAttrs(Tool):
+    name = "invalid_tool"
+    description = "Tool with complex class attributes"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+    complex_attr = [x for x in range(3)]  # Complex class attribute
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input: str) -> str:
+        return input
+
+
+undefined_variable = "undefined_variable"
+
+
+class InvalidToolUndefinedNames(Tool):
+    name = "invalid_tool"
+    description = "Tool with undefined names"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+
+    def forward(self, input: str) -> str:
+        return undefined_variable  # Undefined name
+
+
+class InvalidToolNonLiteralDefaultParam(Tool):
+    name = "invalid_tool"
+    description = "Tool with non-literal default parameter value"
+    inputs = {"input": {"type": "string", "description": "input"}}
+    output_type = "string"
+
+    def __init__(self, default_param=undefined_variable):  # undefined_variable as default is non-literal
+        super().__init__()
+        self.default_param = default_param
+
+    def forward(self, input: str) -> str:
+        return input
+
+
+@pytest.mark.parametrize(
+    "tool_class, expected_error",
+    [
+        (InvalidToolRequiredParams, "required arguments in __init__"),
+        (InvalidToolComplexAttrs, "Complex attributes should be defined in __init"),
+        (InvalidToolUndefinedNames, "Name 'undefined_variable' is undefined"),
+        (InvalidToolNonLiteralDefaultParam, "Tool validation failed"),  # TODO: Improve error message
+    ],
+)
+def test_validate_tool_attributes_exceptions(tool_class, expected_error):
+    with pytest.raises(ValueError, match=expected_error):
+        validate_tool_attributes(tool_class)

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -2,8 +2,28 @@ import pytest
 
 from smolagents.default_tools import DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool
 from smolagents.tool_validation import validate_tool_attributes
+from smolagents.tools import Tool
 
 
 @pytest.mark.parametrize("tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool])
 def test_validate_tool_attributes(tool_class):
     assert validate_tool_attributes(tool_class) is None, f"failed for {tool_class.name} tool"
+
+
+class DummyTool(Tool):
+    name = "DummyTool"
+    description = "A dummy tool for testing"
+    inputs = {"output_string": {"type": "string", "description": "The string to output."}}
+    output_type = "string"
+
+    def __init__(self, tool_class=Tool):
+        super().__init__()
+        self.tool_class = tool_class
+
+    def forward(self, output_string: str) -> str:
+        return "dummy output: " + output_string
+
+
+def test_validate_tool_attributes_exceptions():
+    with pytest.raises(ValueError):
+        validate_tool_attributes(DummyTool)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -235,7 +235,7 @@ class ToolTests(unittest.TestCase):
         fail_tool = FailTool("dummy_url")
         with pytest.raises(Exception) as e:
             fail_tool.to_dict()
-        assert "All parameters of __init__ must have default values!" in str(e)
+        assert "Parameters in __init__ must have default values, found required parameters" in str(e)
 
         class PassTool(Tool):
             name = "specific"


### PR DESCRIPTION
Fix `validate_tool_attributes` for non-literal defaults.

Currently, defining an `__init__` keyword argument that defaults to a variable (`arg=variable`) does not raise an error.