### PR TITLE
Fix CLI webagent

### DIFF
--- a/src/smolagents/vision_web_browser.py
+++ b/src/smolagents/vision_web_browser.py
@@ -202,7 +202,7 @@ def main():
     agent = initialize_agent(model)
 
     # Run the agent with the provided prompt
-    agent.python_executor("from helium import *", agent.state)
+    agent.python_executor("from helium import *")
     agent.run(args.prompt + helium_instructions)
 
 


### PR DESCRIPTION
Fix CLI webagent:
> TypeError: LocalPythonExecutor.__call__() takes 2 positional arguments but 3 were given

It was broken after the merge of:
- #733