### PR TITLE
Support passing flatten_messages_as_text to OpenAIServerModel and test

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -93,7 +93,7 @@ def load_model(model_type: str, model_id: str, api_base: str | None = None, api_
             api_base=api_base,
         )
     elif model_type == "TransformersModel":
-        return TransformersModel(model_id=model_id, device_map="auto", flatten_messages_as_text=False)
+        return TransformersModel(model_id=model_id, device_map="auto")
     elif model_type == "HfApiModel":
         return HfApiModel(
             model_id=model_id,

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -239,10 +239,11 @@ def get_clean_message_list(
 
 
 class Model:
-    def __init__(self, **kwargs):
+    def __init__(self, flatten_messages_as_text: bool = False, **kwargs):
+        self.flatten_messages_as_text = flatten_messages_as_text
+        self.kwargs = kwargs
         self.last_input_token_count = None
         self.last_output_token_count = None
-        self.kwargs = kwargs
 
     def _prepare_completion_kwargs(
         self,
@@ -252,7 +253,6 @@ class Model:
         tools_to_call_from: Optional[List[Tool]] = None,
         custom_role_conversions: Optional[Dict[str, str]] = None,
         convert_images_to_image_urls: bool = False,
-        flatten_messages_as_text: bool = False,
         **kwargs,
     ) -> Dict:
         """
@@ -268,7 +268,7 @@ class Model:
             messages,
             role_conversions=custom_role_conversions or tool_role_conversions,
             convert_images_to_image_urls=convert_images_to_image_urls,
-            flatten_messages_as_text=flatten_messages_as_text,
+            flatten_messages_as_text=self.flatten_messages_as_text,
         )
 
         # Use self.kwargs as the base configuration
@@ -513,7 +513,7 @@ class MLXModel(Model):
         trust_remote_code: bool = False,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(flatten_messages_as_text=True, **kwargs)  # mlx-lm doesn't support vision models
         if not _is_package_available("mlx_lm"):
             raise ModuleNotFoundError(
                 "Please install 'mlx-lm' extra to use 'MLXModel': `pip install 'smolagents[mlx-lm]'`"
@@ -556,7 +556,6 @@ class MLXModel(Model):
         **kwargs,
     ) -> ChatMessage:
         completion_kwargs = self._prepare_completion_kwargs(
-            flatten_messages_as_text=True,  # mlx-lm doesn't support vision models
             messages=messages,
             stop_sequences=stop_sequences,
             grammar=grammar,
@@ -638,7 +637,6 @@ class TransformersModel(Model):
         trust_remote_code: bool = False,
         **kwargs,
     ):
-        super().__init__(**kwargs)
         if not is_torch_available() or not _is_package_available("transformers"):
             raise ModuleNotFoundError(
                 "Please install 'transformers' extra to use 'TransformersModel': `pip install 'smolagents[transformers]'`"
@@ -663,7 +661,6 @@ class TransformersModel(Model):
             logger.warning(
                 f"`max_new_tokens` not provided, using this default value for `max_new_tokens`: {default_max_tokens}"
             )
-        self.kwargs = kwargs
 
         if device_map is None:
             device_map = "cuda" if torch.cuda.is_available() else "cpu"
@@ -686,6 +683,7 @@ class TransformersModel(Model):
                 raise e
         except Exception as e:
             raise ValueError(f"Failed to load tokenizer and model for {model_id=}: {e}") from e
+        super().__init__(flatten_messages_as_text=not self._is_vlm, **kwargs)
 
     def make_stopping_criteria(self, stop_sequences: List[str], tokenizer) -> "StoppingCriteriaList":
         from transformers import StoppingCriteria, StoppingCriteriaList
@@ -720,7 +718,6 @@ class TransformersModel(Model):
             messages=messages,
             stop_sequences=stop_sequences,
             grammar=grammar,
-            flatten_messages_as_text=(not self._is_vlm),
             **kwargs,
         )
 
@@ -830,6 +827,8 @@ class LiteLLMModel(Model):
         custom_role_conversions (`dict[str, str]`, *optional*):
             Custom role conversion mapping to convert message roles in others.
             Useful for specific models that do not support specific message roles like "system".
+        flatten_messages_as_text (`bool`, *optional*): Whether to flatten messages as text.
+            Defaults to `True` for models that start with "ollama", "groq", "cerebras".
         **kwargs:
             Additional keyword arguments to pass to the OpenAI API.
     """
@@ -840,9 +839,9 @@ class LiteLLMModel(Model):
         api_base=None,
         api_key=None,
         custom_role_conversions: Optional[Dict[str, str]] = None,
+        flatten_messages_as_text: bool | None = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
         if not model_id:
             warnings.warn(
                 "The 'model_id' parameter will be required in version 2.0.0. "
@@ -855,11 +854,12 @@ class LiteLLMModel(Model):
         self.api_base = api_base
         self.api_key = api_key
         self.custom_role_conversions = custom_role_conversions
-        self.flatten_messages_as_text = (
-            kwargs.get("flatten_messages_as_text")
-            if "flatten_messages_as_text" in kwargs
+        flatten_messages_as_text = (
+            flatten_messages_as_text
+            if flatten_messages_as_text is not None
             else self.model_id.startswith(("ollama", "groq", "cerebras"))
         )
+        super().__init__(flatten_messages_as_text=flatten_messages_as_text, **kwargs)
 
     def __call__(
         self,
@@ -885,7 +885,6 @@ class LiteLLMModel(Model):
             api_base=self.api_base,
             api_key=self.api_key,
             convert_images_to_image_urls=True,
-            flatten_messages_as_text=self.flatten_messages_as_text,
             custom_role_conversions=self.custom_role_conversions,
             **kwargs,
         )

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -922,6 +922,8 @@ class OpenAIServerModel(Model):
         custom_role_conversions (`dict[str, str]`, *optional*):
             Custom role conversion mapping to convert message roles in others.
             Useful for specific models that do not support specific message roles like "system".
+        flatten_messages_as_text (`bool`, default `False`):
+            Whether to flatten messages as text.
         **kwargs:
             Additional keyword arguments to pass to the OpenAI API.
     """
@@ -935,6 +937,7 @@ class OpenAIServerModel(Model):
         project: Optional[str] | None = None,
         client_kwargs: Optional[Dict[str, Any]] = None,
         custom_role_conversions: Optional[Dict[str, str]] = None,
+        flatten_messages_as_text: bool = False,
         **kwargs,
     ):
         try:
@@ -944,7 +947,7 @@ class OpenAIServerModel(Model):
                 "Please install 'openai' extra to use OpenAIServerModel: `pip install 'smolagents[openai]'`"
             ) from None
 
-        super().__init__(**kwargs)
+        super().__init__(flatten_messages_as_text=flatten_messages_as_text, **kwargs)
         self.model_id = model_id
         self.client = openai.OpenAI(
             base_url=api_base,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@
 import json
 import sys
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -23,6 +24,7 @@ import pytest
 from transformers.testing_utils import get_tests_dir
 
 from smolagents.models import (
+    AzureOpenAIServerModel,
     ChatMessage,
     HfApiModel,
     LiteLLMModel,
@@ -278,3 +280,53 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert len(result) == 1
     assert result[0]["role"] == "user"
     assert result[0]["content"] == "Hello!How are you?"
+
+
+@pytest.mark.parametrize(
+    "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
+    [
+        (AzureOpenAIServerModel, {}, ("openai.AzureOpenAI", {}), False),
+        (HfApiModel, {}, ("huggingface_hub.InferenceClient", {}), False),
+        (LiteLLMModel, {}, None, False),
+        (LiteLLMModel, {"model_id": "ollama"}, None, True),
+        (LiteLLMModel, {"model_id": "groq"}, None, True),
+        (LiteLLMModel, {"model_id": "cerebras"}, None, True),
+        (MLXModel, {}, ("mlx_lm.load", {"return_value": (MagicMock(), MagicMock())}), True),
+        (OpenAIServerModel, {}, ("openai.OpenAI", {}), False),
+        (
+            TransformersModel,
+            {},
+            [
+                ("transformers.AutoModelForCausalLM.from_pretrained", {}),
+                ("transformers.AutoTokenizer.from_pretrained", {}),
+            ],
+            True,
+        ),
+        (
+            TransformersModel,
+            {},
+            [
+                (
+                    "transformers.AutoModelForCausalLM.from_pretrained",
+                    {"side_effect": ValueError("Unrecognized configuration class")},
+                ),
+                ("transformers.AutoModelForImageTextToText.from_pretrained", {}),
+                ("transformers.AutoProcessor.from_pretrained", {}),
+            ],
+            False,
+        ),
+    ],
+)
+def test_flatten_messages_as_text_for_all_models(
+    model_class, model_kwargs, patching, expected_flatten_messages_as_text
+):
+    with ExitStack() as stack:
+        if isinstance(patching, list):
+            for target, kwargs in patching:
+                stack.enter_context(patch(target, **kwargs))
+        elif patching:
+            target, kwargs = patching
+            stack.enter_context(patch(target, **kwargs))
+
+        model = model_class(**{"model_id": "test-model", **model_kwargs})
+    assert model.flatten_messages_as_text is expected_flatten_messages_as_text, f"{model_class.__name__} failed"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -293,6 +293,7 @@ def test_get_clean_message_list_flatten_messages_as_text():
         (LiteLLMModel, {"model_id": "cerebras"}, None, True),
         (MLXModel, {}, ("mlx_lm.load", {"return_value": (MagicMock(), MagicMock())}), True),
         (OpenAIServerModel, {}, ("openai.OpenAI", {}), False),
+        (OpenAIServerModel, {"flatten_messages_as_text": True}, ("openai.OpenAI", {}), True),
         (
             TransformersModel,
             {},


### PR DESCRIPTION
Support passing `flatten_messages_as_text` to `OpenAIServerModel` and test `flatten_messages_as_text` for all models.


See discussion in: https://github.com/huggingface/smolagents/issues/944#issuecomment-2717695966