### PR TITLE
Add audioop-lts as Python>=3.13 Open DeepResearch requirement for pydub

### DIFF
--- a/examples/open_deep_research/requirements.txt
+++ b/examples/open_deep_research/requirements.txt
@@ -1,4 +1,5 @@
 anthropic>=0.37.1
+audioop-lts<1.0; python_version >= "3.13" # required to use pydub in Python >=3.13; LTS port of the removed Python builtin module audioop
 beautifulsoup4>=4.12.3
 datasets>=2.21.0
 google_search_results>=2.4.2


### PR DESCRIPTION
Add audioop-lts as Python >=3.13 Open DeepResearch requirement to use pydub.

Related to discussion in:
- #746