### PR TITLE
Support JSON string arguments in tool calls

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -145,7 +145,7 @@ def parse_json_blob(json_blob: str) -> Tuple[Dict[str, str], str]:
     try:
         first_accolade_index = json_blob.find("{")
         last_accolade_index = [a.start() for a in list(re.finditer("}", json_blob))][-1]
-        json_data = json_blob[first_accolade_index : last_accolade_index + 1].replace('\\"', "'")
+        json_data = json_blob[first_accolade_index : last_accolade_index + 1]
         json_data = json.loads(json_data, strict=False)
         return json_data, json_blob[:first_accolade_index]
     except json.JSONDecodeError as e:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -391,6 +391,11 @@ class TestGetToolCallFromText:
         result = get_tool_call_from_text(text, "name", "arguments")
         assert result.function.arguments == {"city": "New York"}
 
+    def test_get_tool_call_from_text_json_string_args(self):
+        text = '{"name": "weather_tool", "arguments": "{\\"city\\": \\"New York\\"}"}'
+        result = get_tool_call_from_text(text, "name", "arguments")
+        assert result.function.arguments == {"city": "New York"}
+
     def test_get_tool_call_from_text_missing_args(self):
         text = '{"name": "weather_tool"}'
         result = get_tool_call_from_text(text, "name", "arguments")


### PR DESCRIPTION
Support JSON string arguments in tool calls.

This PR adds support for handling tool call arguments that are provided as a JSON string. When a tool call's arguments are passed as a JSON-encoded string rather than a direct JSON object, the function now properly parses this string into a Python object.

For example, arguments can now be passed in these two formats:
- As a direct JSON object: `"arguments": {"city": "New York"}`
- As a JSON string: `"arguments": "{\\"city\\": \\"New York\\"}"`

Both formats will result in proper Python objects in the tool call result.

Fix `parse_json_blob`.

See discussion in: https://github.com/huggingface/smolagents/pull/1000#discussion_r1998082112