### PR TITLE
Do not depend on logger directly in AgentError

### DIFF
--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -22,6 +22,7 @@ from smolagents import (
     ToolCallingAgent,
     stream_to_gradio,
 )
+from smolagents.utils import raise_agent_error
 from smolagents.models import (
     ChatMessage,
     ChatMessageToolCall,
@@ -166,7 +167,8 @@ class MonitoringTester(unittest.TestCase):
         logger = AgentLogger(level=LogLevel.INFO)
 
         def dummy_model(prompt, **kwargs):
-            raise AgentError("Simulated agent error", logger)
+            error = AgentError("Simulated agent error")
+            raise_agent_error(error, logger)
 
         agent = CodeAgent(
             tools=[],


### PR DESCRIPTION
ActionStep contains field `error: AgentError`. AgentError requires logger. This makes representation of ActionStep as a data (e.g for serde) more problematic than it needs to be (IMO).

Instead of depending on the logger in ctor (and calling it), we can log in a separate method and keep the exception simpler.