### PR TITLE
Test all dangerous functions and fix check of os.system

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -117,18 +117,6 @@ BASE_PYTHON_TOOLS = {
     "complex": complex,
 }
 
-DANGEROUS_FUNCTIONS = [
-    "builtins.compile",
-    "builtins.eval",
-    "builtins.exec",
-    "builtins.globals",
-    "builtins.locals",
-    "builtins.__import__",
-    "os.popen",
-    "os.system",
-    "posix.system",
-]
-
 DANGEROUS_MODULES = [
     "builtins",
     "io",
@@ -140,6 +128,18 @@ DANGEROUS_MODULES = [
     "socket",
     "subprocess",
     "sys",
+]
+
+DANGEROUS_FUNCTIONS = [
+    "builtins.compile",
+    "builtins.eval",
+    "builtins.exec",
+    "builtins.globals",
+    "builtins.locals",
+    "builtins.__import__",
+    "os.popen",
+    "os.system",
+    "posix.system",
 ]
 
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1534,6 +1534,8 @@ class TestLocalPythonExecutorSecurity:
     @pytest.mark.parametrize("dangerous_function", DANGEROUS_FUNCTIONS)
     def test_vulnerability_for_all_dangerous_functions(self, dangerous_function):
         dangerous_module_name, dangerous_function_name = dangerous_function.rsplit(".", 1)
+        # Skip test if module is not installed: posix module is not installed on Windows
+        pytest.importorskip(dangerous_module_name)
         executor = LocalPythonExecutor([dangerous_module_name])
         with pytest.raises(InterpreterError, match=f".*Forbidden access to function: {dangerous_function_name}"):
             executor(f"import {dangerous_module_name}; {dangerous_function}")


### PR DESCRIPTION
Test all dangerous functions and fix check of dangerous function `os.system`:
- test all dangerous functions, so we avoid issues like:
  - #909
- fix check of dangerous function `os.system`:
  - this issue was found thanks to the test above
  - the module name of this function is `posix` instead of `os`
```python
In [1]: import os

In [2]: os.system.__module__
Out[2]: 'posix'
```