### PR TITLE
feat: add py.typed marker file for type checker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ lines-after-imports = 2
 
 [tool.setuptools.package-data]
 "smolagents.prompts" = ["*.yaml"]
+"smolagents" = ["py.typed"]
 
 [project.scripts]
 smolagent = "smolagents.cli:main"


### PR DESCRIPTION
closes #1033 adding the py.typed marker file.