### PR TITLE
fix: Add resource cleanup mechanism in CodeAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1281,8 +1281,10 @@ class CodeAgent(MultiStepAgent):
 
     def cleanup(self):
         """Clean up resources used by the agent, especially Docker container resources."""
-        if hasattr(self, "python_executor") and self.executor_type == "docker":
+        try:
             self.python_executor.delete()
+        except AttributeError:
+            pass
 
     def __del__(self):
         """Ensure resources are cleaned up when the agent is garbage collected."""

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1281,20 +1281,9 @@ class CodeAgent(MultiStepAgent):
 
     def cleanup(self):
         """Clean up resources used by the agent, especially Docker container resources."""
-        try:
-            if hasattr(self, "python_executor") and self.executor_type == "docker":
-                container_id = getattr(self.python_executor, "container", None)
-                container_id = getattr(container_id, "short_id", "unknown") if container_id else "unknown"
-                self.logger.log(f"Stopping and removing container {container_id}...", level=LogLevel.INFO)
-                self.python_executor.delete()
-                self.logger.log("Container cleanup completed", level=LogLevel.INFO)
-        except Exception as e:
-            self.logger.log_error(f"Error during cleanup: {e}")
+        if hasattr(self, "python_executor") and self.executor_type == "docker":
+            self.python_executor.delete()
 
     def __del__(self):
         """Ensure resources are cleaned up when the agent is garbage collected."""
-        try:
-            self.cleanup()
-        except Exception as e:
-            # Cannot use logger here as it might already be garbage collected
-            print(f"Error during CodeAgent cleanup in __del__: {e}")
+        self.cleanup()

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1281,7 +1281,7 @@ class CodeAgent(MultiStepAgent):
 
     def cleanup(self):
         """Clean up resources used by the agent, especially Docker container resources."""
-        if self.executor_type == "docker":
+        if hasattr(self, "python_executor") and self.executor_type == "docker":
             self.python_executor.delete()
 
     def __del__(self):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1281,7 +1281,7 @@ class CodeAgent(MultiStepAgent):
 
     def cleanup(self):
         """Clean up resources used by the agent, especially Docker container resources."""
-        if hasattr(self, "python_executor") and self.executor_type == "docker":
+        if self.executor_type == "docker":
             self.python_executor.delete()
 
     def __del__(self):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -552,6 +552,35 @@ nested_answer()
         assert len(agent.memory.steps) == 2
         assert "Generation failed" in str(e)
 
+    @pytest.mark.require_run_all
+    def test_codeagent_cleanup_releases_docker_resources(self):
+        """Test if CodeAgent properly releases Docker resources when cleanup is called"""
+        # Create a simple model
+        model = MagicMock()
+        model.return_value = ChatMessage(role="assistant", content="```python\nprint('Hello, World!')\n```")
+
+        import docker
+
+        # Create Docker client
+        client = docker.from_env()
+
+        # Create CodeAgent with docker as executor
+        agent = CodeAgent(tools=[], model=model, executor_type="docker")
+
+        # Get container ID
+        container_id = agent.python_executor.container.id
+
+        # Verify container is running
+        containers = [c.id for c in client.containers.list()]
+        assert container_id in containers, "Container should be created and running"
+
+        # Directly call cleanup method instead of relying on garbage collection
+        agent.cleanup()
+
+        # Verify container has been removed
+        containers = [c.id for c in client.containers.list(all=True)]
+        assert container_id not in containers, "Docker container should be removed when CodeAgent.cleanup() is called"
+
 
 class CustomFinalAnswerTool(FinalAnswerTool):
     def forward(self, answer) -> str:


### PR DESCRIPTION
# Fix Docker Resource Leaks in CodeAgent

Added `cleanup()` and `__del__()` methods to `CodeAgent` class to properly release Docker container resources when the agent is destroyed. Otherwise, each time `CodeAgent` is used, Docker resources would need to be manually released.