### PR TITLE
Update pyproject.toml transformers dependency installation ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,9 @@ telemetry = [
   "openinference-instrumentation-smolagents>=0.1.4"
 ]
 transformers = [
-  "accelerate",
-  "transformers>=4.0.0",
   "smolagents[torch]",
+  "accelerate",
+  "transformers>=4.0.0"
 ]
 vision = [
   "helium",


### PR DESCRIPTION
Aim to fix bug where failure to install "smolagents[all]" and "smolagents[transformers]" are triggered by not having PyTorch installed first in a new python environment.

See https://github.com/huggingface/smolagents/issues/940 for details.