### PR TITLE
fix gradio string replace error when agent is not named

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -264,7 +264,7 @@ class GradioUI:
 
             with gr.Sidebar():
                 gr.Markdown(
-                    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
+                    f"# {(self.name or 'Agent interface').replace('_', ' ').capitalize()}"
                     "\n> This web ui allows you to interact with a `smolagents` agent that can use tools and execute steps to complete tasks."
                     + (f"\n\n**Agent description:**\n{self.description}" if self.description else "")
                 )


### PR DESCRIPTION
OS Version: 22.04.2 LTS (Jammy Jellyfish) [Windows WSL]
Python version:  Python 3.11.6


Minimal reproducible code:
```
from smolagents import GradioUI,  CodeAgent

manager_agent = CodeAgent(tools=[], additional_authorized_imports=["pandas", "numpy", "matplotlib", "os"],
    model=model
)

ui = GradioUI(manager_agent)
ui.launch()
```

Error stack trace:

```
Traceback (most recent call last):
  File "/home/watsonchua/work/agents-compare/smol_agent_example/resale_main.py", line 101, in <module>
    ui.launch()
  File "/home/watsonchua/work/agents-compare/.venv/lib/python3.11/site-packages/smolagents/gradio_ui.py", line 267, in launch
    f"# {self.name.replace('_', ' ').capitalize() or 'Agent interface'}"
         ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```

Linked Issues: #953