### PR TITLE
Fix code using pillow required dependency

### DIFF
--- a/examples/open_deep_research/scripts/visual_qa.py
+++ b/examples/open_deep_research/scripts/visual_qa.py
@@ -6,10 +6,10 @@ import uuid
 from io import BytesIO
 from typing import Optional
 
+import PIL.Image
 import requests
 from dotenv import load_dotenv
 from huggingface_hub import InferenceClient
-from PIL import Image
 
 from smolagents import Tool, tool
 
@@ -37,7 +37,7 @@ def process_images_and_text(image_path, query, client):
     # encode images to strings which can be sent to the endpoint
     def encode_local_image(image_path):
         # load image
-        image = Image.open(image_path).convert("RGB")
+        image = PIL.Image.open(image_path).convert("RGB")
 
         # Convert the image to a base64 string
         buffer = BytesIO()
@@ -98,7 +98,7 @@ headers = {"Content-Type": "application/json", "Authorization": f"Bearer {os.get
 
 
 def resize_image(image_path):
-    img = Image.open(image_path)
+    img = PIL.Image.open(image_path)
     width, height = img.size
     img = img.resize((int(width / 2), int(height / 2)))
     new_image_path = f"resized_{image_path}"

--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -42,8 +42,6 @@ from typing import (
 
 from huggingface_hub.utils import is_torch_available
 
-from .utils import _is_pillow_available
-
 
 def get_imports(code: str) -> List[str]:
     """
@@ -379,7 +377,7 @@ _BASE_TYPE_MAPPING = {
 def _get_json_schema_type(param_type: str) -> Dict[str, str]:
     if param_type in _BASE_TYPE_MAPPING:
         return copy(_BASE_TYPE_MAPPING[param_type])
-    if str(param_type) == "Image" and _is_pillow_available():
+    if str(param_type) == "Image":
         from PIL.Image import Image
 
         if param_type == Image:

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -24,8 +24,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Tuple
 
+import PIL.Image
 import requests
-from PIL import Image
 
 from .local_python_executor import PythonExecutor
 from .monitoring import LogLevel
@@ -136,7 +136,7 @@ class E2BExecutor(RemotePythonExecutor):
                         if getattr(result, attribute_name) is not None:
                             image_output = getattr(result, attribute_name)
                             decoded_bytes = base64.b64decode(image_output.encode("utf-8"))
-                            return Image.open(BytesIO(decoded_bytes)), execution_logs
+                            return PIL.Image.open(BytesIO(decoded_bytes)), execution_logs
                     for attribute_name in [
                         "chart",
                         "data",

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -45,7 +45,7 @@ from ._function_type_hints_utils import (
 )
 from .agent_types import handle_agent_input_types, handle_agent_output_types
 from .tool_validation import MethodChecker, validate_tool_attributes
-from .utils import BASE_BUILTIN_MODULES, _is_package_available, _is_pillow_available, get_source, instance_to_source
+from .utils import BASE_BUILTIN_MODULES, _is_package_available, get_source, instance_to_source
 
 
 logger = logging.getLogger(__name__)
@@ -535,11 +535,9 @@ class Tool:
 
             def sanitize_argument_for_prediction(self, arg):
                 from gradio_client.utils import is_http_url_like
+                from PIL.Image import Image
 
-                if _is_pillow_available():
-                    from PIL.Image import Image
-
-                if _is_pillow_available() and isinstance(arg, Image):
+                if isinstance(arg, Image):
                     temp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
                     arg.save(temp_file.name)
                     arg = temp_file.name

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -45,11 +45,6 @@ def _is_package_available(package_name: str) -> bool:
         return False
 
 
-@lru_cache
-def _is_pillow_available():
-    return importlib.util.find_spec("PIL") is not None
-
-
 BASE_BUILTIN_MODULES = [
     "collections",
     "datetime",

--- a/src/smolagents/vision_web_browser.py
+++ b/src/smolagents/vision_web_browser.py
@@ -3,8 +3,8 @@ from io import BytesIO
 from time import sleep
 
 import helium
+import PIL.Image
 from dotenv import load_dotenv
-from PIL import Image
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -57,7 +57,7 @@ def save_screenshot(memory_step: ActionStep, agent: CodeAgent) -> None:
             if isinstance(previous_memory_step, ActionStep) and previous_memory_step.step_number <= current_step - 2:
                 previous_memory_step.observations_images = None
         png_bytes = driver.get_screenshot_as_png()
-        image = Image.open(BytesIO(png_bytes))
+        image = PIL.Image.open(BytesIO(png_bytes))
         print(f"Captured a browser screenshot: {image.size} pixels")
         memory_step.observations_images = [image.copy()]  # Create a copy to ensure it persists, important!
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -315,10 +315,10 @@ class AgentTests(unittest.TestCase):
         assert agent.memory.steps[2].model_output is None
 
     def test_toolcalling_agent_handles_image_tool_outputs(self):
-        from PIL import Image
+        import PIL.Image
 
         @tool
-        def fake_image_generation_tool(prompt: str) -> Image.Image:
+        def fake_image_generation_tool(prompt: str) -> PIL.Image.Image:
             """Tool that generates an image.
 
             Args:
@@ -326,22 +326,22 @@ class AgentTests(unittest.TestCase):
             """
             from pathlib import Path
 
-            from PIL import Image
+            import PIL.Image
 
-            return Image.open(Path("tests/fixtures/000000039769.png"))
+            return PIL.Image.open(Path("tests/fixtures/000000039769.png"))
 
         agent = ToolCallingAgent(tools=[fake_image_generation_tool], model=FakeToolCallModelImage())
         output = agent.run("Make me an image.")
         assert isinstance(output, AgentImage)
-        assert isinstance(agent.state["image.png"], Image.Image)
+        assert isinstance(agent.state["image.png"], PIL.Image.Image)
 
     def test_toolcalling_agent_handles_image_inputs(self):
-        from PIL import Image
+        import PIL.Image
 
-        image = Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png")  # dummy input
+        image = PIL.Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png")  # dummy input
 
         @tool
-        def fake_image_understanding_tool(prompt: str, image: Image.Image) -> str:
+        def fake_image_understanding_tool(prompt: str, image: PIL.Image.Image) -> str:
             """Tool that creates a caption for an image.
 
             Args:

--- a/tests/test_final_answer.py
+++ b/tests/test_final_answer.py
@@ -17,7 +17,7 @@ import unittest
 from pathlib import Path
 
 import numpy as np
-from PIL import Image
+import PIL.Image
 from transformers import is_torch_available
 from transformers.testing_utils import get_tests_dir, require_torch
 
@@ -46,7 +46,9 @@ class FinalAnswerToolTester(unittest.TestCase, ToolTesterMixin):
 
     def create_inputs(self):
         inputs_text = {"answer": "Text input"}
-        inputs_image = {"answer": Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png").resize((512, 512))}
+        inputs_image = {
+            "answer": PIL.Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png").resize((512, 512))
+        }
         inputs_audio = {"answer": torch.Tensor(np.ones(3000))}
         return {"string": inputs_text, "image": inputs_image, "audio": inputs_audio}
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -96,9 +96,9 @@ class ModelTests(unittest.TestCase):
         assert output == "assistant\nHello"
 
     def test_transformers_message_vl_no_tool(self):
-        from PIL import Image
+        import PIL.Image
 
-        img = Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png")
+        img = PIL.Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png")
         model = TransformersModel(
             model_id="llava-hf/llava-interleave-qwen-0.5b-hf",
             max_new_tokens=5,

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -2,8 +2,8 @@ from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
 import docker
+import PIL.Image
 import pytest
-from PIL import Image
 
 from smolagents.monitoring import AgentLogger, LogLevel
 from smolagents.remote_executors import DockerExecutor, E2BExecutor
@@ -81,7 +81,7 @@ class TestDockerExecutor:
             final_answer(image)
         """)
         result, logs, final_answer = self.executor(code_action)
-        assert isinstance(result, Image.Image), "Result should be a PIL Image"
+        assert isinstance(result, PIL.Image.Image), "Result should be a PIL Image"
 
     def test_syntax_error_handling(self):
         """Test handling of syntax errors"""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,9 +22,10 @@ from unittest.mock import MagicMock, patch
 
 import mcp
 import numpy as np
+import PIL.Image
 import pytest
 import torch
-from transformers import is_torch_available, is_vision_available
+from transformers import is_torch_available
 from transformers.testing_utils import get_tests_dir
 
 from smolagents.agent_types import _AGENT_TYPE_MAPPING, AgentAudio, AgentImage, AgentText
@@ -36,9 +37,6 @@ from .utils.markers import require_run_all
 if is_torch_available():
     import torch
 
-if is_vision_available():
-    from PIL import Image
-
 
 def create_inputs(tool_inputs: Dict[str, Dict[Union[str, type], str]]):
     inputs = {}
@@ -49,7 +47,9 @@ def create_inputs(tool_inputs: Dict[str, Dict[Union[str, type], str]]):
         if input_type == "string":
             inputs[input_name] = "Text input"
         elif input_type == "image":
-            inputs[input_name] = Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png").resize((512, 512))
+            inputs[input_name] = PIL.Image.open(Path(get_tests_dir("fixtures")) / "000000039769.png").resize(
+                (512, 512)
+            )
         elif input_type == "audio":
             inputs[input_name] = np.ones(3000)
         else:
@@ -61,7 +61,7 @@ def create_inputs(tool_inputs: Dict[str, Dict[Union[str, type], str]]):
 def output_type(output):
     if isinstance(output, (str, AgentText)):
         return "string"
-    elif isinstance(output, (Image.Image, AgentImage)):
+    elif isinstance(output, (PIL.Image.Image, AgentImage)):
         return "image"
     elif isinstance(output, (torch.Tensor, AgentAudio)):
         return "audio"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -18,11 +18,10 @@ import unittest
 import uuid
 from pathlib import Path
 
-from PIL import Image
+import PIL.Image
 from transformers.testing_utils import (
     require_soundfile,
     require_torch,
-    require_vision,
 )
 
 from smolagents.agent_types import AgentAudio, AgentImage, AgentText
@@ -70,7 +69,6 @@ class AgentAudioTests(unittest.TestCase):
         self.assertEqual(agent_type.to_string(), path)
 
 
-@require_vision
 @require_torch
 class AgentImageTests(unittest.TestCase):
     def test_from_tensor(self):
@@ -83,7 +81,7 @@ class AgentImageTests(unittest.TestCase):
         # Ensure that the tensor and the agent_type's tensor are the same
         self.assertTrue(torch.allclose(tensor, agent_type._tensor, atol=1e-4))
 
-        self.assertIsInstance(agent_type.to_raw(), Image.Image)
+        self.assertIsInstance(agent_type.to_raw(), PIL.Image.Image)
 
         # Ensure the path remains even after the object deletion
         del agent_type
@@ -91,7 +89,7 @@ class AgentImageTests(unittest.TestCase):
 
     def test_from_string(self):
         path = Path("tests/fixtures/000000039769.png")
-        image = Image.open(path)
+        image = PIL.Image.open(path)
         agent_type = AgentImage(path)
 
         self.assertTrue(path.samefile(agent_type.to_string()))
@@ -103,7 +101,7 @@ class AgentImageTests(unittest.TestCase):
 
     def test_from_image(self):
         path = Path("tests/fixtures/000000039769.png")
-        image = Image.open(path)
+        image = PIL.Image.open(path)
         agent_type = AgentImage(image)
 
         self.assertFalse(path.samefile(agent_type.to_string()))


### PR DESCRIPTION
Fix code using pillow required dependency.

Note that `pillow` is a required dependency since:
- [More robust log step class, and new examples](https://github.com/huggingface/smolagents/commit/a830b1721affb59858cf59d05e54e6859d325b3b#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

This PR removes the unnecessary functions:
- `_is_pillow_available()`
- `transformers.is_vision_available()`

Additionally, this PR fixes some type hints that used `PIL.Image` (module) instead of `PIL.Image.Image` (class).