### PR TITLE
Images as CodeAct step outputs

### DIFF
--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import tempfile
 import uuid
+import copy
 from io import BytesIO
 
 import numpy as np
@@ -104,6 +105,16 @@ class AgentImage(AgentType, ImageType):
 
         if self._path is None and self._raw is None and self._tensor is None:
             raise TypeError(f"Unsupported type for {self.__class__.__name__}: {type(value)}")
+
+    def __deepcopy__(self, memo):
+        result = self.__class__.__new__(self.__class__)
+        memo[id(self)] = result
+        for key, value in self.__dict__.items():
+            if key == "_raw" and self._raw is not None:
+                setattr(result, '_raw', self._raw.copy())
+            else:
+                setattr(result, key, copy.deepcopy(value, memo))
+        return result
 
     def _ipython_display_(self, include=None, exclude=None):
         """

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1261,6 +1261,10 @@ class CodeAgent(MultiStepAgent):
                     Text(execution_logs),
                 ]
             observation = "Execution logs:\n" + execution_logs
+            if isinstance(output, AgentImage):
+                memory_step.observations_images = [output]
+                output = output.to_string()
+
         except Exception as e:
             if hasattr(self.python_executor, "state") and "_print_outputs" in self.python_executor.state:
                 execution_logs = str(self.python_executor.state["_print_outputs"])


### PR DESCRIPTION
CodeAct currently supports images only as inputs. This PR adds images as step outputs. So, an agent will be able to understand images with the right tools.

The "deepcopy" part of the PR fixes problems with copying Pillow images, since it is needed [here](https://github.com/huggingface/smolagents/blob/main/src/smolagents/models.py#L203).

A tool example:

```
import requests
from PIL import Image
from smolagents.agent_types import AgentImage

def show_image(url: str) -> AgentImage:
    """
    Reads an image from the specified URL using PIL.
    Always call this function at the end of the code block.

    Returns an image.
    Args:
        url: URL of an image
    """
    response = requests.get(path)
    response.raise_for_status()
    return AgentImage(response.content)
```

How it works in the end:

<img width="1261" alt="изображение" src="https://github.com/user-attachments/assets/593f59a1-d14e-4238-b598-9718ba38142f" />
