### PR TITLE
Fix tool function implementation

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -26,7 +26,7 @@ import types
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from huggingface_hub import (
     create_repo,
@@ -866,7 +866,16 @@ def tool(tool_function: Callable) -> Tool:
         ''') + textwrap.indent(forward_method_code, "    ")  # indent for class method
 
     # Execute the code in a new namespace
-    namespace = {"Any": Any, "Optional": Optional, "Tool": Tool, "tool_function": tool_function}
+    namespace = {
+        "Tool": Tool,
+        "tool_function": tool_function,
+        "Any": Any,
+        "Optional": Optional,
+        "Dict": Dict,
+        "List": List,
+        "Tuple": Tuple,
+        "Union": Union,
+    }
     exec(class_code, namespace)
     # Store the source code on both class and method for inspection
     SimpleTool = namespace["SimpleTool"]

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -868,9 +868,10 @@ def tool(tool_function: Callable) -> Tool:
     # Execute the code in a new namespace
     namespace = {"Any": Any, "Optional": Optional, "Tool": Tool, "tool_function": tool_function}
     exec(class_code, namespace)
-    # Store the source code on the class for inspection
+    # Store the source code on both class and method for inspection
     SimpleTool = namespace["SimpleTool"]
     SimpleTool._source = class_code
+    SimpleTool.forward._source = forward_method_code
     return SimpleTool()
 
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -148,7 +148,7 @@ class Tool:
         ):
             signature = inspect.signature(self.forward)
 
-            if not set(signature.parameters.keys()) == set(self.inputs.keys()):
+            if not set(key for key in signature.parameters.keys() if key != "self") == set(self.inputs.keys()):
                 raise Exception(
                     f"In tool '{self.name}', 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'."
                 )

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -840,8 +840,8 @@ def tool(tool_function: Callable) -> Tool:
 
     # Get the signature parameters
     sig = inspect.signature(tool_function)
-    params = ["self"] + list(sig.parameters.keys())
-    params_str = ", ".join(params)
+    # Add "self" as first parameter to signature
+    sig_str = "(self" + ("" if str(sig).startswith("()") else ", ") + str(sig)[1:]
 
     # Get the source code of tool_function
     tool_source = inspect.getsource(tool_function)
@@ -864,7 +864,7 @@ def tool(tool_function: Callable) -> Tool:
             def __init__(self):
                 self.is_initialized = True
 
-            def forward({params_str}):
+            def forward{sig_str}:
         ''')
         + tool_body
     )

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -26,7 +26,7 @@ import types
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from huggingface_hub import (
     create_repo,
@@ -870,7 +870,7 @@ def tool(tool_function: Callable) -> Tool:
     )
 
     # Execute the code in a new namespace
-    namespace = {"Tool": Tool, "tool_function": tool_function}
+    namespace = {"Any": Any, "Optional": Optional, "Tool": Tool, "tool_function": tool_function}
     exec(class_code, namespace)
     # Store the source code on the class for inspection
     SimpleTool = namespace["SimpleTool"]

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -848,7 +848,7 @@ def tool(tool_function: Callable) -> Tool:
     SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
     SimpleTool.output_type = tool_json_schema["return"]["type"]
     # Bind the tool function to the forward method
-    SimpleTool.forward = types.MethodType(tool_function, SimpleTool)
+    SimpleTool.forward = staticmethod(tool_function)
 
     # Get the signature parameters of the tool function
     sig = inspect.signature(tool_function)
@@ -857,7 +857,7 @@ def tool(tool_function: Callable) -> Tool:
         parameters=[inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)] + list(sig.parameters.values())
     )
     # - Set the signature of the forward method
-    SimpleTool.forward.__func__.__signature__ = new_sig
+    SimpleTool.forward.__signature__ = new_sig
 
     # Create and attach the source code of the dynamically created tool class and forward method
     # - Get the source code of tool_function
@@ -885,7 +885,7 @@ def tool(tool_function: Callable) -> Tool:
     )
     # - Store the source code on both class and method for inspection
     SimpleTool.__source = class_source
-    SimpleTool.forward.__func__.__source = forward_method_source
+    SimpleTool.forward.__source = forward_method_source
 
     simple_tool = SimpleTool()
     return simple_tool

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -903,9 +903,7 @@ def tool(tool_function: Callable) -> Tool:
     # Create imports block
     imports_block = "\n".join(sorted(required_imports))
     if imports_block:
-        imports_block += "\n"
-    imports_block += "from smolagents import Tool\n"
-    imports_block += "\n\n"
+        imports_block += "\n\n"
 
     # Create the class code
     class_code = (
@@ -923,9 +921,8 @@ def tool(tool_function: Callable) -> Tool:
         ''')
         + textwrap.indent(forward_method_code, "    ")  # indent for class method
     )
-    # import pdb;pdb.set_trace()
     # Execute the code in a new namespace
-    namespace = {"tool_function": tool_function}
+    namespace = {"Tool": Tool, "tool_function": tool_function}
     exec(class_code, namespace)
     # Store the source code on both class and method for inspection
     SimpleTool = namespace["SimpleTool"]

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -849,12 +849,11 @@ def tool(tool_function: Callable) -> Tool:
     tool_body = "\n".join(tool_source.split("\n")[2:])
     # - Dedent
     tool_body = textwrap.dedent(tool_body)
-    # - Indent for class method
-    tool_body = textwrap.indent(tool_body, "        ")
+    # - Create the forward method code, including def line and indentation
+    forward_method_code = f"def forward{sig_str}:\n{textwrap.indent(tool_body, '    ')}"
 
     # Create the class code
-    class_code = (
-        textwrap.dedent(f'''
+    class_code = textwrap.dedent(f'''
         class SimpleTool(Tool):
             name: str = "{tool_json_schema["name"]}"
             description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
@@ -864,10 +863,7 @@ def tool(tool_function: Callable) -> Tool:
             def __init__(self):
                 self.is_initialized = True
 
-            def forward{sig_str}:
-        ''')
-        + tool_body
-    )
+        ''') + textwrap.indent(forward_method_code, "    ")  # indent for class method
 
     # Execute the code in a new namespace
     namespace = {"Any": Any, "Optional": Optional, "Tool": Tool, "tool_function": tool_function}

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -857,8 +857,8 @@ def tool(tool_function: Callable) -> Tool:
         textwrap.dedent(f'''
         class SimpleTool(Tool):
             name: str = "{tool_json_schema["name"]}"
-            description: str = """{tool_json_schema["description"]}"""
-            inputs: dict[str, dict[str, str]] = {tool_json_schema["parameters"]["properties"]}
+            description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
+            inputs: dict[str, dict[str, str]] = {json.dumps(tool_json_schema["parameters"]["properties"], separators=(",", ":"))}
             output_type: str = "{tool_json_schema["return"]["type"]}"
 
             def __init__(self):

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -903,7 +903,9 @@ def tool(tool_function: Callable) -> Tool:
     # Create imports block
     imports_block = "\n".join(sorted(required_imports))
     if imports_block:
-        imports_block += "\n\n"
+        imports_block += "\n"
+    imports_block += "from smolagents import Tool\n"
+    imports_block += "\n\n"
 
     # Create the class code
     class_code = (
@@ -921,8 +923,9 @@ def tool(tool_function: Callable) -> Tool:
         ''')
         + textwrap.indent(forward_method_code, "    ")  # indent for class method
     )
+    # import pdb;pdb.set_trace()
     # Execute the code in a new namespace
-    namespace = {"Tool": Tool, "tool_function": tool_function}
+    namespace = {"tool_function": tool_function}
     exec(class_code, namespace)
     # Store the source code on both class and method for inspection
     SimpleTool = namespace["SimpleTool"]

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -857,7 +857,7 @@ def tool(tool_function: Callable) -> Tool:
         class SimpleTool(Tool):
             name: str = "{tool_json_schema["name"]}"
             description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
-            inputs: dict[str, dict[str, str]] = {json.dumps(tool_json_schema["parameters"]["properties"], separators=(",", ":"))}
+            inputs: dict[str, dict[str, str]] = {tool_json_schema["parameters"]["properties"]}
             output_type: str = "{tool_json_schema["return"]["type"]}"
 
             def __init__(self):

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -415,7 +415,7 @@ def get_source(obj) -> str:
     inspect_error = None
     try:
         # Handle dynamically created classes
-        source = obj._source if hasattr(obj, "_source") else inspect.getsource(obj)
+        source = obj.__source if hasattr(obj, "__source") else inspect.getsource(obj)
         return dedent(source).strip()
     except OSError as e:
         # let's keep track of the exception to raise it if all further methods fail

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -414,7 +414,9 @@ def get_source(obj) -> str:
 
     inspect_error = None
     try:
-        return dedent(inspect.getsource(obj)).strip()
+        # Handle dynamically created classes
+        source = obj._source if hasattr(obj, "_source") else inspect.getsource(obj)
+        return dedent(source).strip()
     except OSError as e:
         # let's keep track of the exception to raise it if all further methods fail
         inspect_error = e

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -348,8 +348,14 @@ def instance_to_source(instance, base_cls=None):
         name: func
         for name, func in cls.__dict__.items()
         if callable(func)
-        and not (
-            base_cls and hasattr(base_cls, name) and getattr(base_cls, name).__code__.co_code == func.__code__.co_code
+        and (
+            not base_cls
+            or not hasattr(base_cls, name)
+            or (
+                isinstance(func, staticmethod)
+                or isinstance(func, classmethod)
+                or (getattr(base_cls, name).__code__.co_code != func.__code__.co_code)
+            )
         )
     }
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -324,7 +324,11 @@ class AgentTests(unittest.TestCase):
             Args:
                 prompt: The prompt
             """
-            return Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png")
+            from pathlib import Path
+
+            from PIL import Image
+
+            return Image.open(Path("tests/fixtures/000000039769.png"))
 
         agent = ToolCallingAgent(tools=[fake_image_generation_tool], model=FakeToolCallModelImage())
         output = agent.run("Make me an image.")

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -2,7 +2,7 @@ import pytest
 
 from smolagents.default_tools import DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool
 from smolagents.tool_validation import validate_tool_attributes
-from smolagents.tools import Tool
+from smolagents.tools import Tool, tool
 
 
 UNDEFINED_VARIABLE = "undefined_variable"
@@ -29,8 +29,19 @@ class ValidTool(Tool):
         return input.upper()
 
 
-def test_validate_tool_attributes_valid():
-    assert validate_tool_attributes(ValidTool) is None
+@tool
+def valid_tool_function(input: str) -> str:
+    """A valid tool function.
+
+    Args:
+        input (str): Input string.
+    """
+    return input.upper()
+
+
+@pytest.mark.parametrize("tool_class", [ValidTool, valid_tool_function.__class__])
+def test_validate_tool_attributes_valid(tool_class):
+    assert validate_tool_attributes(tool_class) is None
 
 
 class InvalidToolComplexAttrs(Tool):


### PR DESCRIPTION
Fix tool function implementation.

Currently, no `@tool` decorated function can be used in remote code execution, because:
- `RemotePythonExecutor.send_tools`
  - calls `get_tools_definition_code`
    - calls `validate_tool_attributes`

Currently, when using `@tool` decorator, `validate_tool_attribute` raises an error because the dynamically created `SimpleTool` class has required parameters in `__init__` without default values:
https://github.com/huggingface/smolagents/blob/812c2d2e798701024d0259e3d46ab4f45a228185/src/smolagents/tools.py#L839-L853
```python
ValueError: Tool validation failed for SimpleTool:
Parameters in __init__ must have default values, found required parameters: output_type, inputs, name, function, description
```

This PR:
- For tool functions, dynamically create the `SimpleTool` class
- Add tests:
  - `validate_tool_attributes`: for Tool class and tool function
  - `instance_to_source`: for Tool class and tool function
- Fix:
  - `get_source` for dynamically created objects
  - `instance_to_source` to support static and class methods

Fix #913.

Should we do a patch release with this fix?
CC: @aymeric-roucher 