### PR TITLE
Support importing scipy and sklearn without AttributeError: module 'scipy.sparse._coo' has no attribute 'upcast'

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1042,7 +1042,7 @@ def get_safe_module(raw_module, authorized_imports, visited=None):
 
         try:
             attr_value = getattr(raw_module, attr_name)
-        except ImportError as e:
+        except (ImportError, AttributeError) as e:
             # lazy / dynamic loading module -> INFO log and skip
             logger.info(
                 f"Skipping import error while copying {raw_module.__name__}.{attr_name}: {type(e).__name__} - {e}"

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1003,6 +1003,14 @@ texec(tcompile("1 + 1", "no filename", "exec"))
         dangerous_code = "import os; os.listdir('./')"
         evaluate_python_code(dangerous_code, authorized_imports=["*"])
 
+    def test_can_import_scipy_if_explicitly_authorized(self):
+        code = "import scipy"
+        evaluate_python_code(code, authorized_imports=["scipy"])
+
+    def test_can_import_sklearn_if_explicitly_authorized(self):
+        code = "import sklearn"
+        evaluate_python_code(code, authorized_imports=["sklearn"])
+
 
 @pytest.mark.parametrize(
     "code, expected_result",

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1003,10 +1003,12 @@ texec(tcompile("1 + 1", "no filename", "exec"))
         dangerous_code = "import os; os.listdir('./')"
         evaluate_python_code(dangerous_code, authorized_imports=["*"])
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_can_import_scipy_if_explicitly_authorized(self):
         code = "import scipy"
         evaluate_python_code(code, authorized_imports=["scipy"])
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_can_import_sklearn_if_explicitly_authorized(self):
         code = "import sklearn"
         evaluate_python_code(code, authorized_imports=["sklearn"])


### PR DESCRIPTION
Support importing scipy and sklearn.

Currently, an AttributeError is raised: `AttributeError: module 'scipy.sparse._coo' has no attribute 'upcast'`

```python
src/smolagents/local_python_executor.py:1314: in evaluate_ast
    return import_modules(expression, state, authorized_imports)
src/smolagents/local_python_executor.py:1077: in import_modules
    state[alias.asname or alias.name] = get_safe_module(raw_module, authorized_imports)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1053: in get_safe_module
    attr_value = get_safe_module(attr_value, authorized_imports, visited=visited)
src/smolagents/local_python_executor.py:1044: in get_safe_module
    attr_value = getattr(raw_module, attr_name)
venv/lib/python3.11/site-packages/scipy/sparse/coo.py:35: in __getattr__
    return _sub_module_deprecation(sub_package="sparse", module="coo",
venv/lib/python3.11/site-packages/scipy/_lib/deprecation.py:77: in _sub_module_deprecation
    raise e
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def _sub_module_deprecation(*, sub_package, module, private_modules, all,

    ...

        for module in private_modules:
            try:
>               return getattr(import_module(f"scipy.{sub_package}.{module}"), attribute)
E               AttributeError: module 'scipy.sparse._coo' has no attribute 'upcast'

venv/lib/python3.11/site-packages/scipy/_lib/deprecation.py:72: AttributeError
```

Fix #555.

Related issue:
- https://github.com/scipy/scipy/issues/22591