### PR TITLE
Fix AzureOpenAIServerModel to not call openai.OpenAI

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,7 @@ import pytest
 from transformers.testing_utils import get_tests_dir
 
 from smolagents.models import (
+    AzureOpenAIServerModel,
     ChatMessage,
     HfApiModel,
     LiteLLMModel,
@@ -200,6 +201,38 @@ class TestOpenAIServerModel:
             MockOpenAI.assert_called_once_with(
                 base_url=api_base, api_key=api_key, organization=organization, project=project, max_retries=5
             )
+
+
+class TestAzureOpenAIServerModel:
+    def test_client_kwargs_passed_correctly(self):
+        model_id = "gpt-3.5-turbo"
+        api_key = "test_api_key"
+        api_version = "2023-12-01-preview"
+        azure_endpoint = "https://example-resource.azure.openai.com/"
+        organization = "test_org"
+        project = "test_project"
+        client_kwargs = {"max_retries": 5}
+
+        with patch("openai.OpenAI") as MockOpenAI, patch("openai.AzureOpenAI") as MockAzureOpenAI:
+            _ = AzureOpenAIServerModel(
+                model_id=model_id,
+                api_key=api_key,
+                api_version=api_version,
+                azure_endpoint=azure_endpoint,
+                organization=organization,
+                project=project,
+                client_kwargs=client_kwargs,
+            )
+        assert MockOpenAI.call_count == 0
+        MockAzureOpenAI.assert_called_once_with(
+            base_url=None,
+            api_key=api_key,
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+            organization=organization,
+            project=project,
+            max_retries=5,
+        )
 
 
 def test_get_clean_message_list_basic():


### PR DESCRIPTION
Fix `AzureOpenAIServerModel` to not call `openai.OpenAI`.

Note that before this PR:
- `AzureOpenAIServerModel` calls `super().__init__`
- `OpenAIServerModel` instantiates `openai.OpenAI`, which is not required
- Then, `AzureOpenAIServerModel` instantiates `openai.AzureOpenAI`, the only required client

This PR fixes `AzureOpenAIServerModel` so it does not call `openai.OpenAI`, reducing latency.