### PR TITLE
Fix tests of Agent.save and Tool.save

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1024,8 +1024,8 @@ class TestCodeAgent:
         assert agent.prompt_templates["system_prompt"] == "dummy system prompt"
 
 
-class MultiAgentsTests(unittest.TestCase):
-    def test_multiagents_save(self):
+class TestMultiAgents:
+    def test_multiagents_save(self, tmp_path):
         model = HfApiModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", max_tokens=2096, temperature=0.5)
 
         web_agent = ToolCallingAgent(
@@ -1045,7 +1045,7 @@ class MultiAgentsTests(unittest.TestCase):
             executor_type="local",
             executor_kwargs={"max_workers": 2},
         )
-        agent.save("agent_export")
+        agent.save(tmp_path)
 
         expected_structure = {
             "managed_agents": {
@@ -1074,10 +1074,10 @@ class MultiAgentsTests(unittest.TestCase):
                         assert file_path.exists(), f"File {file_path} does not exist"
                         assert file_path.is_file(), f"{file_path} is not a file"
 
-        verify_structure(Path("agent_export"), expected_structure)
+        verify_structure(tmp_path, expected_structure)
 
         # Test that re-loaded agents work as expected.
-        agent2 = CodeAgent.from_folder("agent_export", planning_interval=5)
+        agent2 = CodeAgent.from_folder(tmp_path, planning_interval=5)
         assert agent2.planning_interval == 5  # Check that kwargs are used
         assert set(agent2.authorized_imports) == set(["pandas", "datetime"] + BASE_BUILTIN_MODULES)
         assert agent2.max_print_outputs_length == 1000

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import os
 import tempfile
-import unittest
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -100,7 +99,7 @@ class ToolTesterMixin:
             self.assertTrue(isinstance(output, agent_type))
 
 
-class ToolTests(unittest.TestCase):
+class TestTool:
     def test_tool_init_with_decorator(self):
         @tool
         def coolfunc(a: str, b: int) -> float:
@@ -165,7 +164,7 @@ class ToolTests(unittest.TestCase):
             assert coolfunc.output_type == "number"
         assert "docstring has no description for the argument" in str(e)
 
-    def test_saving_tool_raises_error_imports_outside_function(self):
+    def test_saving_tool_raises_error_imports_outside_function(self, tmp_path):
         with pytest.raises(Exception) as e:
             import numpy as np
 
@@ -176,7 +175,7 @@ class ToolTests(unittest.TestCase):
                 """
                 return str(np.random.random())
 
-            get_current_time.save("output")
+            get_current_time.save(tmp_path)
 
         assert "np" in str(e)
 
@@ -193,7 +192,7 @@ class ToolTests(unittest.TestCase):
                     return str(np.random.random())
 
             get_current_time = GetCurrentTimeTool()
-            get_current_time.save("output")
+            get_current_time.save(tmp_path)
 
         assert "np" in str(e)
 
@@ -255,7 +254,7 @@ class ToolTests(unittest.TestCase):
         fail_tool = PassTool()
         fail_tool.to_dict()
 
-    def test_saving_tool_allows_no_imports_from_outside_methods(self):
+    def test_saving_tool_allows_no_imports_from_outside_methods(self, tmp_path):
         # Test that using imports from outside functions fails
         import numpy as np
 
@@ -274,7 +273,7 @@ class ToolTests(unittest.TestCase):
 
         fail_tool = FailTool()
         with pytest.raises(Exception) as e:
-            fail_tool.save("output")
+            fail_tool.save(tmp_path)
         assert "'np' is undefined" in str(e)
 
         # Test that putting these imports inside functions works
@@ -294,7 +293,7 @@ class ToolTests(unittest.TestCase):
                 return self.useless_method() + string_input
 
         success_tool = SuccessTool()
-        success_tool.save("output")
+        success_tool.save(tmp_path)
 
     def test_tool_missing_class_attributes_raises_error(self):
         with pytest.raises(Exception) as e:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import tempfile
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -408,7 +407,7 @@ class TestTool:
 
         assert get_weather.inputs["celsius"]["nullable"]
 
-    def test_tool_supports_any_none(self):
+    def test_tool_supports_any_none(self, tmp_path):
         @tool
         def get_weather(location: Any) -> None:
             """
@@ -419,8 +418,7 @@ class TestTool:
             """
             return
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            get_weather.save(tmp_dir)
+        get_weather.save(tmp_path)
         assert get_weather.inputs["location"]["type"] == "any"
         assert get_weather.output_type == "null"
 
@@ -439,7 +437,7 @@ class TestTool:
         assert get_weather.inputs["locations"]["type"] == "array"
         assert get_weather.inputs["months"]["type"] == "array"
 
-    def test_saving_tool_produces_valid_pyhon_code_with_multiline_description(self):
+    def test_saving_tool_produces_valid_pyhon_code_with_multiline_description(self, tmp_path):
         @tool
         def get_weather(location: Any) -> None:
             """
@@ -451,13 +449,12 @@ class TestTool:
             """
             return
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            get_weather.save(tmp_dir)
-            with open(os.path.join(tmp_dir, "tool.py"), "r", encoding="utf-8") as f:
-                source_code = f.read()
-                compile(source_code, f.name, "exec")
+        get_weather.save(tmp_path)
+        with open(os.path.join(tmp_path, "tool.py"), "r", encoding="utf-8") as f:
+            source_code = f.read()
+            compile(source_code, f.name, "exec")
 
-    def test_saving_tool_produces_valid_python_code_with_complex_name(self):
+    def test_saving_tool_produces_valid_python_code_with_complex_name(self, tmp_path):
         # Test one cannot save tool with additional args in init
         class FailTool(Tool):
             name = 'spe"\rcific'
@@ -473,11 +470,10 @@ class TestTool:
                 return "foo"
 
         fail_tool = FailTool()
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            fail_tool.save(tmp_dir)
-            with open(os.path.join(tmp_dir, "tool.py"), "r", encoding="utf-8") as f:
-                source_code = f.read()
-                compile(source_code, f.name, "exec")
+        fail_tool.save(tmp_path)
+        with open(os.path.join(tmp_path, "tool.py"), "r", encoding="utf-8") as f:
+            source_code = f.read()
+            compile(source_code, f.name, "exec")
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 import inspect
 import os
-import pathlib
-import tempfile
 import textwrap
 import unittest
 
@@ -203,7 +201,7 @@ def test_instance_to_source(tool, expected_tool_source):
     assert tool_source == expected_tool_source
 
 
-def test_e2e_class_tool_save():
+def test_e2e_class_tool_save(tmp_path):
     class TestTool(Tool):
         name = "test_tool"
         description = "Test tool description"
@@ -221,48 +219,47 @@ def test_e2e_class_tool_save():
             return task
 
     test_tool = TestTool()
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        test_tool.save(tmp_dir, make_gradio_app=True)
-        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
-        assert (
-            pathlib.Path(tmp_dir, "tool.py").read_text()
-            == """from typing import Any, Optional
-from smolagents.tools import Tool
-import IPython
+    test_tool.save(tmp_path, make_gradio_app=True)
+    assert set(os.listdir(tmp_path)) == {"requirements.txt", "app.py", "tool.py"}
+    assert (tmp_path / "tool.py").read_text() == textwrap.dedent(
+        """\
+        from typing import Any, Optional
+        from smolagents.tools import Tool
+        import IPython
 
-class TestTool(Tool):
-    name = "test_tool"
-    description = "Test tool description"
-    inputs = {'task': {'type': 'string', 'description': 'tool input'}}
-    output_type = "string"
+        class TestTool(Tool):
+            name = "test_tool"
+            description = "Test tool description"
+            inputs = {'task': {'type': 'string', 'description': 'tool input'}}
+            output_type = "string"
 
-    def forward(self, task: str):
-        import IPython  # noqa: F401
+            def forward(self, task: str):
+                import IPython  # noqa: F401
 
-        return task
+                return task
 
-    def __init__(self, *args, **kwargs):
-        self.is_initialized = False
-"""
-        )
-        requirements = set(pathlib.Path(tmp_dir, "requirements.txt").read_text().split())
-        assert requirements == {"IPython", "smolagents"}
-        assert (
-            pathlib.Path(tmp_dir, "app.py").read_text()
-            == """from smolagents import launch_gradio_demo
-from tool import TestTool
+            def __init__(self, *args, **kwargs):
+                self.is_initialized = False
+        """
+    )
+    requirements = set((tmp_path / "requirements.txt").read_text().split())
+    assert requirements == {"IPython", "smolagents"}
+    assert (tmp_path / "app.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import launch_gradio_demo
+        from tool import TestTool
 
-tool = TestTool()
+        tool = TestTool()
 
-launch_gradio_demo(tool)
-"""
-        )
+        launch_gradio_demo(tool)
+        """
+    )
 
 
-def test_e2e_ipython_class_tool_save():
+def test_e2e_ipython_class_tool_save(tmp_path):
     shell = InteractiveShell.instance()
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        code_blob = textwrap.dedent(f"""
+    code_blob = textwrap.dedent(
+        f"""\
         from smolagents.tools import Tool
         class TestTool(Tool):
             name = "test_tool"
@@ -277,46 +274,47 @@ def test_e2e_ipython_class_tool_save():
                 import IPython  # noqa: F401
 
                 return task
-        TestTool().save("{tmp_dir}", make_gradio_app=True)
-    """)
-        assert shell.run_cell(code_blob, store_history=True).success
-        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
-        assert (
-            pathlib.Path(tmp_dir, "tool.py").read_text()
-            == """from typing import Any, Optional
-from smolagents.tools import Tool
-import IPython
+        TestTool().save("{tmp_path}", make_gradio_app=True)
+        """
+    )
+    assert shell.run_cell(code_blob, store_history=True).success
+    assert set(os.listdir(tmp_path)) == {"requirements.txt", "app.py", "tool.py"}
+    assert (tmp_path / "tool.py").read_text() == textwrap.dedent(
+        """\
+        from typing import Any, Optional
+        from smolagents.tools import Tool
+        import IPython
 
-class TestTool(Tool):
-    name = "test_tool"
-    description = "Test tool description"
-    inputs = {'task': {'type': 'string', 'description': 'tool input'}}
-    output_type = "string"
+        class TestTool(Tool):
+            name = "test_tool"
+            description = "Test tool description"
+            inputs = {'task': {'type': 'string', 'description': 'tool input'}}
+            output_type = "string"
 
-    def forward(self, task: str):
-        import IPython  # noqa: F401
+            def forward(self, task: str):
+                import IPython  # noqa: F401
 
-        return task
+                return task
 
-    def __init__(self, *args, **kwargs):
-        self.is_initialized = False
-"""
-        )
-        requirements = set(pathlib.Path(tmp_dir, "requirements.txt").read_text().split())
-        assert requirements == {"IPython", "smolagents"}
-        assert (
-            pathlib.Path(tmp_dir, "app.py").read_text()
-            == """from smolagents import launch_gradio_demo
-from tool import TestTool
+            def __init__(self, *args, **kwargs):
+                self.is_initialized = False
+        """
+    )
+    requirements = set((tmp_path / "requirements.txt").read_text().split())
+    assert requirements == {"IPython", "smolagents"}
+    assert (tmp_path / "app.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import launch_gradio_demo
+        from tool import TestTool
 
-tool = TestTool()
+        tool = TestTool()
 
-launch_gradio_demo(tool)
-"""
-        )
+        launch_gradio_demo(tool)
+        """
+    )
 
 
-def test_e2e_function_tool_save():
+def test_e2e_function_tool_save(tmp_path):
     @tool
     def test_tool(task: str) -> str:
         """
@@ -329,49 +327,48 @@ def test_e2e_function_tool_save():
 
         return task
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        test_tool.save(tmp_dir, make_gradio_app=True)
-        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
-        assert (
-            pathlib.Path(tmp_dir, "tool.py").read_text()
-            == """from smolagents import Tool
-from typing import Any, Optional
+    test_tool.save(tmp_path, make_gradio_app=True)
+    assert set(os.listdir(tmp_path)) == {"requirements.txt", "app.py", "tool.py"}
+    assert (tmp_path / "tool.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import Tool
+        from typing import Any, Optional
 
-class SimpleTool(Tool):
-    name = "test_tool"
-    description = "Test tool description"
-    inputs = {"task":{"type":"string","description":"tool input"}}
-    output_type = "string"
+        class SimpleTool(Tool):
+            name = "test_tool"
+            description = "Test tool description"
+            inputs = {"task":{"type":"string","description":"tool input"}}
+            output_type = "string"
 
-    def forward(self, task: str) -> str:
-        \"""
-        Test tool description
+            def forward(self, task: str) -> str:
+                \"""
+                Test tool description
 
-        Args:
-            task: tool input
-        \"""
-        import IPython  # noqa: F401
+                Args:
+                    task: tool input
+                \"""
+                import IPython  # noqa: F401
 
-        return task"""
-        )
-        requirements = set(pathlib.Path(tmp_dir, "requirements.txt").read_text().split())
-        assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
-        assert (
-            pathlib.Path(tmp_dir, "app.py").read_text()
-            == """from smolagents import launch_gradio_demo
-from tool import SimpleTool
+                return task"""
+    )
+    requirements = set((tmp_path / "requirements.txt").read_text().split())
+    assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
+    assert (tmp_path / "app.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import launch_gradio_demo
+        from tool import SimpleTool
 
-tool = SimpleTool()
+        tool = SimpleTool()
 
-launch_gradio_demo(tool)
-"""
-        )
+        launch_gradio_demo(tool)
+        """
+    )
 
 
-def test_e2e_ipython_function_tool_save():
+def test_e2e_ipython_function_tool_save(tmp_path):
     shell = InteractiveShell.instance()
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        code_blob = textwrap.dedent(f"""
+    code_blob = textwrap.dedent(
+        f"""
         from smolagents import tool
 
         @tool
@@ -386,44 +383,45 @@ def test_e2e_ipython_function_tool_save():
 
             return task
 
-        test_tool.save("{tmp_dir}", make_gradio_app=True)
-        """)
-        assert shell.run_cell(code_blob, store_history=True).success
-        assert set(os.listdir(tmp_dir)) == {"requirements.txt", "app.py", "tool.py"}
-        assert (
-            pathlib.Path(tmp_dir, "tool.py").read_text()
-            == """from smolagents import Tool
-from typing import Any, Optional
+        test_tool.save("{tmp_path}", make_gradio_app=True)
+        """
+    )
+    assert shell.run_cell(code_blob, store_history=True).success
+    assert set(os.listdir(tmp_path)) == {"requirements.txt", "app.py", "tool.py"}
+    assert (tmp_path / "tool.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import Tool
+        from typing import Any, Optional
 
-class SimpleTool(Tool):
-    name = "test_tool"
-    description = "Test tool description"
-    inputs = {"task":{"type":"string","description":"tool input"}}
-    output_type = "string"
+        class SimpleTool(Tool):
+            name = "test_tool"
+            description = "Test tool description"
+            inputs = {"task":{"type":"string","description":"tool input"}}
+            output_type = "string"
 
-    def forward(self, task: str) -> str:
-        \"""
-        Test tool description
+            def forward(self, task: str) -> str:
+                \"""
+                Test tool description
 
-        Args:
-            task: tool input
-        \"""
-        import IPython  # noqa: F401
+                Args:
+                    task: tool input
+                \"""
+                import IPython  # noqa: F401
 
-        return task"""
-        )
-        requirements = set(pathlib.Path(tmp_dir, "requirements.txt").read_text().split())
-        assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
-        assert (
-            pathlib.Path(tmp_dir, "app.py").read_text()
-            == """from smolagents import launch_gradio_demo
-from tool import SimpleTool
+                return task"""
+    )
+    requirements = set((tmp_path / "requirements.txt").read_text().split())
+    assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
+    assert (tmp_path / "app.py").read_text() == textwrap.dedent(
+        """\
+        from smolagents import launch_gradio_demo
+        from tool import SimpleTool
 
-tool = SimpleTool()
+        tool = SimpleTool()
 
-launch_gradio_demo(tool)
-"""
-        )
+        launch_gradio_demo(tool)
+        """
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix tests of Agent.save and Tool.save.

Currently, when running the tests, they generate 2 directories in the current working directory: `agent_export` and `output`.

This PR fixes the tests so they save the Agent/Tool in a test-specific temporary directory.