### PR TITLE
Make pandas a test extra dependency only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 torch = [
   "torch",
   "torchvision",
+  "numpy>=1.21.2",
 ]
 audio = [
   "soundfile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "huggingface-hub>=0.28.0",
   "requests>=2.32.3",
   "rich>=13.9.4",
-  "pandas>=2.2.3",
   "jinja2>=3.1.4",
   "pillow>=11.0.0",
   "markdownify>=0.14.1",
@@ -83,6 +82,7 @@ quality = [
 ]
 test = [
   "ipython>=8.31.0", # for interactive environment tests
+  "pandas>=2.2.3",
   "pytest>=8.1.0",
   "pytest-datadir",
   "python-dotenv>=1.0.1", # For test_all_docs

--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -19,7 +19,6 @@ import tempfile
 import uuid
 from io import BytesIO
 
-import numpy as np
 import PIL.Image
 import requests
 from huggingface_hub.utils import is_torch_available
@@ -98,6 +97,8 @@ class AgentImage(AgentType, PIL.Image.Image):
 
             if isinstance(value, torch.Tensor):
                 self._tensor = value
+            import numpy as np
+
             if isinstance(value, np.ndarray):
                 self._tensor = torch.from_numpy(value)
 
@@ -124,6 +125,8 @@ class AgentImage(AgentType, PIL.Image.Image):
             return self._raw
 
         if self._tensor is not None:
+            import numpy as np
+
             array = self._tensor.cpu().detach().numpy()
             return PIL.Image.fromarray((255 - array * 255).astype(np.uint8))
 
@@ -142,6 +145,8 @@ class AgentImage(AgentType, PIL.Image.Image):
             return self._path
 
         if self._tensor is not None:
+            import numpy as np
+
             array = self._tensor.cpu().detach().numpy()
 
             # There is likely simpler than load into image into save
@@ -175,6 +180,7 @@ class AgentAudio(AgentType, str):
             raise ModuleNotFoundError(
                 "Please install 'audio' extra to use AgentAudio: `pip install 'smolagents[audio]'`"
             )
+        import numpy as np
         import torch
 
         super().__init__(value)


### PR DESCRIPTION
Make pandas a test extra dependency only.

Note that it is not a required dependency because we don't use it in the base code. We want to be sure to support it, so we only use it in tests.

Fix #1080.