### PR TITLE
Bugfix: imports for telemetry

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1146,6 +1146,7 @@ __all__ = [
     "Model",
     "MLXModel",
     "TransformersModel",
+    "ApiModel",
     "HfApiModel",
     "LiteLLMModel",
     "OpenAIServerModel",


### PR DESCRIPTION
While using SmolagentsInstrumentor().instrument() this error appears:
```
File "/home/yallen/holosophos/holosophos/main_agent.py", line 76, in run_main_agent
    SmolagentsInstrumentor().instrument()
  File "/home/yallen/.local/lib/python3.11/site-packages/opentelemetry/instrumentation/instrumentor.py", line 116, in instrument
    result = self._instrument(  # pylint: disable=assignment-from-no-return
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yallen/.local/lib/python3.11/site-packages/openinference/instrumentation/smolagents/__init__.py", line 71, in _instrument
    wrap_function_wrapper(
  File "/home/yallen/.local/lib/python3.11/site-packages/wrapt/patches.py", line 114, in wrap_function_wrapper
    return wrap_object(module, name, FunctionWrapper, (wrapper,))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yallen/.local/lib/python3.11/site-packages/wrapt/patches.py", line 60, in wrap_object
    (parent, attribute, original) = resolve_path(module, name)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yallen/.local/lib/python3.11/site-packages/wrapt/patches.py", line 48, in resolve_path
    original = lookup_attribute(parent, attribute)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yallen/.local/lib/python3.11/site-packages/wrapt/patches.py", line 46, in lookup_attribute
    return getattr(parent, attribute)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'smolagents' has no attribute 'ApiModel'. Did you mean: 'HfApiModel'?
```

This PR fixes it by properly exporting ApiModel.