### PR TITLE
Remove article section from launch_gradio_demo Interface

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -633,7 +633,7 @@ def launch_gradio_demo(tool: Tool):
     `inputs` and `output_type`.
 
     Args:
-        tool (`type`): The tool for which to launch the demo.
+        tool (`Tool`): The tool for which to launch the demo.
     """
     try:
         import gradio as gr

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -667,7 +667,6 @@ def launch_gradio_demo(tool: Tool):
         inputs=gradio_inputs,
         outputs=gradio_output,
         title=tool.name,
-        article=tool.description,
         description=tool.description,
         api_name=tool.name,
     ).launch()


### PR DESCRIPTION
Remove article section from `launch_gradio_demo` Interface.

Currently, the tool description appear both, above and below the input components.

This PR removes the description appearing below the input components, called `article` attribute in the Gradio Interface.