### PR TITLE
Make local Python interpreter safer by checking if returns builtins

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -22,6 +22,7 @@ import logging
 import math
 import re
 from collections.abc import Mapping
+from functools import wraps
 from importlib import import_module
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -210,6 +211,29 @@ def fix_final_answer_code(code: str) -> str:
     variable_regex = r"(?<!\.)(?<!\w)(\bfinal_answer\b)(?!\s*\()"
     code = re.sub(variable_regex, "final_answer_variable", code)
     return code
+
+
+def safer_eval(func: Callable):
+    """
+    Decorator to make the evaluation of a function safer by checking its return value.
+
+    Args:
+        func: Function to make safer.
+
+    Returns:
+        Callable: Safer function with return value check.
+    """
+
+    @wraps(func)
+    def _check_return(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if (isinstance(result, ModuleType) and result is builtins) or (
+            isinstance(result, dict) and result == vars(builtins)
+        ):
+            raise InterpreterError("Forbidden return value: builtins")
+        return result
+
+    return _check_return
 
 
 def evaluate_unaryop(
@@ -1177,6 +1201,7 @@ def evaluate_delete(
             raise InterpreterError(f"Deletion of {type(target).__name__} targets is not supported")
 
 
+@safer_eval
 def evaluate_ast(
     expression: ast.AST,
     state: Dict[str, Any],

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -980,20 +980,12 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
             evaluate_python_code(dangerous_code, static_tools=BASE_PYTHON_TOOLS)
 
     def test_dangerous_builtins_are_callable_if_explicitly_added(self):
-        dangerous_code = """
-compile = callable.__self__.compile
-eval = callable.__self__.eval
-exec = callable.__self__.exec
-
-eval("1 + 1")
-exec(compile("1 + 1", "no filename", "exec"))
-
-teval("1 + 1")
-texec(tcompile("1 + 1", "no filename", "exec"))
-        """
-
+        dangerous_code = dedent("""
+            eval("1 + 1")
+            exec(compile("1 + 1", "no filename", "exec"))
+        """)
         evaluate_python_code(
-            dangerous_code, static_tools={"tcompile": compile, "teval": eval, "texec": exec} | BASE_PYTHON_TOOLS
+            dangerous_code, static_tools={"compile": compile, "eval": eval, "exec": exec} | BASE_PYTHON_TOOLS
         )
 
     def test_can_import_os_if_explicitly_authorized(self):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -16,6 +16,7 @@
 import ast
 import types
 import unittest
+from contextlib import nullcontext as does_not_raise
 from textwrap import dedent
 
 import numpy as np
@@ -1419,9 +1420,13 @@ class TestLocalPythonExecutor:
 
 
 class TestLocalPythonExecutorSecurity:
-    def test_vulnerability(self):
-        executor = LocalPythonExecutor([])
-        with pytest.raises(InterpreterError):
+    @pytest.mark.parametrize(
+        "additional_authorized_imports, expectation",
+        [([], pytest.raises(InterpreterError)), (["os"], does_not_raise())],
+    )
+    def test_vulnerability_import(self, additional_authorized_imports, expectation):
+        executor = LocalPythonExecutor(additional_authorized_imports)
+        with expectation:
             executor("import os")
 
     def test_vulnerability_builtins(self):


### PR DESCRIPTION
Make local Python interpreter safer by checking if returns builtins.