### PR TITLE
AITS-197: Add state persistence for smolagents

### DIFF
--- a/docs/persistent_agent.md
+++ b/docs/persistent_agent.md
@@ -1,0 +1,97 @@
+# PersistentCodeAgent
+
+The `PersistentCodeAgent` is an extension of the `CodeAgent` class that adds state persistence capabilities, allowing you to pause and resume agent execution.
+
+## Features
+
+- **Pause Execution**: Pause the agent at any point during execution and save its state
+- **Resume Execution**: Restore a previously paused agent and continue execution from where it left off
+- **Stop Execution**: Gracefully stop agent execution
+- **OpenTelemetry Context Preservation**: Save and restore OTEL context for tracing
+
+## Use Cases
+
+- **Human-in-the-loop interactions**: Pause agent execution to get human input, then resume
+- **Post-processing of agent workflows**: Save intermediate states for later analysis
+- **Recovery from failures or interruptions**: Restore agent state after system failures
+- **Long-running agent sessions**: Support sessions that span multiple interactions
+
+## Usage
+
+### Basic Usage
+
+```python
+from smolagents import PersistentCodeAgent, Tool
+from smolagents.utils import AgentPausedException, AgentStoppedException
+
+# Create a PersistentCodeAgent
+agent = PersistentCodeAgent(
+    tools=[...],
+    model=your_model,
+    storage_path="/path/to/save/agent_state.pkl"  # Optional, defaults to ./agent_state.pkl
+)
+
+# Run the agent
+result = agent.run("Your task here")
+```
+
+### Pausing and Resuming
+
+You can pause the agent by raising an `AgentPausedException` from a callback or tool:
+
+```python
+class PauseTool(Tool):
+    name = "pause_agent"
+    description = "Pauses the agent execution for later resumption"
+    
+    def __call__(self, agent=None):
+        if agent:
+            # Optionally capture OTEL context
+            otel_context = get_current_otel_context()
+            raise AgentPausedException("Agent paused", agent.logger, None, otel_context)
+        return "Agent would be paused if running in an agent context"
+
+# Later, to resume:
+resumed_agent = PersistentCodeAgent.resume_execution(
+    "/path/to/save/agent_state.pkl",
+    otel_context_handler=restore_otel_context  # Optional function to restore OTEL context
+)
+
+# Continue execution
+result = resumed_agent.run(resumed_agent.task, reset=False)
+```
+
+### Stopping
+
+To gracefully stop the agent:
+
+```python
+class StopTool(Tool):
+    name = "stop_agent"
+    description = "Stops the agent execution"
+    
+    def __call__(self, agent=None):
+        if agent:
+            raise AgentStoppedException("Agent stopped", agent.logger)
+        return "Agent would be stopped if running in an agent context"
+```
+
+## Implementation Details
+
+The `PersistentCodeAgent` uses [cloudpickle](https://github.com/cloudpipe/cloudpickle) for serialization, which provides better support for pickling Python constructs compared to the standard `pickle` module.
+
+When an agent is paused:
+1. The agent state is captured, including memory, tools, and execution context
+2. OpenTelemetry context is saved (if provided)
+3. The state is serialized to disk using cloudpickle
+4. A message is returned indicating the agent was paused
+
+When resuming:
+1. The serialized state is loaded from disk
+2. The agent is reconstructed with all its previous state
+3. OpenTelemetry context is restored (if a handler is provided)
+4. Execution can continue from where it left off
+
+## Example
+
+See the [persistent_agent_example.py](../examples/persistent_agent_example.py) file for a complete example of using the `PersistentCodeAgent` with pause and resume functionality.

--- a/examples/persistent_agent_example.py
+++ b/examples/persistent_agent_example.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example demonstrating the PersistentCodeAgent with pause and resume functionality.
+"""
+
+import os
+import time
+from typing import Dict, List
+
+from smolagents import PersistentCodeAgent, Tool, ActionStep
+from smolagents.utils import AgentPausedException, AgentStoppedException
+
+# Mock model for demonstration purposes
+def mock_model(messages: List[Dict[str, str]]):
+    class MockMessage:
+        def __init__(self, content):
+            self.content = content
+    
+    # Return a simple Python code that will trigger our pause/stop logic
+    return MockMessage("""
+```python
+# This is a simple example to demonstrate pause/stop functionality
+import time
+
+print("Starting execution...")
+time.sleep(1)
+
+# This will trigger the pause callback after 3 steps
+if step_number == 3:
+    print("About to pause execution")
+    raise_pause_exception()
+
+# This will trigger the stop callback after 5 steps
+if step_number == 5:
+    print("About to stop execution")
+    raise_stop_exception()
+
+print(f"Completed step {step_number}")
+```
+""")
+
+# Custom tools for pausing and stopping the agent
+class PauseTool(Tool):
+    name = "raise_pause_exception"
+    description = "Pauses the agent execution for later resumption"
+    
+    def __call__(self, agent=None):
+        if agent:
+            # In a real implementation, you might want to capture OTEL context here
+            otel_context = {"trace_id": "mock-trace-id", "span_id": "mock-span-id"}
+            raise AgentPausedException("Agent paused by user request", agent.logger, None, otel_context)
+        return "Agent would be paused if running in an agent context"
+
+class StopTool(Tool):
+    name = "raise_stop_exception"
+    description = "Stops the agent execution"
+    
+    def __call__(self, agent=None):
+        if agent:
+            raise AgentStoppedException("Agent stopped by user request", agent.logger)
+        return "Agent would be stopped if running in an agent context"
+
+# Custom callback to track steps and demonstrate pause/resume
+def step_callback(memory_step: ActionStep, agent=None):
+    print(f"Step {memory_step.step_number} completed")
+    # Access step_number in the agent's Python environment
+    if agent and hasattr(agent, "python_executor"):
+        agent.python_executor.send_variables({"step_number": memory_step.step_number})
+
+def main():
+    # Create storage path
+    storage_path = os.path.join(os.getcwd(), "agent_state.pkl")
+    
+    # Create tools
+    tools = [PauseTool(), StopTool()]
+    
+    # Create agent
+    agent = PersistentCodeAgent(
+        tools=tools,
+        model=mock_model,
+        storage_path=storage_path,
+        step_callbacks=[step_callback],
+        additional_authorized_imports=["time"],
+    )
+    
+    try:
+        # Run the agent - it will pause at step 3
+        print("\n=== Starting agent execution ===")
+        result = agent.run("Execute a task with pause and resume capability")
+        print(f"Result: {result}")
+    except Exception as e:
+        print(f"Agent execution interrupted: {str(e)}")
+    
+    # Check if the agent state was saved
+    if os.path.exists(storage_path):
+        print(f"\n=== Agent state saved to {storage_path} ===")
+        
+        # Wait a moment to simulate time passing
+        time.sleep(2)
+        
+        # Resume the agent
+        print("\n=== Resuming agent execution ===")
+        resumed_agent = PersistentCodeAgent.resume_execution(storage_path)
+        
+        try:
+            # Continue execution - it will stop at step 5
+            result = resumed_agent.run(resumed_agent.task, reset=False)
+            print(f"Final result: {result}")
+        except Exception as e:
+            print(f"Resumed agent execution interrupted: {str(e)}")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
   "pillow>=11.0.0",
   "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
-  "python-dotenv"
+  "python-dotenv",
+  "cloudpickle>=3.0.0"
 ]
 
 [project.optional-dependencies]

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -24,6 +24,7 @@ from .local_python_executor import *
 from .memory import *
 from .models import *
 from .monitoring import *
+from .persistent_agent import *
 from .remote_executors import *
 from .tools import *
 from .utils import *

--- a/src/smolagents/persistent_agent.py
+++ b/src/smolagents/persistent_agent.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import cloudpickle
+
+from smolagents.agents import CodeAgent, ActionStep
+from smolagents.utils import AgentExecutionError, AgentStoppedException, AgentPausedException
+
+
+class PersistentCodeAgent(CodeAgent):
+    """
+    An extension of CodeAgent that supports state persistence through pause and resume functionality.
+    
+    This agent can handle two special exceptions:
+    - AgentStoppedException: Gracefully stops execution
+    - AgentPausedException: Pauses execution and saves the agent state for later resumption
+    
+    Args:
+        storage_path (`str`, *optional*): Path where agent state will be saved when paused.
+            Defaults to a temporary file in the current directory.
+        **kwargs: All arguments accepted by CodeAgent.
+    """
+    
+    def __init__(
+        self,
+        tools: List[Any],
+        model: Callable[[List[Dict[str, str]]], Any],
+        storage_path: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(tools=tools, model=model, **kwargs)
+        self.storage_path = storage_path or os.path.join(os.getcwd(), "agent_state.pkl")
+    
+    def step(self, memory_step: ActionStep) -> Union[None, Any]:
+        """
+        Perform one step in the ReAct framework with support for pause/stop exceptions.
+        
+        This method extends the CodeAgent step method to handle AgentStoppedException
+        and AgentPausedException, which can be raised from callbacks.
+        """
+        try:
+            return super().step(memory_step)
+        except AgentStoppedException as e:
+            # Log the stop event and gracefully terminate
+            self.logger.log(f"Agent execution stopped: {e.message}", level=0)
+            return f"Agent execution stopped: {e.message}"
+        except AgentPausedException as e:
+            # Save the agent state for later resumption
+            self.logger.log(f"Agent execution paused: {e.message}", level=0)
+            self._save_state(e.otel_context)
+            return f"Agent execution paused: {e.message}"
+    
+    def _save_state(self, otel_context=None):
+        """
+        Save the agent's state to the storage path using cloudpickle.
+        
+        Args:
+            otel_context: Optional OpenTelemetry context to save with the agent state.
+        """
+        state_data = {
+            "agent": self,
+            "otel_context": otel_context,
+            "timestamp": time.time(),
+        }
+        
+        try:
+            with open(self.storage_path, "wb") as f:
+                cloudpickle.dump(state_data, f)
+            self.logger.log(f"Agent state saved to {self.storage_path}", level=0)
+        except Exception as e:
+            error_msg = f"Failed to save agent state: {str(e)}"
+            self.logger.log(error_msg, level=0)
+            raise AgentExecutionError(error_msg, self.logger)
+    
+    @classmethod
+    def resume_execution(cls, storage_path: str, otel_context_handler=None):
+        """
+        Resume execution of a previously paused agent.
+        
+        Args:
+            storage_path (`str`): Path to the saved agent state file.
+            otel_context_handler (`Callable`, *optional*): Function to handle the OpenTelemetry context.
+                If provided, it will be called with the saved OTEL context.
+        
+        Returns:
+            PersistentCodeAgent: The restored agent instance.
+        
+        Raises:
+            FileNotFoundError: If the storage path does not exist.
+            AgentExecutionError: If there's an error loading the agent state.
+        """
+        if not os.path.exists(storage_path):
+            raise FileNotFoundError(f"Agent state file not found at {storage_path}")
+        
+        try:
+            with open(storage_path, "rb") as f:
+                state_data = cloudpickle.load(f)
+            
+            agent = state_data["agent"]
+            otel_context = state_data["otel_context"]
+            
+            # Restore OTEL context if a handler is provided
+            if otel_context_handler and otel_context:
+                otel_context_handler(otel_context)
+            
+            agent.logger.log(f"Agent state restored from {storage_path}", level=0)
+            return agent
+        except Exception as e:
+            raise AgentExecutionError(f"Failed to restore agent state: {str(e)}", agent.logger if 'agent' in locals() else None)

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from smolagents.memory import AgentLogger
 
 
-__all__ = ["AgentError"]
+__all__ = ["AgentError", "AgentStoppedException", "AgentPausedException"]
 
 
 @lru_cache
@@ -112,6 +112,21 @@ class AgentGenerationError(AgentError):
     """Exception raised for errors in generation in the agent"""
 
     pass
+
+
+class AgentStoppedException(AgentError):
+    """Exception raised when the agent is explicitly stopped"""
+
+    pass
+
+
+class AgentPausedException(AgentError):
+    """Exception raised when the agent is paused for later resumption"""
+
+    def __init__(self, message, logger: "AgentLogger", agent_state=None, otel_context=None):
+        super().__init__(message, logger)
+        self.agent_state = agent_state
+        self.otel_context = otel_context
 
 
 def make_json_serializable(obj: Any) -> Any:

--- a/tests/test_persistent_agent.py
+++ b/tests/test_persistent_agent.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from smolagents import PersistentCodeAgent, Tool, ActionStep
+from smolagents.utils import AgentPausedException, AgentStoppedException
+
+
+class MockMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+def mock_model(messages):
+    return MockMessage("""
+```python
+print("Test execution")
+```
+""")
+
+
+class TestPersistentCodeAgent(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.storage_path = os.path.join(self.temp_dir.name, "agent_state.pkl")
+        
+        # Create a simple agent for testing
+        self.agent = PersistentCodeAgent(
+            tools=[],
+            model=mock_model,
+            storage_path=self.storage_path,
+        )
+    
+    def tearDown(self):
+        self.temp_dir.cleanup()
+    
+    def test_agent_initialization(self):
+        """Test that the agent initializes correctly with storage path."""
+        self.assertEqual(self.agent.storage_path, self.storage_path)
+        self.assertIsInstance(self.agent, PersistentCodeAgent)
+    
+    def test_agent_stop_exception_handling(self):
+        """Test that the agent handles AgentStoppedException correctly."""
+        # Create a mock memory step
+        memory_step = ActionStep(step_number=1)
+        
+        # Mock the super().step method to raise AgentStoppedException
+        with patch('smolagents.agents.CodeAgent.step') as mock_super_step:
+            mock_super_step.side_effect = AgentStoppedException("Test stop", self.agent.logger)
+            
+            # Call the step method
+            result = self.agent.step(memory_step)
+            
+            # Verify the result contains the stop message
+            self.assertIn("Agent execution stopped", result)
+    
+    def test_agent_pause_exception_handling(self):
+        """Test that the agent handles AgentPausedException correctly."""
+        # Create a mock memory step
+        memory_step = ActionStep(step_number=1)
+        
+        # Mock the super().step method to raise AgentPausedException
+        with patch('smolagents.agents.CodeAgent.step') as mock_super_step:
+            mock_super_step.side_effect = AgentPausedException("Test pause", self.agent.logger)
+            
+            # Mock the _save_state method to avoid actual serialization
+            with patch.object(self.agent, '_save_state') as mock_save:
+                # Call the step method
+                result = self.agent.step(memory_step)
+                
+                # Verify the result contains the pause message
+                self.assertIn("Agent execution paused", result)
+                
+                # Verify _save_state was called
+                mock_save.assert_called_once()
+    
+    def test_save_and_resume_state(self):
+        """Test saving and resuming agent state."""
+        # Mock cloudpickle.dump to avoid actual serialization
+        with patch('cloudpickle.dump') as mock_dump:
+            # Save the agent state
+            self.agent._save_state({"test_context": "value"})
+            
+            # Verify cloudpickle.dump was called
+            mock_dump.assert_called_once()
+        
+        # Mock open and cloudpickle.load for resume
+        mock_state = {
+            "agent": self.agent,
+            "otel_context": {"test_context": "value"},
+            "timestamp": 123456789,
+        }
+        
+        with patch('builtins.open', MagicMock()):
+            with patch('cloudpickle.load', return_value=mock_state):
+                # Mock the otel_context_handler
+                otel_handler = MagicMock()
+                
+                # Resume the agent
+                with patch.object(self.agent.logger, 'log'):  # Mock logger.log
+                    resumed_agent = PersistentCodeAgent.resume_execution(
+                        self.storage_path, 
+                        otel_context_handler=otel_handler
+                    )
+                
+                # Verify the agent was restored
+                self.assertIsInstance(resumed_agent, PersistentCodeAgent)
+                
+                # Verify the otel_context_handler was called with the context
+                otel_handler.assert_called_once_with({"test_context": "value"})
+    
+    def test_resume_with_missing_file(self):
+        """Test resuming with a missing state file."""
+        non_existent_path = os.path.join(self.temp_dir.name, "non_existent.pkl")
+        
+        # Verify that attempting to resume from a non-existent file raises FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            PersistentCodeAgent.resume_execution(non_existent_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a PersistentCodeAgent class that extends CodeAgent with pause/resume functionality:

- Adds AgentStoppedException and AgentPausedException
- Implements state serialization using cloudpickle
- Provides a resume_execution method to restore agent state
- Includes unit tests and example code
- Adds documentation

This feature enables several important use cases:
- Human-in-the-loop interactions: Pausing agent execution to get human input, then resuming
- Post-processing of agent workflows
- Recovery from failures or interruptions
- Long-running agent sessions that can span multiple interactions