### PR TITLE
Update Open DeepResearch to install smolagents from local path

### DIFF
--- a/examples/open_deep_research/README.md
+++ b/examples/open_deep_research/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 And install smolagents dev version
 ```bash
-pip install smolagents[dev]
+pip install -e ../../.[dev]
 ```
 
 Then you're good to go! Run the run.py script, as in:


### PR DESCRIPTION
Update Open DeepResearch to install smolagents from local path in editable mode.

In order to be sure that the running of Open DeepResearch is aligned with the smolagents version, smolagents should be installed from the local path in editable mode.

Related to:
- #777