### PR TITLE
Fix: prevent flatten_messages_as_text from being passed to completion…

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -955,6 +955,12 @@ class OpenAIServerModel(Model):
             **(client_kwargs or {}),
         )
         self.custom_role_conversions = custom_role_conversions
+        self.flatten_messages_as_text = (
+            kwargs.get("flatten_messages_as_text")
+            if "flatten_messages_as_text" in kwargs
+            else self.model_id.startswith("deepseek")
+        )
+        self.kwargs.pop("flatten_messages_as_text", None)
 
     def __call__(
         self,
@@ -972,6 +978,7 @@ class OpenAIServerModel(Model):
             model=self.model_id,
             custom_role_conversions=self.custom_role_conversions,
             convert_images_to_image_urls=True,
+            flatten_messages_as_text = self.flatten_messages_as_text,
             **kwargs,
         )
         response = self.client.chat.completions.create(**completion_kwargs)


### PR DESCRIPTION
https://github.com/huggingface/smolagents/issues/944#issue-2910323067
```python
model = OpenAIServerModel(
    model_id="deepseek-chat",
    api_base="https://api.deepseek.com",
    api_key = DEEPSEEK_API_KEY,
    flatten_messages_as_text=True, 
    temperature=0,
)
```
Simply passing this parameter, flatten_messages_as_text=True, will still cause an error.
'OpenAIServerModel' object has no attribute 'flatten_messages_as_text'

Since completions.create does not have a parameter named flatten_messages_as_text, and OpenAIServerModel does not explicitly define it, it ends up being passed as part of **kwargs, which causes the error.