### PR TITLE
allow users to retrieve original Gradio app

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -254,6 +254,9 @@ class GradioUI:
         )
 
     def launch(self, share: bool = True, **kwargs):
+        self.create_app().launch(debug=True, share=share, **kwargs)
+
+    def create_app(self):
         import gradio as gr
 
         with gr.Blocks(theme="ocean", fill_height=True) as demo:
@@ -339,7 +342,7 @@ class GradioUI:
                 [text_input, submit_btn],
             )
 
-        demo.launch(debug=True, share=share, **kwargs)
+        return demo
 
 
 __all__ = ["stream_to_gradio", "GradioUI"]


### PR DESCRIPTION
Closes https://github.com/huggingface/smolagents/issues/789

This will allow the use of gradio hot reload feature. For example:
```py
# example.py

model = ...
agent = CodeAgent(
    tools=[
        ocr_document,
        ssh_execute_command_with_agent,
        generate_temp_file,
        download_file,
    ],
    model=model,
)

demo = GradioUI(agent).create_app()

if __name__ == "__main__":
    demo.launch(debug=True, share=False)
```
When launched with:
```
 gradio example.py 
```
Will enable gradio hot reload. I.e. any changes to `example.py` will reload the file and restart a server.