### PR TITLE
Ignore parameter types in tool docstrings

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -228,7 +228,7 @@ args_re = re.compile(r"\n\s*Args:\n\s*(.*?)[\n\s]*(Returns:|Raises:|\Z)", re.DOT
 args_split_re = re.compile(
     r"""
 (?:^|\n)  # Match the start of the args block, or a newline
-\s*(\w+):\s*  # Capture the argument name and strip spacing
+\s*(\w+)\s*(?:\([^)]*\))?:\s*  # Capture the argument name (ignore the type) and strip spacing
 (.*?)\s*  # Capture the argument description, which can span multiple lines, and strip trailing spacing
 (?=\n\s*\w+:|\Z)  # Stop when you hit the next argument or the end of the block
 """,


### PR DESCRIPTION
## Description

This PR enhances the docstring parser to support Google-style docstrings that include parameter types (e.g., `x (float): ...`). The changes are backward-compatible and maintain support for docstrings without parameter types (e.g., `x: ...`).

### Changes
- Updated the regular expression in the docstring parser to handle parameter types.

### Examples

The parser now correctly handles docstrings with parameter types:
```python
def multiply(x, y):
    """
    Args:
        x (float): The first number to multiply.
        y (float): The second number to multiply.
    """
    return x * y
```
Previous the args may be reconized as "x (float)" and raise the exception "Cannot generate JSON schema for multiply because the docstring has no description for the argument 'x'".The changes reduces the need for users to manually adjust their docstrings.