### PR TITLE
Improve evaluate_subscript

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import math
 import re
+from collections.abc import Mapping
 from functools import wraps
 from importlib import import_module
 from types import BuiltinFunctionType, FunctionType, ModuleType
@@ -722,7 +723,12 @@ def evaluate_subscript(
     try:
         return value[index]
     except (KeyError, IndexError, TypeError) as e:
-        raise InterpreterError(f"Could not index {value} with '{index}': {type(e).__name__}: {e}") from e
+        error_message = f"Could not index {value} with '{index}': {type(e).__name__}: {e}"
+        if isinstance(index, str) and isinstance(value, Mapping):
+            close_matches = difflib.get_close_matches(index, list(value.keys()))
+            if len(close_matches) > 0:
+                error_message += f". Maybe you meant one of these indexes instead: {str(close_matches)}"
+        raise InterpreterError(error_message) from e
 
 
 def evaluate_name(

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -21,14 +21,10 @@ import inspect
 import logging
 import math
 import re
-from collections.abc import Mapping
 from functools import wraps
 from importlib import import_module
 from types import BuiltinFunctionType, FunctionType, ModuleType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-
-import numpy as np
-import pandas as pd
 
 from .tools import Tool
 from .utils import BASE_BUILTIN_MODULES, truncate_content
@@ -723,38 +719,10 @@ def evaluate_subscript(
 ) -> Any:
     index = evaluate_ast(subscript.slice, state, static_tools, custom_tools, authorized_imports)
     value = evaluate_ast(subscript.value, state, static_tools, custom_tools, authorized_imports)
-
-    if isinstance(value, str) and isinstance(index, str):
-        raise InterpreterError("You're trying to subscript a string with a string index, which is impossible")
-    if isinstance(value, pd.core.indexing._LocIndexer):
-        parent_object = value.obj
-        return parent_object.loc[index]
-    if isinstance(value, pd.core.indexing._iLocIndexer):
-        parent_object = value.obj
-        return parent_object.iloc[index]
-    if isinstance(value, (pd.DataFrame, pd.Series, np.ndarray)):
+    try:
         return value[index]
-    elif isinstance(value, pd.core.groupby.generic.DataFrameGroupBy):
-        return value[index]
-    elif isinstance(index, slice):
-        return value[index]
-    elif isinstance(value, (list, tuple)):
-        if not (-len(value) <= index < len(value)):
-            raise InterpreterError(f"Index {index} out of bounds for list of length {len(value)}")
-        return value[int(index)]
-    elif isinstance(value, str):
-        if not (-len(value) <= index < len(value)):
-            raise InterpreterError(f"Index {index} out of bounds for string of length {len(value)}")
-        return value[index]
-    elif index in value:
-        return value[index]
-    else:
-        error_message = f"Could not index {value} with '{index}'."
-        if isinstance(index, str) and isinstance(value, Mapping):
-            close_matches = difflib.get_close_matches(index, list(value.keys()))
-            if len(close_matches) > 0:
-                error_message += f" Maybe you meant one of these indexes instead: {str(close_matches)}"
-        raise InterpreterError(error_message)
+    except (KeyError, IndexError, TypeError) as e:
+        raise InterpreterError(f"Could not index {value} with '{index}': {type(e).__name__}: {e}") from e
 
 
 def evaluate_name(

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1131,7 +1131,7 @@ def test_evaluate_augassign_custom(operator, expected_result):
                 del x[2]
                 x[2]
             """),
-            "Index 2 out of bounds for list of length 2",
+            "IndexError: list index out of range",
         ),
         (
             dedent("""\

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1369,6 +1369,18 @@ def test_evaluate_subscript(subscript, state, expected_result):
         assert (result == expected_result).all()
 
 
+def test_evaluate_subscript_with_custom_class():
+    class Custom:
+        def __getitem__(self, key):
+            return key * 10
+
+    state = {"obj": Custom()}
+    subscript = "obj[2]"
+    subscript_ast = ast.parse(subscript).body[0].value
+    result = evaluate_subscript(subscript_ast, state, {}, {}, [])
+    assert result == 20
+
+
 def test_get_safe_module_handle_lazy_imports():
     class FakeModule(types.ModuleType):
         def __init__(self, name):


### PR DESCRIPTION
Improve `evaluate_subscript`:
- Support pandas operators `.at` and `.iat`
- Support custom class with `__getitem__` but without `__contains__`
- Simplify the code
- Test all cases

Currently:
- custom class with `__getitem__` but without `__contains__` might get into an infinite loop: check test in d7332218023239a9f80679f762c9
- pandas operators `.at` and `.iat` are not supported:
```
FAILED tests/test_local_python_executor.py::test_evaluate_subscript[ser.at[1]-state36-3] - KeyError: 0
FAILED tests/test_local_python_executor.py::test_evaluate_subscript[df.at[1, 'y']-state49-4] - TypeError: DataFrame._get_value() missing 1 required positional argument: 'col'
FAILED tests/test_local_python_executor.py::test_evaluate_subscript[df.at[5, 'y']-state50-3] - TypeError: DataFrame._get_value() missing 1 required positional argument: 'col'
FAILED tests/test_local_python_executor.py::test_evaluate_subscript[df.iat[1, 1]-state51-4] - TypeError: DataFrame._get_value() missing 1 required positional argument: 'col'
FAILED tests/test_local_python_executor.py::test_evaluate_subscript[df.iat[1, 1]-state52-4] - TypeError: DataFrame._get_value() missing 1 required positional argument: 'col'
```

Supersede and close #910.