### PR TITLE
Bugfix: adding <end_code> to prevent imaginary tool calls in CodeAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1224,6 +1224,8 @@ class CodeAgent(MultiStepAgent):
             )
             memory_step.model_output_message = chat_message
             model_output = chat_message.content
+            if model_output.endswith("```"):
+                model_output += "<end_code>"
             memory_step.model_output = model_output
         except Exception as e:
             raise AgentGenerationError(f"Error in generating model output:\n{e}", self.logger) from e

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -286,7 +286,6 @@ class MultiStepAgent:
         agent.run("What is the result of 2 power 3.7384?")
         ```
         """
-
         max_steps = max_steps or self.max_steps
         self.task = task
         if additional_args is not None:

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -286,6 +286,7 @@ class MultiStepAgent:
         agent.run("What is the result of 2 power 3.7384?")
         ```
         """
+
         max_steps = max_steps or self.max_steps
         self.task = task
         if additional_args is not None:
@@ -1234,8 +1235,13 @@ class CodeAgent(MultiStepAgent):
             )
             memory_step.model_output_message = chat_message
             model_output = chat_message.content
-            if model_output.endswith("```"):
+
+            # This adds <end_code> sequence to the history.
+            # So a model will have examples of completing code sections in a right way.
+            if model_output and model_output.strip().endswith("```"):
                 model_output += "<end_code>"
+                memory_step.model_output_message.content = model_output
+
             memory_step.model_output = model_output
         except Exception as e:
             raise AgentGenerationError(f"Error in generating model output:\n{e}", self.logger) from e

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1236,7 +1236,7 @@ class CodeAgent(MultiStepAgent):
             model_output = chat_message.content
 
             # This adds <end_code> sequence to the history.
-            # So a model will have examples of completing code sections in a right way.
+            # This will nudge ulterior LLM calls to finish with <end_code>, thus efficiently stopping generation.
             if model_output and model_output.strip().endswith("```"):
                 model_output += "<end_code>"
                 memory_step.model_output_message.content = model_output

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -411,31 +411,6 @@ class AgentTests(unittest.TestCase):
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
-    def test_end_code_appending(self):
-        # Checking original output message
-        orig_output = fake_code_model_no_return([])
-        assert not orig_output.content.endswith("<end_code>")
-
-        # Checking the step output
-        agent = CodeAgent(
-            tools=[PythonInterpreterTool()],
-            model=fake_code_model_no_return,
-            max_steps=1,
-        )
-        answer = agent.run("What is 2 multiplied by 3.6452?")
-        assert answer
-
-        memory_steps = agent.memory.steps
-        actions_steps = [s for s in memory_steps if isinstance(s, ActionStep)]
-
-        outputs = [s.model_output for s in actions_steps if s.model_output]
-        assert outputs
-        assert all(o.endswith("<end_code>") for o in outputs)
-
-        messages = [s.model_output_message for s in actions_steps if s.model_output_message]
-        assert messages
-        assert all(m.content.endswith("<end_code>") for m in messages)
-
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"
@@ -941,6 +916,31 @@ class TestCodeAgent:
         assert isinstance(output, AgentText)
         assert output == "got an error"
         assert '    print("Failing due to unexpected indent")' in str(agent.memory.steps)
+
+    def test_end_code_appending(self):
+        # Checking original output message
+        orig_output = fake_code_model_no_return([])
+        assert not orig_output.content.endswith("<end_code>")
+
+        # Checking the step output
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=fake_code_model_no_return,
+            max_steps=1,
+        )
+        answer = agent.run("What is 2 multiplied by 3.6452?")
+        assert answer
+
+        memory_steps = agent.memory.steps
+        actions_steps = [s for s in memory_steps if isinstance(s, ActionStep)]
+
+        outputs = [s.model_output for s in actions_steps if s.model_output]
+        assert outputs
+        assert all(o.endswith("<end_code>") for o in outputs)
+
+        messages = [s.model_output_message for s in actions_steps if s.model_output_message]
+        assert messages
+        assert all(m.content.endswith("<end_code>") for m in messages)
 
     def test_change_tools_after_init(self):
         from smolagents import tool


### PR DESCRIPTION
## The problem
Recently, I noticed that some models (such as claude-sonnet-3.7) generate imaginary tool calls in the CodeAct agent. Please take a look at the screenshot below; there is a "Calling tools" section right after the code. It is also how the tool calls are stored in history. Since there is no <end_code> token in the history, models are instructed in a few-shot way not to generate <end_code> token but to generate these imaginary tool calls instead.

These calls do not actually break anything, but they are a colossal waste of tokens.

Fixes this issue: #375 

<img width="696" alt="изображение" src="https://github.com/user-attachments/assets/96e3e4f3-240e-4b68-923e-fa8e0d52cbb3" />

## The solution
The simplest solution is to add <end_code> in history, and this PR does exactly that. This trains a model to generate it instead of imaginary tool calls.