### PR TITLE
Fix Agent.from_hub for older smolagents exports

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1180,24 +1180,24 @@ class CodeAgent(MultiStepAgent):
             )
         self.executor_type = executor_type or "local"
         self.executor_kwargs = executor_kwargs or {}
-        self.python_executor = self.create_python_executor(executor_type, self.executor_kwargs)
+        self.python_executor = self.create_python_executor()
 
-    def create_python_executor(self, executor_type: str, kwargs: Dict[str, Any]) -> PythonExecutor:
-        match executor_type:
+    def create_python_executor(self) -> PythonExecutor:
+        match self.executor_type:
             case "e2b" | "docker":
                 if self.managed_agents:
                     raise Exception("Managed agents are not yet supported with remote code execution.")
-                if executor_type == "e2b":
-                    return E2BExecutor(self.additional_authorized_imports, self.logger, **kwargs)
+                if self.executor_type == "e2b":
+                    return E2BExecutor(self.additional_authorized_imports, self.logger, **self.executor_kwargs)
                 else:
-                    return DockerExecutor(self.additional_authorized_imports, self.logger, **kwargs)
+                    return DockerExecutor(self.additional_authorized_imports, self.logger, **self.executor_kwargs)
             case "local":
                 return LocalPythonExecutor(
                     self.additional_authorized_imports,
                     max_print_outputs_length=self.max_print_outputs_length,
                 )
             case _:  # if applicable
-                raise ValueError(f"Unsupported executor type: {executor_type}")
+                raise ValueError(f"Unsupported executor type: {self.executor_type}")
 
     def initialize_system_prompt(self) -> str:
         system_prompt = populate_template(

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -936,9 +936,9 @@ You have been provided with these additional arguments, that you can access usin
         )
         if cls.__name__ == "CodeAgent":
             args["additional_authorized_imports"] = agent_dict["authorized_imports"]
-            args["executor_type"] = agent_dict["executor_type"]
-            args["executor_kwargs"] = agent_dict["executor_kwargs"]
-            args["max_print_outputs_length"] = agent_dict["max_print_outputs_length"]
+            args["executor_type"] = agent_dict.get("executor_type")
+            args["executor_kwargs"] = agent_dict.get("executor_kwargs")
+            args["max_print_outputs_length"] = agent_dict.get("max_print_outputs_length")
         args.update(kwargs)
         return cls(**args)
 
@@ -1154,7 +1154,7 @@ class CodeAgent(MultiStepAgent):
         grammar: Optional[Dict[str, str]] = None,
         additional_authorized_imports: Optional[List[str]] = None,
         planning_interval: Optional[int] = None,
-        executor_type: str = "local",
+        executor_type: str | None = "local",
         executor_kwargs: Optional[Dict[str, Any]] = None,
         max_print_outputs_length: Optional[int] = None,
         **kwargs,
@@ -1178,7 +1178,7 @@ class CodeAgent(MultiStepAgent):
                 "Caution: you set an authorization for all imports, meaning your agent can decide to import any package it deems necessary. This might raise issues if the package is not installed in your environment.",
                 0,
             )
-        self.executor_type = executor_type
+        self.executor_type = executor_type or "local"
         self.executor_kwargs = executor_kwargs or {}
         self.python_executor = self.create_python_executor(executor_type, self.executor_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ from smolagents.agents import MultiStepAgent
 from smolagents.monitoring import LogLevel
 
 
+# Import fixture modules as plugins
+pytest_plugins = ["tests.fixtures.agents"]
+
 original_multi_step_agent_init = MultiStepAgent.__init__
 
 

--- a/tests/fixtures/agents.py
+++ b/tests/fixtures/agents.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+AGENT_DICTS = {
+    "v1.9": {
+        "tools": [],
+        "model": {
+            "class": "HfApiModel",
+            "data": {
+                "last_input_token_count": None,
+                "last_output_token_count": None,
+                "model_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+                "provider": None,
+            },
+        },
+        "managed_agents": {},
+        "prompt_templates": None,
+        "max_steps": 10,
+        "verbosity_level": 2,
+        "grammar": None,
+        "planning_interval": 2,
+        "name": "test_agent",
+        "description": "dummy description",
+        "requirements": ["smolagents"],
+        "authorized_imports": ["pandas"],
+    },
+    # Added: executor_type, executor_kwargs, max_print_outputs_length
+    "v1.10": {
+        "tools": [],
+        "model": {
+            "class": "HfApiModel",
+            "data": {
+                "last_input_token_count": None,
+                "last_output_token_count": None,
+                "model_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+                "provider": None,
+            },
+        },
+        "managed_agents": {},
+        "prompt_templates": None,
+        "max_steps": 10,
+        "verbosity_level": 2,
+        "grammar": None,
+        "planning_interval": 2,
+        "name": "test_agent",
+        "description": "dummy description",
+        "requirements": ["smolagents"],
+        "authorized_imports": ["pandas"],
+        "executor_type": "local",
+        "executor_kwargs": {},
+        "max_print_outputs_length": None,
+    },
+}
+
+
+@pytest.fixture
+def get_agent_dict():
+    def _get_agent_dict(agent_dict_key):
+        return AGENT_DICTS[agent_dict_key]
+
+    return _get_agent_dict


### PR DESCRIPTION
Fix Agent.from_hub for agents exported in previous `smolagents` versions.

Currently they raise:
> KeyError: 'executor_type'

The functionality to share agents to the Hub was introduced in smolagents-1.9.0:
- #533

However, agents exported with smolagents-1.9.0 are no longer importable with smolagents-1.10.0 after:
- #645
- #733 

This PR allows importing agents exported either with v1.9 or v1.10.

Fix #978.