### PR TITLE
Make local Python interpreter safer by adding builtins to dangerous modules

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -249,11 +249,21 @@ def safer_eval(func: Callable):
         if "*" not in authorized_imports:
             if isinstance(result, ModuleType):
                 for module in DANGEROUS_MODULES:
-                    if module not in authorized_imports and result is import_module(module):
+                    if (
+                        module not in authorized_imports
+                        and result.__name__ == module
+                        # builtins has no __file__ attribute
+                        and getattr(result, "__file__", "") == getattr(import_module(module), "__file__", "")
+                    ):
                         raise InterpreterError(f"Forbidden return value: {module}")
-            elif isinstance(result, dict):
+            elif isinstance(result, dict) and result.get("__name__"):
                 for module in DANGEROUS_MODULES:
-                    if module not in authorized_imports and result == vars(import_module(module)):
+                    if (
+                        module not in authorized_imports
+                        and result["__name__"] == module
+                        # builtins has no __file__ attribute
+                        and result.get("__file__", "") == getattr(import_module(module), "__file__", "")
+                    ):
                         raise InterpreterError(f"Forbidden return value: {module}")
         return result
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -138,15 +138,15 @@ DANGEROUS_PATTERNS = (
 
 DANGEROUS_MODULES = [
     "builtins",
+    "io",
+    "multiprocessing",
     "os",
-    "subprocess",
+    "pathlib",
     "pty",
     "shutil",
-    "sys",
-    "pathlib",
-    "io",
     "socket",
-    "multiprocessing",
+    "subprocess",
+    "sys",
 ]
 
 


### PR DESCRIPTION
Make local Python interpreter safer by adding builtins to dangerous modules:
- treat builtins as the rest of dangerous modules
- do not raise error if explicitly allowed
- add tests