### PR TITLE
Regression fix: ChatMessageToolCall id must be a string

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -249,7 +249,7 @@ def get_tool_call_chat_message_from_text(text: str, tool_name_key: str, tool_arg
         content=text,
         tool_calls=[
             ChatMessageToolCall(
-                id=uuid.uuid4(),
+                id=str(uuid.uuid4()),
                 type="function",
                 function=ChatMessageToolCallDefinition(name=tool_name, arguments=tool_arguments),
             )


### PR DESCRIPTION
@aymeric-roucher 

Fixes a regression introduced here: https://github.com/huggingface/smolagents/commit/e432d4190d36296456b62f358359be3bc184be34#diff-0319e64c7d0f9e302a7c7a0dd60f04dedb7d4dcf7dbe9e046543335654a9efa1R252

ID must be a string, since later on it is being added to a chat message that a json parser will fail to parse.