### PR TITLE
Fix typos in Code Agent prompt

### DIFF
--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -173,7 +173,7 @@ system_prompt: |-
   Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
 planning:
   initial_plan : |-
-    You are a world express at analyzing a situation to derive facts, and plan accordingly towards solving a task.
+    You are a world expert at analyzing a situation to derive facts, and plan accordingly towards solving a task.
     Below I will present you a task. You will need to 1. build a survey of facts known or needed to solve the task, then 2. make a plan of action to solve the task.
 
     1. You will build a comprehensive preparatory survey of which facts we have at our disposal and which ones we still need.
@@ -230,7 +230,7 @@ planning:
 
     Now begin! First in part 1, list the facts that you have at your disposal, then in part 2, make a plan to solve the task.
   update_plan_pre_messages: |-
-    You are a world express at analyzing a situation to derive facts, and plan accordingly towards solving a task.
+    You are a world expert at analyzing a situation to derive facts, and plan accordingly towards solving a task.
     You have been given a task:
     ```
     {{task}}


### PR DESCRIPTION
"world express" --> "world expert"

To be honest, I'm not 100% sure what scenarios use these prompt fragments - when I run CodeAgent and view all LLM requests, including with managed agents, I don't see it ever use `planning.initial_plan` or `planning.update_plan_pre_message`. But I suppose it can't hurt to correct this typo (unless it's intentional in some 500 IQ way that I don't understand)