### PR TITLE
Set Agent/Tool requirements as a sorted list

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -795,7 +795,7 @@ You have been provided with these additional arguments, that you can access usin
             "planning_interval": self.planning_interval,
             "name": self.name,
             "description": self.description,
-            "requirements": list(requirements),
+            "requirements": sorted(requirements),
         }
         return agent_dict
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -261,7 +261,7 @@ class Tool:
 
         requirements = {el for el in get_imports(tool_code) if el not in sys.stdlib_module_names} | {"smolagents"}
 
-        return {"name": self.name, "code": tool_code, "requirements": requirements}
+        return {"name": self.name, "code": tool_code, "requirements": sorted(requirements)}
 
     def save(self, output_dir: str, tool_file_name: str = "tool", make_gradio_app: bool = True):
         """


### PR DESCRIPTION
Set Agent/Tool requirements as a sorted list.

Note that currently, tools requirements returned by `to_dict` are a set.