### PR TITLE
Add env variable setting reminder for running open deep research

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -20,3 +20,9 @@ Then you're good to go! Run the run.py script, as in:
 ```bash
 python run.py --model-id "o1" "Your question here!"
 ```
+
+Note that for running the `run.py` and `run_gaia.py` you need to set the following variables properly:
+```bash
+export SERPAPI_API_KEY="YOUR_API_KEY"
+export HF_TOKEN="YOUR_API_KEY" # for downloading GAIA benchmark
+```


### PR DESCRIPTION
This pull request reminds the `examples/open_deep_research/README.md` file to include additional setup instructions for running the `run.py` and `run_gaia.py` scripts properly.

* Added instructions to set the `SERPAPI_API_KEY` and `HF_TOKEN` environment variables before running the scripts.