### PR TITLE
Add trust_remote_code to ToolCollection.from_mcp

### DIFF
--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -242,7 +242,7 @@ server_parameters = StdioServerParameters(
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
-with ToolCollection.from_mcp(server_parameters) as tool_collection:
+with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
     agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```
@@ -251,7 +251,7 @@ For SSE-based MCP servers, simply pass a dict with parameters to `mcp.client.sse
 ```py
 from smolagents import ToolCollection, CodeAgent
 
-with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}) as tool_collection:
+with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}, trust_remote_code=True) as tool_collection:
     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```

--- a/docs/source/hi/tutorials/tools.mdx
+++ b/docs/source/hi/tutorials/tools.mdx
@@ -241,7 +241,7 @@ server_parameters = StdioServerParameters(
     env={"UV_PYTHON": "3.12", **os.environ},
 )
 
-with ToolCollection.from_mcp(server_parameters) as tool_collection:
+with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -852,14 +852,14 @@ class ToolCollection:
         >>>     env={"UV_PYTHON": "3.12", **os.environ},
         >>> )
 
-        >>> with ToolCollection.from_mcp(server_parameters) as tool_collection:
+        >>> with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
         >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
         >>>     agent.run("Please find a remedy for hangover.")
         ```
 
         Example with an SSE MCP server:
         ```py
-        >>> with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}) as tool_collection:
+        >>> with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}, trust_remote_code=True) as tool_collection:
         >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
         >>>     agent.run("Please find a remedy for hangover.")
         ```

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -817,7 +817,7 @@ class ToolCollection:
     @classmethod
     @contextmanager
     def from_mcp(
-        cls, server_parameters: "mcp.StdioServerParameters" | dict, trust_remote_code: bool = False
+        cls, server_parameters: Union["mcp.StdioServerParameters", dict], trust_remote_code: bool = False
     ) -> "ToolCollection":
         """Automatically load a tool collection from an MCP server.
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -812,7 +812,7 @@ class ToolCollection:
 
     @classmethod
     @contextmanager
-    def from_mcp(cls, server_parameters) -> "ToolCollection":
+    def from_mcp(cls, server_parameters, trust_remote_code: bool = False) -> "ToolCollection":
         """Automatically load a tool collection from an MCP server.
 
         This method supports both SSE and Stdio MCP servers. Look at the `sever_parameters`
@@ -825,6 +825,12 @@ class ToolCollection:
             server_parameters (mcp.StdioServerParameters | dict):
                 The server parameters to use to connect to the MCP server. If a dict is
                 provided, it is assumed to be the parameters of `mcp.client.sse.sse_client`.
+            trust_remote_code (`bool`, *optional*, defaults to `False`):
+                Whether to trust the execution of code from tools defined on the MCP server.
+                This option should only be set to `True` if you trust the MCP server,
+                and undertand the risks associated with running remote code on your local machine.
+                If set to `False`, loading tools from MCP will fail.
+
 
         Returns:
             ToolCollection: A tool collection instance.
@@ -852,6 +858,11 @@ class ToolCollection:
         >>>     agent.run("Please find a remedy for hangover.")
         ```
         """
+        if not trust_remote_code:
+            raise ValueError(
+                "Loading tools from MCP requires you to acknowledge you trust the MCP server, "
+                "as it will execute code on your local machine: pass `trust_remote_code=True`."
+            )
         try:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -26,7 +26,7 @@ import types
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from huggingface_hub import (
     CommitOperationAdd,
@@ -47,6 +47,10 @@ from ._function_type_hints_utils import (
 from .agent_types import handle_agent_input_types, handle_agent_output_types
 from .tool_validation import MethodChecker, validate_tool_attributes
 from .utils import BASE_BUILTIN_MODULES, _is_package_available, get_source, instance_to_source
+
+
+if TYPE_CHECKING:
+    import mcp
 
 
 logger = logging.getLogger(__name__)
@@ -812,7 +816,9 @@ class ToolCollection:
 
     @classmethod
     @contextmanager
-    def from_mcp(cls, server_parameters, trust_remote_code: bool = False) -> "ToolCollection":
+    def from_mcp(
+        cls, server_parameters: "mcp.StdioServerParameters" | dict, trust_remote_code: bool = False
+    ) -> "ToolCollection":
         """Automatically load a tool collection from an MCP server.
 
         This method supports both SSE and Stdio MCP servers. Look at the `sever_parameters`
@@ -822,7 +828,7 @@ class ToolCollection:
         the MCP server.
 
         Args:
-            server_parameters (mcp.StdioServerParameters | dict):
+            server_parameters (`mcp.StdioServerParameters` or `dict`):
                 The server parameters to use to connect to the MCP server. If a dict is
                 provided, it is assumed to be the parameters of `mcp.client.sse.sse_client`.
             trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -516,7 +516,7 @@ def mock_smolagents_adapter():
 
 class TestToolCollection:
     def test_from_mcp(self, mock_server_parameters, mock_mcp_adapt, mock_smolagents_adapter):
-        with ToolCollection.from_mcp(mock_server_parameters) as tool_collection:
+        with ToolCollection.from_mcp(mock_server_parameters, trust_remote_code=True) as tool_collection:
             assert isinstance(tool_collection, ToolCollection)
             assert len(tool_collection.tools) == 2
             assert "tool1" in tool_collection.tools
@@ -542,7 +542,7 @@ class TestToolCollection:
             args=["-c", mcp_server_script],
         )
 
-        with ToolCollection.from_mcp(mcp_server_params) as tool_collection:
+        with ToolCollection.from_mcp(mcp_server_params, trust_remote_code=True) as tool_collection:
             assert len(tool_collection.tools) == 1, "Expected 1 tool"
             assert tool_collection.tools[0].name == "echo_tool", "Expected tool name to be 'echo_tool'"
             assert tool_collection.tools[0](text="Hello") == "Hello", "Expected tool to echo the input text"
@@ -573,7 +573,9 @@ class TestToolCollection:
         time.sleep(1)
 
         try:
-            with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}) as tool_collection:
+            with ToolCollection.from_mcp(
+                {"url": "http://127.0.0.1:8000/sse"}, trust_remote_code=True
+            ) as tool_collection:
                 assert len(tool_collection.tools) == 1, "Expected 1 tool"
                 assert tool_collection.tools[0].name == "echo_tool", "Expected tool name to be 'echo_tool'"
                 assert tool_collection.tools[0](text="Hello") == "Hello", "Expected tool to echo the input text"


### PR DESCRIPTION
Add `trust_remote_code` to `ToolCollection.from_mcp`.

**Important:** This is a *breaking change*:  
- Existing code that does not pass `trust_remote_code` will now raise an error.  
- However, this change is necessary for security reasons: helps users be more aware of the risks associated with executing remote code

Related to:
- #1085 
- #1090
