### PR TITLE
Fix call from dict with LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -610,7 +610,7 @@ def evaluate_call(
             )
 
     elif isinstance(call.func, ast.Subscript):
-        func = evaluate_ast(call.func, state, static_tools, custom_tools, authorized_imports)
+        func = evaluate_subscript(call.func, state, static_tools, custom_tools, authorized_imports)
         if not callable(func):
             raise InterpreterError(f"This is not a correct function: {call.func}).")
         func_name = None

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -610,13 +610,7 @@ def evaluate_call(
             )
 
     elif isinstance(call.func, ast.Subscript):
-        value = evaluate_ast(call.func.value, state, static_tools, custom_tools, authorized_imports)
-        index = evaluate_ast(call.func.slice, state, static_tools, custom_tools, authorized_imports)
-        if isinstance(value, (list, tuple)):
-            func = value[index]
-        else:
-            raise InterpreterError(f"Cannot subscript object of type {type(value).__name__}")
-
+        func = evaluate_ast(call.func, state, static_tools, custom_tools, authorized_imports)
         if not callable(func):
             raise InterpreterError(f"This is not a correct function: {call.func}).")
         func_name = None

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -25,6 +25,7 @@ import pytest
 from smolagents.default_tools import BASE_PYTHON_TOOLS
 from smolagents.local_python_executor import (
     InterpreterError,
+    LocalPythonExecutor,
     PrintContainer,
     check_module_authorized,
     evaluate_condition,
@@ -1409,3 +1410,17 @@ class TestPrintContainer:
 )
 def test_check_module_authorized(module: str, authorized_imports: list[str], expected: bool):
     assert check_module_authorized(module, authorized_imports) == expected
+
+
+class TestLocalPythonExecutor:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "d = {'func': lambda x: x + 10,}; func = d['func']; func(1)",
+            "d = {'func': lambda x: x + 10,}; d['func'](1)",
+        ],
+    )
+    def test_call_from_dict(self, code):
+        executor = LocalPythonExecutor([])
+        result, _, _ = executor(code)
+        assert result == 11

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1416,8 +1416,8 @@ class TestLocalPythonExecutor:
     @pytest.mark.parametrize(
         "code",
         [
-            "d = {'func': lambda x: x + 10,}; func = d['func']; func(1)",
-            "d = {'func': lambda x: x + 10,}; d['func'](1)",
+            "d = {'func': lambda x: x + 10}; func = d['func']; func(1)",
+            "d = {'func': lambda x: x + 10}; d['func'](1)",
         ],
     )
     def test_call_from_dict(self, code):


### PR DESCRIPTION
Fix call from dict with `LocalPythonExecutor`.

Currently, the code
```python
d = {'func': lambda x: x + 10}
d['func'](1)
```
raises `InterpreterError: Cannot subscript object of type dict`.