### PR TITLE
Remove unnecessary self argument in GoogleSearchTool super() call

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -138,7 +138,7 @@ class GoogleSearchTool(Tool):
     output_type = "string"
 
     def __init__(self, provider: str = "serpapi"):
-        super().__init__(self)
+        super().__init__()
         import os
 
         self.provider = provider


### PR DESCRIPTION
### the GoogleSearchTool class had an error line 141: 
super().__init__(**self**) instead of **super().__init__()**. I removed the **self**, which was causing the following issue when using it: 
```python
TypeError: GoogleSearchTool.__init__() got an unexpected keyword argument 'provider'
```

in the following code: 
```python
model = HfApiModel(
    "Qwen/Qwen2.5-Coder-32B-Instruct", provider="together", max_tokens=8096
)

web_agent = CodeAgent(
    model=model,
    tools=[
        GoogleSearchTool(provider="serpapi"),
        VisitWebpageTool(),
        calculate_cargo_travel_time,
    ],
    name="web_agent",
    description="Browses the web to find information",
    verbosity_level=0,
    max_steps=10,
)
```

from the [multiagent_notebook](https://colab.research.google.com/github/huggingface/agents-course/blob/main/notebooks/unit2/smolagents/multiagent_notebook.ipynb) of the agents course, unit 2.1, [Multi-Agent Systems chapter](https://huggingface.co/learn/agents-course/unit2/smolagents/multi_agent_systems)