### PR TITLE
fix: correcting tool_call role

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -89,7 +89,7 @@ class ActionStep(MemoryStep):
         if self.tool_calls is not None:
             messages.append(
                 Message(
-                    role=MessageRole.ASSISTANT,
+                    role=MessageRole.TOOL_CALL,
                     content=[
                         {
                             "type": "text",


### PR DESCRIPTION
An incorrect role may cause the model to think that the tool_call message should be generated by the model. As a result, the model predicts the tool_call message after the codeblock in the subsequent step.