### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: quality style test docs utils
 
-check_dirs := src tests utils
+check_dirs := examples src tests utils
 
 # Check code quality of the source code
 quality:


### PR DESCRIPTION
Fix typo in Makefile introduced accidentally in:
- #388