### PR TITLE
Fix and refactor tests of Docker executors

### DIFF
--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -56,7 +56,6 @@ class TestDockerExecutor:
         result, logs, final_answer = self.executor(code_action)
         assert result == "This is the final answer", "Result should be 'This is the final answer'"
 
-    @pytest.mark.xfail(reason="NameError: name 'image' is not defined")
     def test_execute_image_output(self):
         """Test execution that returns a base64 image"""
         code_action = dedent("""

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -1,10 +1,11 @@
-import logging
-from unittest import TestCase
+from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
 import docker
+import pytest
 from PIL import Image
 
+from smolagents.monitoring import AgentLogger, LogLevel
 from smolagents.remote_executors import DockerExecutor, E2BExecutor
 
 from .utils.markers import require_run_all
@@ -23,19 +24,23 @@ class TestE2BExecutor:
         assert executor.sandbox == mock_sandbox.return_value
 
 
-class TestDockerExecutor(TestCase):
-    def setUp(self):
-        self.logger = logging.getLogger("DockerExecutorTest")
-        self.executor = DockerExecutor(
-            additional_imports=["pillow", "numpy"], tools=[], logger=self.logger, initial_state={}
-        )
+@pytest.fixture
+def docker_executor():
+    executor = DockerExecutor(additional_imports=["pillow", "numpy"], logger=AgentLogger(level=LogLevel.OFF))
+    yield executor
+    executor.delete()
 
-    @require_run_all
+
+@require_run_all
+class TestDockerExecutor:
+    @pytest.fixture(autouse=True)
+    def set_executor(self, docker_executor):
+        self.executor = docker_executor
+
     def test_initialization(self):
         """Check if DockerExecutor initializes without errors"""
-        self.assertIsNotNone(self.executor.container, "Container should be initialized")
+        assert self.executor.container is not None, "Container should be initialized"
 
-    @require_run_all
     def test_state_persistence(self):
         """Test that variables and imports form one snippet persist in the next"""
         code_action = "import numpy as np; a = 2"
@@ -45,31 +50,32 @@ class TestDockerExecutor(TestCase):
         result, logs, final_answer = self.executor(code_action)
         assert "1.41421" in logs
 
-    @require_run_all
+    def test_execute_output(self):
+        """Test execution that returns a string"""
+        code_action = 'final_answer("This is the final answer")'
+        result, logs, final_answer = self.executor(code_action)
+        assert result == "This is the final answer", "Result should be 'This is the final answer'"
+
+    @pytest.mark.xfail(reason="NameError: name 'image' is not defined")
     def test_execute_image_output(self):
         """Test execution that returns a base64 image"""
-        code_action = """
-import base64
-from PIL import Image
-from io import BytesIO
-
-image = Image.new("RGB", (10, 10), (255, 0, 0))
-final_answer(image)
-"""
+        code_action = dedent("""
+            import base64
+            from PIL import Image
+            from io import BytesIO
+            image = Image.new("RGB", (10, 10), (255, 0, 0))
+            final_answer(image)
+        """)
         result, logs, final_answer = self.executor(code_action)
+        assert isinstance(result, Image.Image), "Result should be a PIL Image"
 
-        self.assertIsInstance(result, Image.Image, "Result should be a PIL Image")
-
-    @require_run_all
     def test_syntax_error_handling(self):
         """Test handling of syntax errors"""
         code_action = 'print("Missing Parenthesis'  # Syntax error
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(RuntimeError) as exception_info:
             self.executor(code_action)
+        assert "SyntaxError" in str(exception_info.value), "Should raise a syntax error"
 
-        self.assertIn("SyntaxError", str(context.exception), "Should raise a syntax error")
-
-    @require_run_all
     def test_cleanup_on_deletion(self):
         """Test if Docker container stops and removes on deletion"""
         container_id = self.executor.container.id
@@ -77,4 +83,4 @@ final_answer(image)
 
         client = docker.from_env()
         containers = [c.id for c in client.containers.list(all=True)]
-        self.assertNotIn(container_id, containers, "Container should be removed")
+        assert container_id not in containers, "Container should be removed"

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -56,6 +56,12 @@ class TestDockerExecutor:
         result, logs, final_answer = self.executor(code_action)
         assert result == "This is the final answer", "Result should be 'This is the final answer'"
 
+    def test_execute_multiline_output(self):
+        """Test execution that returns a string"""
+        code_action = 'result = "This is the final answer"\nfinal_answer(result)'
+        result, logs, final_answer = self.executor(code_action)
+        assert result == "This is the final answer", "Result should be 'This is the final answer'"
+
     def test_execute_image_output(self):
         """Test execution that returns a base64 image"""
         code_action = dedent("""


### PR DESCRIPTION
Fix and refactor tests of Docker executors.

There were multiple errors raised by the tests of Docker executors:
- `TypeError: DockerExecutor.__init__() got an unexpected keyword argument 'tools'`
- `TypeError: DockerExecutor.__init__() got an unexpected keyword argument 'initial_state'`
- `TypeError: Logger.log() missing 1 required positional argument: 'msg'`
- `RuntimeError: Failed to initialize Jupyter kernel: 500 Server Error for http+docker://localhost/v1.48/containers/3c46306598f69647c6c3d40e3ef17b044ae7b47ea3876f3cde41aed07eaaf3a1/start: Internal Server Error ("driver failed programming external connectivity on endpoint interesting_herschel (e46e013e2f4f571693b7833124b806da357617cfc32c40904aa54cd2cc0d907a): Bind for 127.0.0.1:8888 failed: port is already allocated")`
  - because Docker executors were not properly deleted between test function calls

EDIT:

Note that
- `test_execute_output`,
- `test_execute_multiline_output`, and
- `test_execute_image_output` 

will only pass after the fix in:
- #826

Before #826 fix, the following errors were raised:
- `NameError: name 'final_answer' is not defined`
- `NameError: name 'image' is not defined`
