### PR TITLE
Fix LiteLLMModel API key usage in CLI

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -89,7 +89,7 @@ def load_model(model_type: str, model_id: str, api_base: str | None, api_key: st
     elif model_type == "LiteLLMModel":
         return LiteLLMModel(
             model_id=model_id,
-            api_key=api_key or os.getenv("OPENAI_API_KEY"),
+            api_key=api_key,
             api_base=api_base,
         )
     elif model_type == "TransformersModel":


### PR DESCRIPTION
This PR fixes `LiteLLMModel` API key handling in the CLI. Before this, when running without `--api-key`, the CLI defaulted to using `OPENAI_API_KEY` even for non-OpenAI models, preventing LiteLLM's built-in API key detection based on the model provider.

I've tested the fix with:
```bash
export OPENAI_API_KEY="sk-openai-key"
export ANTHROPIC_API_KEY="sk-anthropic-key"

smolagent "What is the 42nd decimal digit of π?" --model-type "LiteLLMModel" --model-id "anthropic/claude-3-7-sonnet-latest"
```

Since the `load_model` function is called in both `smolagent` and `webagent`, this fix should improve this behavior for both.

Closes #787 