### PR TITLE
Document returned value of `MultiStepAgent.run()`

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -282,11 +282,17 @@ class MultiStepAgent:
             additional_args (`dict`, *optional*): Any other variables that you want to pass to the agent run, for instance images or dataframes. Give them clear names!
             max_steps (`int`, *optional*): Maximum number of steps the agent can take to solve the task. if not provided, will use the agent's default value.
 
+        Returns:
+            If `stream` is False:
+                - The final answer to the task
+            If `stream` is True:
+                - The output of each step, as it is taken, as a Generator
+
         Example:
         ```py
         from smolagents import CodeAgent
         agent = CodeAgent(tools=[])
-        agent.run("What is the result of 2 power 3.7384?")
+        final_answer = agent.run("What is the result of 2 power 3.7384?")
         ```
         """
         max_steps = max_steps or self.max_steps


### PR DESCRIPTION
This wasn't documented anywhere. Maybe an example for the streaming version would be helpful.