### PR TITLE
Fix ToolCalling agent argument/name extraction

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -612,7 +612,7 @@ You have been provided with these additional arguments, that you can access usin
         """
         available_tools = {**self.tools, **self.managed_agents}
         if tool_name not in available_tools:
-            error_msg = f"Unknown tool {tool_name}, should be instead one of {list(available_tools.keys())}."
+            error_msg = f"Unknown tool {tool_name}, should be instead one of: {', '.join(available_tools)}."
             raise AgentExecutionError(error_msg, self.logger)
 
         try:
@@ -638,13 +638,13 @@ You have been provided with these additional arguments, that you can access usin
                 tool = self.tools[tool_name]
                 error_msg = (
                     f"Error when executing tool {tool_name} with arguments {arguments}: {type(e).__name__}: {e}\nYou should only use this tool with a correct input.\n"
-                    f"As a reminder, this tool's description is the following: '{tool.description}'.\nIt takes inputs: {tool.inputs} and returns output type {tool.output_type}"
+                    f"As a reminder, this tool's description is the following: '{tool.description}'.\nIt takes inputs: {json.dumps(tool.inputs)} and returns output type {tool.output_type}"
                 )
                 raise AgentExecutionError(error_msg, self.logger)
             elif tool_name in self.managed_agents:
                 error_msg = (
                     f"Error in calling team member: {e}\nYou should only ask this team member with a correct request.\n"
-                    f"As a reminder, this team member's description is the following:\n{available_tools[tool_name]}"
+                    f"As a reminder, this team member's description is the following:\n{self.managed_agents[tool_name].description}\n"
                 )
                 raise AgentExecutionError(error_msg, self.logger)
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -250,11 +250,11 @@ class VisitWebpageTool(Tool):
             return truncate_content(markdown_content, 10000)
 
         except requests.exceptions.Timeout:
-            return "The request timed out. Please try again later or check the URL."
+            raise Exception("The request timed out. Please try again later or check the URL.")
         except RequestException as e:
-            return f"Error fetching the webpage: {str(e)}"
+            raise Exception(f"Error fetching the webpage: {str(e)}")
         except Exception as e:
-            return f"An unexpected error occurred: {str(e)}"
+            raise Exception(f"An unexpected error occurred: {str(e)}")
 
 
 class SpeechToTextTool(PipelineTool):

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import asdict, dataclass
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, Union
@@ -93,7 +94,7 @@ class ActionStep(MemoryStep):
                     content=[
                         {
                             "type": "text",
-                            "text": "Calling tools:\n" + str([tc.dict() for tc in self.tool_calls]),
+                            "text": "Calling tools:\n" + json.dumps([tc.dict() for tc in self.tool_calls]),
                         }
                     ],
                 )

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -144,8 +144,12 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools:
   {%- for tool in tools.values() %}
   - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
-      Returns an output of type: {{tool.output_type}}
+    {%- if tool.inputs %}
+    Takes inputs: {{ tool.inputs }}
+    {% else %}
+    Takes NO inputs.
+    {%- endif %}
+    Returns an output of type: {{ tool.output_type }}
   {%- endfor %}
 
   {%- if managed_agents and managed_agents.values() | list %}
@@ -201,7 +205,7 @@ planning:
     {{task}}
     ```
     Now begin!
-  initial_plan : |-
+  initial_plan: |-
     You are a world expert at making efficient plans to solve any task using a set of carefully crafted tools.
 
     Now for the given task, develop a step-by-step high-level plan taking into account the above inputs and list of facts.
@@ -218,7 +222,11 @@ planning:
     You can leverage these tools:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
+        {%- if tool.inputs %}
+        Takes inputs: {{ tool.inputs }}
+        {% else %}
+        Takes NO inputs.
+        {%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -276,7 +284,11 @@ planning:
     You can leverage these tools:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
+        {%- if tool.inputs %}
+        Takes inputs: {{ tool.inputs }}
+        {% else %}
+        Takes NO inputs.
+        {%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -304,24 +316,24 @@ planning:
     Now write your new plan below.
 managed_agent:
   task: |-
-      You're a helpful agent named '{{name}}'.
-      You have been submitted this task by your manager.
-      ---
-      Task:
-      {{task}}
-      ---
-      You're helping your manager solve a wider task: so make sure to not provide a one-line answer, but give as much information as possible to give them a clear understanding of the answer.
+    You're a helpful agent named '{{name}}'.
+    You have been submitted this task by your manager.
+    ---
+    Task:
+    {{task}}
+    ---
+    You're helping your manager solve a wider task: so make sure to not provide a one-line answer, but give as much information as possible to give them a clear understanding of the answer.
 
-      Your final_answer WILL HAVE to contain these parts:
-      ### 1. Task outcome (short version):
-      ### 2. Task outcome (extremely detailed version):
-      ### 3. Additional context (if relevant):
+    Your final_answer WILL HAVE to contain these parts:
+    ### 1. Task outcome (short version):
+    ### 2. Task outcome (extremely detailed version):
+    ### 3. Additional context (if relevant):
 
-      Put all these in your final_answer tool, everything that you do not pass as an argument to final_answer will be lost.
-      And even if your task resolution is not successful, please return as much context as possible, so that your manager can act upon this feedback.
+    Put all these in your final_answer tool, everything that you do not pass as an argument to final_answer will be lost.
+    And even if your task resolution is not successful, please return as much context as possible, so that your manager can act upon this feedback.
   report: |-
-      Here is the final answer from your managed agent '{{name}}':
-      {{final_answer}}
+    Here is the final answer from your managed agent '{{name}}':
+    {{final_answer}}
 final_answer:
   pre_messages: |-
     An agent tried to answer a user query but it got stuck and failed to do so. You are tasked with providing an answer instead. Here is the agent's memory:

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -145,10 +145,7 @@ system_prompt: |-
   {%- for tool in tools.values() %}
   - {{ tool.name }}: {{ tool.description }}
     {%- if tool.inputs %}
-    Takes inputs: {{ tool.inputs }}
-    {% else %}
-    Takes NO inputs.
-    {%- endif %}
+    Takes inputs: {{ tool.inputs }}{% else %}Takes NO inputs.{%- endif %}
     Returns an output of type: {{ tool.output_type }}
   {%- endfor %}
 
@@ -223,10 +220,7 @@ planning:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
         {%- if tool.inputs %}
-        Takes inputs: {{ tool.inputs }}
-        {% else %}
-        Takes NO inputs.
-        {%- endif %}
+        Takes inputs: {{ tool.inputs }}{% else %}Takes NO inputs.{%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -285,10 +279,7 @@ planning:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
         {%- if tool.inputs %}
-        Takes inputs: {{ tool.inputs }}
-        {% else %}
-        Takes NO inputs.
-        {%- endif %}
+        Takes inputs: {{ tool.inputs }}{% else %}Takes NO inputs.{%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -92,7 +92,11 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. You only have access to these tools:
   {%- for tool in tools.values() %}
   - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
+      {%- if tool.inputs %}
+      Takes inputs: {{ tool.inputs }}
+      {% else %}
+      Takes NO inputs.
+      {%- endif %}
       Returns an output of type: {{tool.output_type}}
   {%- endfor %}
 
@@ -144,7 +148,7 @@ planning:
     {{task}}
     ```
     Now begin!
-  initial_plan : |-
+  initial_plan: |-
     You are a world expert at making efficient plans to solve any task using a set of carefully crafted tools.
 
     Now for the given task, develop a step-by-step high-level plan taking into account the above inputs and list of facts.
@@ -161,7 +165,11 @@ planning:
     You can leverage these tools:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
+        {%- if tool.inputs %}
+        Takes inputs: {{ tool.inputs }}
+        {% else %}
+        Takes NO inputs.
+        {%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -219,7 +227,11 @@ planning:
     You can leverage these tools:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
+        {%- if tool.inputs %}
+        Takes inputs: {{ tool.inputs }}
+        {% else %}
+        Takes NO inputs.
+        {%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -247,24 +259,24 @@ planning:
     Now write your new plan below.
 managed_agent:
   task: |-
-      You're a helpful agent named '{{name}}'.
-      You have been submitted this task by your manager.
-      ---
-      Task:
-      {{task}}
-      ---
-      You're helping your manager solve a wider task: so make sure to not provide a one-line answer, but give as much information as possible to give them a clear understanding of the answer.
+    You're a helpful agent named '{{name}}'.
+    You have been submitted this task by your manager.
+    ---
+    Task:
+    {{task}}
+    ---
+    You're helping your manager solve a wider task: so make sure to not provide a one-line answer, but give as much information as possible to give them a clear understanding of the answer.
 
-      Your final_answer WILL HAVE to contain these parts:
-      ### 1. Task outcome (short version):
-      ### 2. Task outcome (extremely detailed version):
-      ### 3. Additional context (if relevant):
+    Your final_answer WILL HAVE to contain these parts:
+    ### 1. Task outcome (short version):
+    ### 2. Task outcome (extremely detailed version):
+    ### 3. Additional context (if relevant):
 
-      Put all these in your final_answer tool, everything that you do not pass as an argument to final_answer will be lost.
-      And even if your task resolution is not successful, please return as much context as possible, so that your manager can act upon this feedback.
+    Put all these in your final_answer tool, everything that you do not pass as an argument to final_answer will be lost.
+    And even if your task resolution is not successful, please return as much context as possible, so that your manager can act upon this feedback.
   report: |-
-      Here is the final answer from your managed agent '{{name}}':
-      {{final_answer}}
+    Here is the final answer from your managed agent '{{name}}':
+    {{final_answer}}
 final_answer:
   pre_messages: |-
     An agent tried to answer a user query but it got stuck and failed to do so. You are tasked with providing an answer instead. Here is the agent's memory:

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -93,10 +93,7 @@ system_prompt: |-
   {%- for tool in tools.values() %}
   - {{ tool.name }}: {{ tool.description }}
       {%- if tool.inputs %}
-      Takes inputs: {{ tool.inputs }}
-      {% else %}
-      Takes NO inputs.
-      {%- endif %}
+      Takes inputs: {{ tool.inputs | tojson }}{% else %}Takes NO inputs.{%- endif %}
       Returns an output of type: {{tool.output_type}}
   {%- endfor %}
 
@@ -166,10 +163,7 @@ planning:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
         {%- if tool.inputs %}
-        Takes inputs: {{ tool.inputs }}
-        {% else %}
-        Takes NO inputs.
-        {%- endif %}
+        Takes inputs: {{ tool.inputs | tojson }}{% else %}Takes NO inputs.{%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 
@@ -228,10 +222,7 @@ planning:
     {%- for tool in tools.values() %}
     - {{ tool.name }}: {{ tool.description }}
         {%- if tool.inputs %}
-        Takes inputs: {{ tool.inputs }}
-        {% else %}
-        Takes NO inputs.
-        {%- endif %}
+        Takes inputs: {{ tool.inputs | tojson }}{% else %}Takes NO inputs.{%- endif %}
         Returns an output of type: {{tool.output_type}}
     {%- endfor %}
 

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -102,6 +102,12 @@ class AgentExecutionError(AgentError):
     pass
 
 
+class AgentInvocationError(AgentError):
+    """Exception raised for errors when incorrect arguments are used"""
+
+    pass
+
+
 class AgentMaxStepsError(AgentError):
     """Exception raised for errors in execution in the agent"""
 
@@ -145,8 +151,8 @@ def parse_json_blob(json_blob: str) -> Tuple[Dict[str, str], str]:
     try:
         first_accolade_index = json_blob.find("{")
         last_accolade_index = [a.start() for a in list(re.finditer("}", json_blob))][-1]
-        json_blob = json_blob[first_accolade_index : last_accolade_index + 1].replace('\\"', "'")
-        json_data = json.loads(json_blob, strict=False)
+        json_data = json_blob[first_accolade_index : last_accolade_index + 1].replace('\\"', "'")
+        json_data = json.loads(json_data, strict=False)
         return json_data, json_blob[:first_accolade_index]
     except json.JSONDecodeError as e:
         place = e.pos


### PR DESCRIPTION
An attempt to fix https://github.com/huggingface/smolagents/issues/960 and https://github.com/huggingface/smolagents/issues/938

A model in some cases was returning python dictionaries whilst generating tool call args/name.
I have a feeling it stems from this:
https://github.com/huggingface/smolagents/pull/962/files#diff-e03ffeb1ffdc0c18d4a29eaec2694a39de7c9ce98647a9dcf5fc372a61d4d40aL640
Since
```py
f"As a reminder, this tool's description is the following: '{tool.description}'.\nIt takes inputs: {tool.inputs} and returns output type {tool.output_type}"
```
Embeds in a message a python dictionary, with singular quotes. Hence I added a `json.dumps` that forces it to be a proper json blob. I still added a regular expression that tries to convert a received python dictionary into a json blob.

Besides that it is assumed that model returns:
```
{"name": "some-name", "arguments": ...}
```
However it kept placing them under `function` key. So I added a fallback:
https://github.com/huggingface/smolagents/pull/962/files#diff-0319e64c7d0f9e302a7c7a0dd60f04dedb7d4dcf7dbe9e046543335654a9efa1R815

Also the prompt:
```
  - {{ tool.name }}: {{ tool.description }}
      Takes inputs: {{tool.inputs}}
```
slightly confuses a model, still trying to pass something in. I found it performing better if specifically instructing that there are no arguments available.