### PR TITLE
Update guided_tour.mdx: "the task= argument"

### DIFF
--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -373,7 +373,7 @@ web_agent = CodeAgent(
     tools=[DuckDuckGoSearchTool()],
     model=model,
     name="web_search",
-    description="Runs web searches for you. Give it your query as an argument."
+    description="Runs web searches for you. Give it your query as the task= argument."
 )
 
 manager_agent = CodeAgent(

--- a/docs/source/hi/guided_tour.mdx
+++ b/docs/source/hi/guided_tour.mdx
@@ -310,7 +310,7 @@ web_agent = CodeAgent(tools=[DuckDuckGoSearchTool()], model=model)
 managed_web_agent = ManagedAgent(
     agent=web_agent,
     name="web_search",
-    description="Runs web searches for you. Give it your query as an argument."
+    description="Runs web searches for you. Give it your query as the task= argument."
 )
 
 manager_agent = CodeAgent(

--- a/docs/source/zh/guided_tour.mdx
+++ b/docs/source/zh/guided_tour.mdx
@@ -320,7 +320,7 @@ web_agent = CodeAgent(tools=[DuckDuckGoSearchTool()], model=model)
 managed_web_agent = ManagedAgent(
     agent=web_agent,
     name="web_search",
-    description="Runs web searches for you. Give it your query as an argument."
+    description="Runs web searches for you. Give it your query as the task= argument."
 )
 
 manager_agent = CodeAgent(


### PR DESCRIPTION
The agents always try `results = web_search(query="…")` and fail, instead of the intended `results = web_search("…")` or
`results = web_search(task="…")`.

While this should ultimately be fixed in the internal prompts that instruct the agent how to use team members, changing here will at least make the tutorial go smoother.