### PR TITLE
Added quantization_config parameter to TransformersModel

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -24,6 +24,7 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from transformers import QuantizationConfigMixin
 
 from huggingface_hub.utils import is_torch_available
 
@@ -608,6 +609,8 @@ class TransformersModel(Model):
             The torch_dtype to initialize your model with.
         trust_remote_code (bool, default `False`):
             Some models on the Hub require running remote code: for this model, you would have to set this flag to True.
+        quantization_config: Optional[QuantizationConfigMixin] = None,
+            Abstract class of the HuggingFace quantizer. Supports for now quantizing HF transformers models for inference and/or quantization.
         kwargs (dict, *optional*):
             Any additional keyword arguments that you want to use in model.generate(), for instance `max_new_tokens` or `device`.
         **kwargs:
@@ -636,6 +639,7 @@ class TransformersModel(Model):
         device_map: Optional[str] = None,
         torch_dtype: Optional[str] = None,
         trust_remote_code: bool = False,
+        quantization_config: Optional[QuantizationConfigMixin] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -675,6 +679,7 @@ class TransformersModel(Model):
                 device_map=device_map,
                 torch_dtype=torch_dtype,
                 trust_remote_code=trust_remote_code,
+                quantization_config=quantization_config,
             )
             self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         except ValueError as e:


### PR DESCRIPTION
Transformers support quantization using the following parameter:

```
    quantization_config = BitsAndBytesConfig(load_in_8bit=True)
    self.model = AutoModelForCausalLM.from_pretrained(
        model_id,
        device_map=device_map,
        torch_dtype=torch_dtype,
        trust_remote_code=trust_remote_code,
        quantization_config=quantization_config,
    )
```

This transformers feature was not supported in TransformersModel, because it did not pass the `quantization_config` parameter.