### PR TITLE
Always parse arguments from API tool calls

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -223,6 +223,10 @@ class VisitWebpageTool(Tool):
     }
     output_type = "string"
 
+    def __init__(self, max_output_length: int = 40000):
+        super().__init__()
+        self.max_output_length = max_output_length
+
     def forward(self, url: str) -> str:
         try:
             import re
@@ -247,7 +251,7 @@ class VisitWebpageTool(Tool):
             # Remove multiple line breaks
             markdown_content = re.sub(r"\n{3,}", "\n\n", markdown_content)
 
-            return truncate_content(markdown_content, 10000)
+            return truncate_content(markdown_content, self.max_output_length)
 
         except requests.exceptions.Timeout:
             return "The request timed out. Please try again later or check the URL."

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -811,10 +811,13 @@ class ApiModel(Model):
     def postprocess_message(self, message: ChatMessage, tools_to_call_from) -> ChatMessage:
         """Sometimes APIs fail to properly parse a tool call: this function tries to parse."""
         message.role = MessageRole.ASSISTANT  # Overwrite role if needed
-        if tools_to_call_from and not message.tool_calls:
-            message.tool_calls = [
-                get_tool_call_from_text(message.content, self.tool_name_key, self.tool_arguments_key)
-            ]
+        if tools_to_call_from:
+            if not message.tool_calls:
+                message.tool_calls = [
+                    get_tool_call_from_text(message.content, self.tool_name_key, self.tool_arguments_key)
+                ]
+            for tool_call in message.tool_calls:
+                tool_call.function.arguments = parse_json_if_needed(tool_call.function.arguments)
         return message
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -873,7 +873,6 @@ class TestToolCallingAgent(unittest.TestCase):
         mock_response.usage.prompt_tokens = 10
         mock_response.usage.completion_tokens = 20
 
-        # Create your model and test it
         model = HfApiModel(model_id="test-model")
 
         from smolagents import tool
@@ -888,7 +887,7 @@ class TestToolCallingAgent(unittest.TestCase):
             """
             return f"The weather in {location} on date:{date} is sunny."
 
-        agent = ToolCallingAgent(model=model, tools=[weather_api], max_steps=1, verbosity_level=2)
+        agent = ToolCallingAgent(model=model, tools=[weather_api], max_steps=1)
         agent.run("What's the weather in Paris?")
         assert agent.memory.steps[0].task == "What's the weather in Paris?"
         assert agent.memory.steps[1].tool_calls[0].name == "weather_api"
@@ -910,7 +909,7 @@ class TestToolCallingAgent(unittest.TestCase):
         agent.run("What's the weather in Paris?")
         assert agent.memory.steps[0].task == "What's the weather in Paris?"
         assert agent.memory.steps[1].tool_calls[0].name == "weather_api"
-        # assert agent.memory.steps[1].tool_calls[0].arguments == {"location": "Paris", "date": "today"}
+        assert agent.memory.steps[1].tool_calls[0].arguments == {"location": "Paris", "date": "today"}
         assert agent.memory.steps[1].observations == "The weather in Paris on date:today is sunny."
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -859,6 +859,61 @@ class TestMultiStepAgent:
             )
 
 
+class TestToolCallingAgent(unittest.TestCase):
+    @patch("huggingface_hub.InferenceClient")
+    def test_toolcalling_agent_api(self, mock_inference_client):
+        mock_client = mock_inference_client.return_value
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = MagicMock()
+        mock_response.choices[
+            0
+        ].message.content = '{"name": "weather_api", "arguments": {"location": "Paris", "date": "today"}}'
+        mock_client.chat_completion.return_value = mock_response
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 20
+
+        # Create your model and test it
+        model = HfApiModel(model_id="test-model")
+
+        from smolagents import tool
+
+        @tool
+        def weather_api(location: str, date: str) -> str:
+            """
+            Gets the weather in the next days at given location.
+            Args:
+                location: the location
+                date: the date
+            """
+            return f"The weather in {location} on date:{date} is sunny."
+
+        agent = ToolCallingAgent(model=model, tools=[weather_api], max_steps=1, verbosity_level=2)
+        agent.run("What's the weather in Paris?")
+        assert agent.memory.steps[0].task == "What's the weather in Paris?"
+        assert agent.memory.steps[1].tool_calls[0].name == "weather_api"
+        assert agent.memory.steps[1].tool_calls[0].arguments == {"location": "Paris", "date": "today"}
+        assert agent.memory.steps[1].observations == "The weather in Paris on date:today is sunny."
+
+        mock_response.choices[0].message.tool_calls = [
+            ChatMessageToolCall(
+                function=ChatMessageToolCallDefinition(
+                    name="weather_api", arguments='{"location": "Paris", "date": "today"}'
+                ),
+                id="call_0",
+                type="function",
+            )
+        ]
+        mock_response.choices[0].message.content = None
+        mock_client.chat_completion.return_value = mock_response
+
+        agent.run("What's the weather in Paris?")
+        assert agent.memory.steps[0].task == "What's the weather in Paris?"
+        assert agent.memory.steps[1].tool_calls[0].name == "weather_api"
+        # assert agent.memory.steps[1].tool_calls[0].arguments == {"location": "Paris", "date": "today"}
+        assert agent.memory.steps[1].observations == "The weather in Paris on date:today is sunny."
+
+
 class TestCodeAgent:
     @pytest.mark.parametrize("provide_run_summary", [False, True])
     def test_call_with_provide_run_summary(self, provide_run_summary):


### PR DESCRIPTION
Sometimes APIs return proper tool calls, but as a JSON string instead of a dictionary: this was not parsed as json using `parse_json_if_needed`, thus the usage of said args would fail.
This PR fixes it and adds a regression test.


Here is now how the API models returns are processed after this PR
```
if return has a built in tool call:
    if this tool call has incompletly parsed arguments like a string '{"location": "Paris"}' instead of the dict '{"location": "Paris"}' , parse them
    # Above line is what this PR #1000 adds
if return has no built-in tool call:
    try parsing the tool call from the return string
    if no tool call is found, fail
```