### PR TITLE
Draft: Add caching to MLX model

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -648,9 +648,11 @@ class MLXModel(Model):
         self.model_id = model_id
         self.model, self.tokenizer = mlx_lm.load(model_id, tokenizer_config={"trust_remote_code": trust_remote_code})
         self.stream_generate = mlx_lm.stream_generate
+        self.prompt_cache = mlx_lm.models.cache.make_prompt_cache(self.model)
         self.tool_name_key = tool_name_key
         self.tool_arguments_key = tool_arguments_key
         self.is_vlm = False  # mlx-lm doesn't support vision models
+        self._num_processed_token = 0
 
     def __call__(
         self,
@@ -677,12 +679,15 @@ class MLXModel(Model):
             tools=tools,
             add_generation_prompt=True,
         )
+        prompt_ids = prompt_ids[self._num_processed_token:]
+        self._num_processed_token += len(prompt_ids)
 
         self.last_input_token_count = len(prompt_ids)
         self.last_output_token_count = 0
         text = ""
 
-        for _ in self.stream_generate(self.model, self.tokenizer, prompt=prompt_ids, **completion_kwargs):
+        found_stop_sequence = False
+        for _ in self.stream_generate(self.model, self.tokenizer, prompt=prompt_ids, prompt_cache=self.prompt_cache, **completion_kwargs):
             self.last_output_token_count += 1
             text += _.text
             for stop_sequence in prepared_stop_sequences:

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -679,6 +679,10 @@ class MLXModel(Model):
             tools=tools,
             add_generation_prompt=True,
         )
+        if self._num_processed_token > len(prompt_ids):
+            # TODO: this only works if the new prmopt_ids is shorter than
+            # what was previously processed.
+            self._num_processed_token = 0
         prompt_ids = prompt_ids[self._num_processed_token:]
         self._num_processed_token += len(prompt_ids)
 


### PR DESCRIPTION
<details>
<summary>Run without caching:
</summary>

<img width="412" alt="image" src="https://github.com/user-attachments/assets/94401fc2-781b-4807-9e0d-309a6359777d" />

</details>



<details>
<summary>Run with caching:
</summary>

<img width="412" alt="image" src="https://github.com/user-attachments/assets/68b39aa9-37e0-4ac4-a0ea-3e8c17644905" />

</details>


Also fixes a bug with `found_stop_sequence`


EDIT: I just noticed the `sum(token)` with caching doesn't match the run without caching  ⚠️  Not sure why, my first attempt was to cache based by number of messages but that lead to different behaviour. Is there a unit test I can use?

There's another bug when multiple prompts are passed to the agent.