### PR TITLE
Use docker extra in Secure code execution docs

### DIFF
--- a/docs/source/en/tutorials/secure_code_execution.mdx
+++ b/docs/source/en/tutorials/secure_code_execution.mdx
@@ -163,9 +163,9 @@ print(execution_logs)
 #### Installation
 
 1. [Install Docker on your system](https://docs.docker.com/get-started/get-docker/)
-2. Install the Python Docker package:
+2. Install the required packages:
 ```bash
-pip install docker
+pip install 'smolagents[docker]'
 ```
 
 #### Setting up the docker sandbox


### PR DESCRIPTION
Use docker extra in Secure code execution docs.

Follow-up to:
- #747 

once merged:
- #764