### PR TITLE
Fix custom prompt templates in Agent.from_hub

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -933,6 +933,7 @@ You have been provided with these additional arguments, that you can access usin
             planning_interval=agent_dict["planning_interval"],
             grammar=agent_dict["grammar"],
             verbosity_level=agent_dict["verbosity_level"],
+            prompt_templates=agent_dict["prompt_templates"],
         )
         if cls.__name__ == "CodeAgent":
             args["additional_authorized_imports"] = agent_dict["authorized_imports"]

--- a/tests/fixtures/agents.py
+++ b/tests/fixtures/agents.py
@@ -14,7 +14,25 @@ AGENT_DICTS = {
             },
         },
         "managed_agents": {},
-        "prompt_templates": None,
+        "prompt_templates": {
+            "system_prompt": "dummy system prompt",
+            "planning": {
+                "initial_facts": "dummy planning initial facts",
+                "initial_plan": "dummy planning initial plan",
+                "update_facts_pre_messages": "dummy planning update facts pre messages",
+                "update_facts_post_messages": "dummy planning update facts post messages",
+                "update_plan_pre_messages": "dummy planning update plan pre messages",
+                "update_plan_post_messages": "dummy planning update plan post messages",
+            },
+            "managed_agent": {
+                "task": "dummy managed agent task",
+                "report": "dummy managed agent report",
+            },
+            "final_answer": {
+                "pre_messages": "dummy final answer pre messages",
+                "post_messages": "dummy final answer post messages",
+            },
+        },
         "max_steps": 10,
         "verbosity_level": 2,
         "grammar": None,
@@ -37,7 +55,25 @@ AGENT_DICTS = {
             },
         },
         "managed_agents": {},
-        "prompt_templates": None,
+        "prompt_templates": {
+            "system_prompt": "dummy system prompt",
+            "planning": {
+                "initial_facts": "dummy planning initial facts",
+                "initial_plan": "dummy planning initial plan",
+                "update_facts_pre_messages": "dummy planning update facts pre messages",
+                "update_facts_post_messages": "dummy planning update facts post messages",
+                "update_plan_pre_messages": "dummy planning update plan pre messages",
+                "update_plan_post_messages": "dummy planning update plan post messages",
+            },
+            "managed_agent": {
+                "task": "dummy managed agent task",
+                "report": "dummy managed agent report",
+            },
+            "final_answer": {
+                "pre_messages": "dummy final answer pre messages",
+                "post_messages": "dummy final answer post messages",
+            },
+        },
         "max_steps": 10,
         "verbosity_level": 2,
         "grammar": None,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -967,6 +967,7 @@ class TestCodeAgent:
         assert mock_model.from_dict.call_args.args[0]["model_id"] == "Qwen/Qwen2.5-Coder-32B-Instruct"
         assert agent.model.model_id == "Qwen/Qwen2.5-Coder-32B-Instruct"
         assert agent.logger.level == 2
+        assert agent.prompt_templates["system_prompt"] == "dummy system prompt"
 
 
 class MultiAgentsTests(unittest.TestCase):


### PR DESCRIPTION
Fix prompt templates in Agent.from_hub.

Currently, custom `prompt_templates` are exported but ignored when importing and the default ones are used instead.