### PR TITLE
Support other models than o1 in Open Deep Research

### DIFF
--- a/examples/open_deep_research/run.py
+++ b/examples/open_deep_research/run.py
@@ -84,15 +84,16 @@ os.makedirs(f"./{BROWSER_CONFIG['downloads_folder']}", exist_ok=True)
 
 
 def create_agent(model_id="o1"):
+    model_params = {
+        "model_id": model_id,
+        "custom_role_conversions": custom_role_conversions,
+        "max_completion_tokens": 8192,
+    }
+    if model_id == "o1":
+        model_params["reasoning_effort"] = "high"
+    model = LiteLLMModel(**model_params)
+
     text_limit = 100000
-
-    model = LiteLLMModel(
-        model_id,
-        custom_role_conversions=custom_role_conversions,
-        max_completion_tokens=8192,
-        reasoning_effort="high",
-    )
-
     browser = SimpleTextBrowser(**BROWSER_CONFIG)
     WEB_TOOLS = [
         GoogleSearchTool(provider="serper"),

--- a/examples/open_deep_research/run_gaia.py
+++ b/examples/open_deep_research/run_gaia.py
@@ -178,12 +178,14 @@ def append_answer(entry: dict, jsonl_file: str) -> None:
 
 
 def answer_single_question(example, model_id, answers_file, visual_inspection_tool):
-    model = LiteLLMModel(
-        model_id,
-        custom_role_conversions=custom_role_conversions,
-        max_completion_tokens=8192,
-        reasoning_effort="high",
-    )
+    model_params = {
+        "model_id": model_id,
+        "custom_role_conversions": custom_role_conversions,
+        "max_completion_tokens": 8192,
+    }
+    if model_id == "o1":
+        model_params["reasoning_effort"] = "high"
+    model = LiteLLMModel(**model_params)
     # model = HfApiModel("Qwen/Qwen2.5-72B-Instruct", provider="together")
     #     "https://lnxyuvj02bpe6mam.us-east-1.aws.endpoints.huggingface.cloud",
     #     custom_role_conversions=custom_role_conversions,


### PR DESCRIPTION
Support other models than o1 in Open Deep Research:
- Use `reasoning_effort` only with o1 model

Related to:
- #760
- #676