### PR TITLE
Fix double space in toolcalling_agent.yaml

### DIFF
--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -1,5 +1,5 @@
 system_prompt: |-
-  You are an expert assistant who can solve any task using  tool calls. You will be given a task to solve as best you can.
+  You are an expert assistant who can solve any task using tool calls. You will be given a task to solve as best you can.
   To do so, you have been given access to some tools.
 
   The tool call you write is an action: after the tool is executed, you will get the result of the tool call as an "observation".


### PR DESCRIPTION
This PR corrects a double space in the ToolAgent system prompt