### PR TITLE
Pass trust_remote_code to transformers tokenizer/processor

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -687,7 +687,7 @@ class TransformersModel(Model):
                 torch_dtype=torch_dtype,
                 trust_remote_code=trust_remote_code,
             )
-            self.tokenizer = AutoTokenizer.from_pretrained(model_id)
+            self.tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         except ValueError as e:
             if "Unrecognized configuration class" in str(e):
                 self.model = AutoModelForImageTextToText.from_pretrained(
@@ -696,7 +696,7 @@ class TransformersModel(Model):
                     torch_dtype=torch_dtype,
                     trust_remote_code=trust_remote_code,
                 )
-                self.processor = AutoProcessor.from_pretrained(model_id)
+                self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
                 self._is_vlm = True
             else:
                 raise e

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -267,6 +267,8 @@ class TestTransformersModel:
                 "trust_remote_code": True,
             }
             assert model.tokenizer == mocks["transformers.AutoTokenizer.from_pretrained"].return_value
+            assert mocks["transformers.AutoTokenizer.from_pretrained"].call_args.args == ("test-model",)
+            assert mocks["transformers.AutoTokenizer.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
         elif "transformers.AutoProcessor.from_pretrained" in mocks:
             assert model.model == mocks["transformers.AutoModelForImageTextToText.from_pretrained"].return_value
             assert mocks["transformers.AutoModelForImageTextToText.from_pretrained"].call_args.kwargs == {
@@ -275,6 +277,8 @@ class TestTransformersModel:
                 "trust_remote_code": True,
             }
             assert model.processor == mocks["transformers.AutoProcessor.from_pretrained"].return_value
+            assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.args == ("test-model",)
+            assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
 
 
 def test_get_clean_message_list_basic():


### PR DESCRIPTION
Pass `trust_remote_code` to transformers tokenizer/processor.