### PR TITLE
feat: add custom Docker image support and enhanced configuration for DockerExecutor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -168,7 +168,7 @@ class DockerExecutor(RemotePythonExecutor):
         host: str = "127.0.0.1",
         port: int = 8888,
         image_name: str = "jupyter-kernel",
-        rebuild_image: bool = True,
+        build_new_image: bool = True,
         container_run_kwargs: Dict[str, Any] | None = None,
     ):
         """
@@ -180,7 +180,7 @@ class DockerExecutor(RemotePythonExecutor):
             host: Host to bind to.
             port: Port to bind to.
             image_name: Name of the Docker image to use. If the image doesn't exist, it will be built.
-            rebuild_image: If True, the image will be rebuilt even if it already exists.
+            build_new_image: If True, the image will be rebuilt even if it already exists.
             container_run_kwargs: Additional keyword arguments to pass to the Docker container run command.
         """
         super().__init__(additional_imports, logger)
@@ -204,17 +204,15 @@ class DockerExecutor(RemotePythonExecutor):
         # Build and start container
         try:
             # Check if image exists, unless forced to rebuild
-            build_image = rebuild_image
-            if not rebuild_image:
+            if not build_new_image:
                 try:
                     self.client.images.get(self.image_name)
                     self.logger.log(f"Using existing Docker image: {self.image_name}", level=LogLevel.INFO)
-                    build_image = False
                 except docker.errors.ImageNotFound:
                     self.logger.log(f"Image {self.image_name} not found, building...", level=LogLevel.INFO)
-                    build_image = True
+                    build_new_image = True
 
-            if build_image:
+            if build_new_image:
                 self.logger.log(f"Building Docker image {self.image_name}...", level=LogLevel.INFO)
                 dockerfile_path = Path(__file__).parent / "Dockerfile"
                 if not dockerfile_path.exists():

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -167,9 +167,19 @@ class DockerExecutor(RemotePythonExecutor):
         logger,
         host: str = "127.0.0.1",
         port: int = 8888,
+        image_name: str = "jupyter-kernel",
+        rebuild_image: bool = True,
     ):
         """
         Initialize the Docker-based Jupyter Kernel Gateway executor.
+
+        Args:
+            additional_imports: Additional imports to install.
+            logger: Logger to use.
+            host: Host to bind to.
+            port: Port to bind to.
+            image_name: Name of the Docker image to use. If the image doesn't exist, it will be built.
+            rebuild_image: If True, the image will be rebuilt even if it already exists.
         """
         super().__init__(additional_imports, logger)
         try:
@@ -181,6 +191,7 @@ class DockerExecutor(RemotePythonExecutor):
             )
         self.host = host
         self.port = port
+        self.image_name = image_name
 
         # Initialize Docker
         try:
@@ -190,11 +201,23 @@ class DockerExecutor(RemotePythonExecutor):
 
         # Build and start container
         try:
-            self.logger.log("Building Docker image...", level=LogLevel.INFO)
-            dockerfile_path = Path(__file__).parent / "Dockerfile"
-            if not dockerfile_path.exists():
-                with open(dockerfile_path, "w") as f:
-                    f.write("""FROM python:3.12-slim
+            # Check if image exists, unless forced to rebuild
+            build_image = rebuild_image
+            if not rebuild_image:
+                try:
+                    self.client.images.get(self.image_name)
+                    self.logger.log(f"Using existing Docker image: {self.image_name}", level=LogLevel.INFO)
+                    build_image = False
+                except docker.errors.ImageNotFound:
+                    self.logger.log(f"Image {self.image_name} not found, building...", level=LogLevel.INFO)
+                    build_image = True
+
+            if build_image:
+                self.logger.log(f"Building Docker image {self.image_name}...", level=LogLevel.INFO)
+                dockerfile_path = Path(__file__).parent / "Dockerfile"
+                if not dockerfile_path.exists():
+                    with open(dockerfile_path, "w") as f:
+                        f.write("""FROM python:3.12-slim
 
 RUN pip install jupyter_kernel_gateway requests numpy pandas
 RUN pip install jupyter_client notebook
@@ -202,15 +225,13 @@ RUN pip install jupyter_client notebook
 EXPOSE 8888
 CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", "--KernelGatewayApp.allow_origin='*'"]
 """)
-            _, build_logs = self.client.images.build(
-                path=str(dockerfile_path.parent), dockerfile=str(dockerfile_path), tag="jupyter-kernel"
-            )
-            self.logger.log(build_logs, level=LogLevel.DEBUG)
+                _, build_logs = self.client.images.build(
+                    path=str(dockerfile_path.parent), dockerfile=str(dockerfile_path), tag=self.image_name
+                )
+                self.logger.log(build_logs, level=LogLevel.DEBUG)
 
             self.logger.log(f"Starting container on {host}:{port}...", level=LogLevel.INFO)
-            self.container = self.client.containers.run(
-                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True
-            )
+            self.container = self.client.containers.run(self.image_name, ports={"8888/tcp": (host, port)}, detach=True)
 
             retries = 0
             while self.container.status != "running" and retries < 5:


### PR DESCRIPTION
# Add Custom Docker Image Support and Enhanced Configuration for `DockerExecutor`

## Description

This PR enhances the `DockerExecutor` class by adding the ability to specify custom Docker image names, control the image building process, and configure container runtime parameters. Previously, the executor would always build a new image with a hardcoded name ("jupyter-kernel") on initialization and had limited container configuration options.

## Changes

- Added new parameters to `DockerExecutor.__init__`:
  - `image_name`: Allows specifying a custom Docker image name (default: "jupyter-kernel")
  - `rebuild_image`: Controls whether to rebuild the image even if it exists (default: True)
  - `container_run_kwargs`: Enables passing additional keyword arguments to the Docker container run command

- Implemented image existence checking logic:
  - If `rebuild_image` is False, the executor will check if the specified image already exists
  - If the image exists, it will be used directly without rebuilding
  - If the image doesn't exist, it will be built automatically

- Allows users to customize container settings while maintaining core functionality

## Usage Example

```python
# Use existing image without rebuilding
executor = DockerExecutor(
    additional_imports=["numpy", "pandas"],
    logger=logger,
    image_name="my-custom-jupyter",
    rebuild_image=False
)

# Force rebuild of an image
executor = DockerExecutor(
    additional_imports=["numpy", "pandas"],
    logger=logger,
    image_name="jupyter-kernel",
    rebuild_image=True
)

# Use custom container configuration
executor = DockerExecutor(
    additional_imports=["numpy", "pandas"],
    logger=logger,
    container_run_kwargs={
        "extra_hosts": {"host.docker.internal": "host-gateway"},
        "environment": {
            "HTTP_PROXY": "http://host.docker.internal:7890",
            "HTTPS_PROXY": "http://host.docker.internal:7890",
        },
    }
)
```