### PR TITLE
Test vulnerability for dangerous modules

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -116,15 +116,24 @@ BASE_PYTHON_TOOLS = {
 
 DANGEROUS_MODULES = [
     "builtins",
+    "code",
+    "codecs",
+    "distutils",
+    "glob",
     "io",
     "multiprocessing",
     "os",
     "pathlib",
+    "pickle",
+    "posix",
     "pty",
+    "shelve",
     "shutil",
     "socket",
+    "sqlite3",
     "subprocess",
     "sys",
+    "venv",
 ]
 
 DANGEROUS_FUNCTIONS = [

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -116,24 +116,15 @@ BASE_PYTHON_TOOLS = {
 
 DANGEROUS_MODULES = [
     "builtins",
-    "code",
-    "codecs",
-    "distutils",
-    "glob",
     "io",
     "multiprocessing",
     "os",
     "pathlib",
-    "pickle",
-    "posix",
     "pty",
-    "shelve",
     "shutil",
     "socket",
-    "sqlite3",
     "subprocess",
     "sys",
-    "venv",
 ]
 
 DANGEROUS_FUNCTIONS = [


### PR DESCRIPTION
Test vulnerability for dangerous modules: improve test coverage

EDIT: See https://github.com/huggingface/smolagents/pull/929#pullrequestreview-2672044981
~~Add more dangerous modules to security check:~~
- ~~code~~
- ~~codecs~~
- ~~distutils~~
- ~~glob~~
- ~~pickle~~
- ~~posix: see #911~~
- ~~shelve~~
- ~~sqlite3~~
- ~~venv~~