### PR TITLE
Fix gradio_ui name handling

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -263,8 +263,13 @@ class GradioUI:
             file_uploads_log = gr.State([])
 
             with gr.Sidebar():
+                agent_name=""
+                try:
+                    agent_name=self.name.replace('_', ' ').capitalize()
+                except:
+                    agent_name = 'Agent interface'
                 gr.Markdown(
-                    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
+                    f"# {agent_name}"
                     "\n> This web ui allows you to interact with a `smolagents` agent that can use tools and execute steps to complete tasks."
                     + (f"\n\n**Agent description:**\n{self.description}" if self.description else "")
                 )


### PR DESCRIPTION
Graceful handling of Name display in Gradio UI. When agent name was not present, the code was crashing.