### PR TITLE
Support passing env variables to docker executor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -167,6 +167,7 @@ class DockerExecutor(RemotePythonExecutor):
         logger,
         host: str = "127.0.0.1",
         port: int = 8888,
+        environment: Dict[str, str] = None,
     ):
         """
         Initialize the Docker-based Jupyter Kernel Gateway executor.
@@ -209,7 +210,7 @@ CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGat
 
             self.logger.log(f"Starting container on {host}:{port}...", level=LogLevel.INFO)
             self.container = self.client.containers.run(
-                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True
+                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True, environment=environment
             )
 
             retries = 0

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -167,7 +167,7 @@ class DockerExecutor(RemotePythonExecutor):
         logger,
         host: str = "127.0.0.1",
         port: int = 8888,
-        environment: Dict[str, str] = None,
+        environment_variables: Dict[str, str] = None,
     ):
         """
         Initialize the Docker-based Jupyter Kernel Gateway executor.
@@ -210,7 +210,7 @@ CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGat
 
             self.logger.log(f"Starting container on {host}:{port}...", level=LogLevel.INFO)
             self.container = self.client.containers.run(
-                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True, environment=environment
+                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True, environment=environment_variables
             )
 
             retries = 0

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -35,7 +35,11 @@ class TestE2BExecutorMock:
 
 @pytest.fixture
 def docker_executor():
-    executor = DockerExecutor(additional_imports=["pillow", "numpy"], logger=AgentLogger(level=LogLevel.INFO))
+    executor = DockerExecutor(
+        additional_imports=["pillow", "numpy"],
+        logger=AgentLogger(level=LogLevel.INFO),
+        environment={"TEST_ENV": "TEST123"},
+    )
     yield executor
     executor.delete()
 
@@ -58,6 +62,15 @@ class TestDockerExecutor:
         code_action = "print(np.sqrt(a))"
         result, logs, final_answer = self.executor(code_action)
         assert "1.41421" in logs
+
+    def test_environment_variables(self):
+        """Test that custom environment variables are added to the container"""
+        code_action = dedent("""
+            import os
+            print(os.environ.get("TEST_ENV", ""))
+        """)
+        result, logs, final_answer = self.executor(code_action)
+        assert "TEST123" in logs
 
     def test_execute_output(self):
         """Test execution that returns a string"""

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -38,7 +38,7 @@ def docker_executor():
     executor = DockerExecutor(
         additional_imports=["pillow", "numpy"],
         logger=AgentLogger(level=LogLevel.INFO),
-        environment={"TEST_ENV": "TEST123"},
+        environment_variables={"TEST_ENV": "TEST123"},
     )
     yield executor
     executor.delete()


### PR DESCRIPTION
This PR adds support for passing environment variables to remote docker executor. For example, this solves a problem where you have a tool which requires an api key environment variable.
https://github.com/huggingface/smolagents/issues/939