### PR TITLE
Fix Gradio UI for unnamed agents

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -264,7 +264,7 @@ class GradioUI:
 
             with gr.Sidebar():
                 gr.Markdown(
-                    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
+                    f"# {self.name.replace('_', ' ').capitalize() if self.name is not None else 'Agent interface'}"
                     "\n> This web ui allows you to interact with a `smolagents` agent that can use tools and execute steps to complete tasks."
                     + (f"\n\n**Agent description:**\n{self.description}" if self.description else "")
                 )

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -184,7 +184,7 @@ class GradioUI:
             )
         self.agent = agent
         self.file_upload_folder = file_upload_folder
-        self.name = getattr(agent, "name", None)
+        self.name = getattr(agent, "name", "Agent interface")
         self.description = getattr(agent, "description", None)
         if self.file_upload_folder is not None:
             if not os.path.exists(file_upload_folder):
@@ -264,7 +264,7 @@ class GradioUI:
 
             with gr.Sidebar():
                 gr.Markdown(
-                    f"# {self.name.replace('_', ' ').capitalize() if self.name is not None else 'Agent interface'}"
+                    f"# {self.name.replace('_', ' ').capitalize()}"
                     "\n> This web ui allows you to interact with a `smolagents` agent that can use tools and execute steps to complete tasks."
                     + (f"\n\n**Agent description:**\n{self.description}" if self.description else "")
                 )


### PR DESCRIPTION
Fixes this issue:
```
Traceback (most recent call last):
  File "/Users/user/Documents/Dev/sysradium/ml-playground/agents/smol_example.py", line 163, in <module>
    demo = GradioUI(agent).create_app()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Documents/Dev/sysradium/ml-playground/.venv/lib/python3.12/site-packages/smolagents/gradio_ui.py", line 270, in create_app
    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
```
Name is optional and thus by default is `None`:
https://github.com/huggingface/smolagents/blob/af03d17813c987fbb79e303fadf4713b29ccf2f1/src/smolagents/agents.py#L214
Also if name is not event specified it is `None` as well:
https://github.com/huggingface/smolagents/blob/main/src/smolagents/gradio_ui.py#L187
Hence the bugfix. 

Maybe we can consider using this instead:
https://github.com/huggingface/smolagents/blob/main/src/smolagents/agents.py#L205