### PR TITLE
Fix broken example of using MCP Server

### DIFF
--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -236,12 +236,12 @@ from smolagents import ToolCollection, CodeAgent
 from mcp import StdioServerParameters
 
 server_parameters = StdioServerParameters(
-    command="uv",
+    command="uvx",
     args=["--quiet", "pubmedmcp@0.1.3"],
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
 with ToolCollection.from_mcp(server_parameters) as tool_collection:
-    agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
+    agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```


### PR DESCRIPTION
The example of how to integrate smolagents with an MCP server was broken. This fixes it. Should resolve https://github.com/huggingface/smolagents/issues/442 