### PR TITLE
Fix Tool.to_dict for nullable input parameter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from smolagents.monitoring import LogLevel
 
 
 # Import fixture modules as plugins
-pytest_plugins = ["tests.fixtures.agents"]
+pytest_plugins = ["tests.fixtures.agents", "tests.fixtures.tools"]
 
 original_multi_step_agent_init = MultiStepAgent.__init__
 

--- a/tests/fixtures/tools.py
+++ b/tests/fixtures/tools.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+import pytest
+
+from smolagents.tools import Tool, tool
+
+
+@pytest.fixture
+def boolean_default_tool_class():
+    class BooleanDefaultTool(Tool):
+        name = "boolean_default_tool"
+        description = "A tool with a boolean default parameter"
+        inputs = {
+            "text": {"type": "string", "description": "Input text"},
+            "flag": {"type": "boolean", "description": "Boolean flag with default value", "nullable": True},
+        }
+        output_type = "string"
+
+        def forward(self, text: str, flag: bool = False) -> str:
+            return f"Text: {text}, Flag: {flag}"
+
+    return BooleanDefaultTool()
+
+
+@pytest.fixture
+def boolean_default_tool_function():
+    @tool
+    def boolean_default_tool(text: str, flag: bool = False) -> str:
+        """
+        A tool with a boolean default parameter.
+
+        Args:
+            text: Input text
+            flag: Boolean flag with default value
+        """
+        return f"Text: {text}, Flag: {flag}"
+
+    return boolean_default_tool
+
+
+@pytest.fixture
+def optional_input_tool_class():
+    class OptionalInputTool(Tool):
+        name = "optional_input_tool"
+        description = "A tool with an optional input parameter"
+        inputs = {
+            "required_text": {"type": "string", "description": "Required input text"},
+            "optional_text": {"type": "string", "description": "Optional input text", "nullable": True},
+        }
+        output_type = "string"
+
+        def forward(self, required_text: str, optional_text: Optional[str] = None) -> str:
+            if optional_text:
+                return f"{required_text} + {optional_text}"
+            return required_text
+
+    return OptionalInputTool()
+
+
+@pytest.fixture
+def optional_input_tool_function():
+    @tool
+    def optional_input_tool(required_text: str, optional_text: Optional[str] = None) -> str:
+        """
+        A tool with an optional input parameter.
+
+        Args:
+            required_text: Required input text
+            optional_text: Optional input text
+        """
+        if optional_text:
+            return f"{required_text} + {optional_text}"
+        return required_text
+
+    return optional_input_tool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -474,6 +474,26 @@ class TestTool:
             source_code = f.read()
             compile(source_code, f.name, "exec")
 
+    @pytest.mark.parametrize("fixture_name", ["boolean_default_tool_class", "boolean_default_tool_function"])
+    def test_to_dict_boolean_default_input(self, fixture_name, request):
+        """Test that boolean input parameter with default value is correctly represented in to_dict output"""
+        tool = request.getfixturevalue(fixture_name)
+        result = tool.to_dict()
+        # Check that the boolean default annotation is preserved
+        assert "flag: bool = False" in result["code"]
+        # Check nullable attribute is set for the parameter with default value
+        assert "'nullable': True" in result["code"]
+
+    @pytest.mark.parametrize("fixture_name", ["optional_input_tool_class", "optional_input_tool_function"])
+    def test_to_dict_optional_input(self, fixture_name, request):
+        """Test that Optional/nullable input parameter is correctly represented in to_dict output"""
+        tool = request.getfixturevalue(fixture_name)
+        result = tool.to_dict()
+        # Check the Optional type annotation is preserved
+        assert "optional_text: Optional[str] = None" in result["code"]
+        # Check that the input is marked as nullable in the code
+        assert "'nullable': True" in result["code"]
+
 
 @pytest.fixture
 def mock_server_parameters():


### PR DESCRIPTION
Fix `Tool.to_dict` for nullable input parameter.

Currently, nullable parameters are exported to dict with `nullable` value as `true`, which is not valid Python syntax.
```python
"nullable":true
```
