### PR TITLE
Supplemental explanation for manage agent name.

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -182,7 +182,7 @@ class MultiStepAgent:
         managed_agents (`list`, *optional*): Managed agents that the agent can call.
         step_callbacks (`list[Callable]`, *optional*): Callbacks that will be called at each step.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
-        name (`str`, *optional*): Necessary for a managed agent only - the name by which this agent can be called.
+        name (`str`, *optional*): Necessary for a managed agent only - the name by which this agent can be called, must be identical to the name of the agent instance.
         description (`str`, *optional*): Necessary for a managed agent only - the description of this agent.
         provide_run_summary (`bool`, *optional*): Whether to provide a run summary when called as a managed agent.
         final_answer_checks (`list`, *optional*): List of Callables to run before returning a final answer for checking validity.


### PR DESCRIPTION
Based on the issue [https://github.com/huggingface/smolagents/issues/640](https://github.com/huggingface/smolagents/issues/640), it seems that users often overlook the requirement that the `name` must be identical to the Agent instance name when using MultiAgent. A simpler approach would be to avoid setting the `name` and directly use the Agent instance name. However, this is not easily achievable in Python (it would require using `inspect`). So, for now, we've added a supplementary explanation in the `name` comment.

However, I feel that this is still too obscure. Is there a better way to address this issue?