### PR TITLE
Name is required with GradioUI

### DIFF
--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -405,7 +405,7 @@ image_generation_tool = load_tool("m-ric/text-to-image", trust_remote_code=True)
 model = HfApiModel(model_id=model_id)
 
 # Initialize the agent with the image generation tool
-agent = CodeAgent(tools=[image_generation_tool], model=model)
+agent = CodeAgent(name="image-agent", tools=[image_generation_tool], model=model)
 
 GradioUI(agent).launch()
 ```


### PR DESCRIPTION
Without the definition of a agent name the GradioUI will fail to start.
```python
from smolagents import (
    load_tool,
    CodeAgent,
    HfApiModel,
    GradioUI
)

# Import tool from Hub
image_generation_tool = load_tool("m-ric/text-to-image", trust_remote_code=True)

model = HfApiModel(model_id=model_id)

# Initialize the agent with the image generation tool
agent = CodeAgent(tools=[image_generation_tool], model=model)

GradioUI(agent).launch()
```
Error:
```
Traceback (most recent call last):
  File "/Users/ec2-user/q1.py", line 37, in <module>
    GradioUI(agent).launch()
  File "/Users/ec2-user/.venv/lib/python3.12/site-packages/smolagents/gradio_ui.py", line 267, in launch
    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
         ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```