### PR TITLE
Raise agent generation errors

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -331,7 +331,11 @@ You have been provided with these additional arguments, that you can access usin
             memory_step = self._create_memory_step(step_start_time, images)
             try:
                 final_answer = self._execute_step(task, memory_step)
+            except AgentGenerationError as e:
+                # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
+                raise e
             except AgentError as e:
+                # Other AgentError types are caused by the Model, so we should log them and iterate.
                 memory_step.error = e
             finally:
                 self._finalize_step(memory_step, step_start_time)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -43,7 +43,7 @@ from smolagents.models import (
     TransformersModel,
 )
 from smolagents.tools import Tool, tool
-from smolagents.utils import BASE_BUILTIN_MODULES
+from smolagents.utils import BASE_BUILTIN_MODULES, AgentGenerationError
 
 
 def get_new_path(suffix="") -> str:
@@ -568,6 +568,16 @@ nested_answer()
         agent = CodeAgent(model=fake_code_model, tools=[], final_answer_checks=[check_always_fails])
         agent.run("Dummy task.")
         assert "Error raised in check" in str(agent.write_memory_to_messages())
+
+    def test_generation_errors_are_raised(self):
+        def fake_model(messages, stop_sequences):
+            assert False, "Generation failed"
+
+        agent = CodeAgent(model=fake_model, tools=[])
+        with pytest.raises(AgentGenerationError) as e:
+            agent.run("Dummy task.")
+        assert len(agent.memory.steps) == 2
+        assert "Generation failed" in str(e)
 
 
 class CustomFinalAnswerTool(FinalAnswerTool):


### PR DESCRIPTION
Until now we log all errors to agent memory, display them as a summary version (not the whole traceback) and keep running the agent. But although this makes sense for AgentParsingError and AgentExecutionError, it does not for AgentGenerationError which should never happen and retry. If the LLM call fails, it's an implementation issue, not an error from the agent, so this should just interrupt the agent run and log the full traceback!