### PR TITLE
Fix Gemma3 Compatibility Issue

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -656,7 +656,7 @@ class TransformersModel(Model):
                 "Please install 'transformers' extra to use 'TransformersModel': `pip install 'smolagents[transformers]'`"
             )
         import torch
-        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+        from transformers import AutoModel, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
 
         if not model_id:
             warnings.warn(
@@ -681,7 +681,7 @@ class TransformersModel(Model):
         logger.info(f"Using device: {device_map}")
         self._is_vlm = False
         try:
-            self.model = AutoModelForCausalLM.from_pretrained(
+            self.model = AutoModel.from_pretrained(
                 model_id,
                 device_map=device_map,
                 torch_dtype=torch_dtype,


### PR DESCRIPTION
This PR fixes the Gemma3 compatibility issue raised in https://github.com/huggingface/smolagents/issues/965

As suggested in the Issue discussion by @aymeric-roucher 

changed
```
try:
    self.model = AutoModelForCausalLM.from_pretrained(
```
to:
```
try:
    self.model = AutoModel.from_pretrained(
```

- This change fixes the issue and works with Gemma3 model

![Fix Gemma3 Compatibility Issue](https://github.com/user-attachments/assets/168707f4-4857-4f60-97b6-8f9d797e39f9)
