### PR TITLE
Forbid all modules by default except whitelist authorized_imports

### DIFF
--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -181,6 +181,9 @@ agent = CodeAgent(tools=[], model=model, additional_authorized_imports=['request
 agent.run("Could you get me the title of the page at url 'https://huggingface.co/blog'?")
 ```
 
+Additionally, as an extra security layer, access to submodule is forbidden by default, unless explicitly authorized within the import list.
+For instance, to access the `numpy.random` submodule, you need to add `'numpy.random'` to the `additional_authorized_imports` list.
+
 > [!WARNING]
 > The LLM can generate arbitrary code that will then be executed: do not add any unsafe imports!
 

--- a/docs/source/en/tutorials/secure_code_execution.mdx
+++ b/docs/source/en/tutorials/secure_code_execution.mdx
@@ -52,7 +52,8 @@ We have re-built a more secure `LocalPythonExecutor` from the ground up.
 
 To be precise, this interpreter works by loading the Abstract Syntax Tree (AST) from your Code and executes it operation by operation, making sure to always follow certain rules:
 - By default, imports are disallowed unless they have been explicitly added to an authorization list by the user.
-   - Even so, because some innocuous packages like `re` can give access to potentially harmful packages as in `re.subprocess`, subpackages that match a list of dangerous patterns are not imported.
+- Furthermore, access to submodules is disabled by default, and each must be explicitly authorized in the import list as well.
+   - Note that some seemingly innocuous packages like `random` can give access to potentially harmful submodules, as in `random._os`.
  - The total count of elementary operations processed is capped to prevent infinite loops and resource bloating.
  - Any operation that has not been explicitly defined in our custom interpreter will raise an error.
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -473,12 +473,10 @@ if char.isalpha():
 
         # Test submodules are handled properly, thus not raising error
         code = "import numpy.random as rd\nrng = rd.default_rng(12345)\nrng.random()"
-        result, _ = evaluate_python_code(
-            code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy", "numpy.random"]
-        )
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy.random"])
 
         code = "from numpy.random import default_rng as d_rng\nrng = d_rng(12345)\nrng.random()"
-        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy"])
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy.random"])
 
     def test_additional_imports(self):
         code = "import numpy as np"

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1820,8 +1820,12 @@ class TestLocalPythonExecutorSecurity:
     @pytest.mark.parametrize(
         "additional_authorized_imports, additional_tools, expected_error",
         [
-            ([], [], InterpreterError("Forbidden access to module: builtins")),
-            (["builtins", "os"], ["__import__"], None),
+            ([], [], InterpreterError("Forbidden access to module: smolagents.local_python_executor")),
+            (
+                ["builtins", "os"],
+                ["__import__"],
+                InterpreterError("Forbidden access to module: smolagents.local_python_executor"),
+            ),
         ],
     )
     def test_vulnerability_builtins_via_traceback(

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -473,7 +473,9 @@ if char.isalpha():
 
         # Test submodules are handled properly, thus not raising error
         code = "import numpy.random as rd\nrng = rd.default_rng(12345)\nrng.random()"
-        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy"])
+        result, _ = evaluate_python_code(
+            code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy", "numpy.random"]
+        )
 
         code = "from numpy.random import default_rng as d_rng\nrng = d_rng(12345)\nrng.random()"
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["numpy"])

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -27,7 +27,6 @@ import pytest
 from smolagents.default_tools import BASE_PYTHON_TOOLS
 from smolagents.local_python_executor import (
     DANGEROUS_FUNCTIONS,
-    DANGEROUS_MODULES,
     InterpreterError,
     LocalPythonExecutor,
     PrintContainer,
@@ -39,6 +38,21 @@ from smolagents.local_python_executor import (
     fix_final_answer_code,
     get_safe_module,
 )
+
+
+# Non-exhaustive list of dangerous modules that should not be imported
+DANGEROUS_MODULES = [
+    "builtins",
+    "io",
+    "multiprocessing",
+    "os",
+    "pathlib",
+    "pty",
+    "shutil",
+    "socket",
+    "subprocess",
+    "sys",
+]
 
 
 # Fake function we will use as tool


### PR DESCRIPTION
Forbid all modules by default except whitelist `authorized_imports`.

This PR implements a more robust security approach: use a deny-by-default policy and only whitelist specific modules that are known to be safe for your use case, rather than trying to maintain a comprehensive blacklist

As discussed in: https://github.com/huggingface/smolagents/pull/929#pullrequestreview-2672044981