### PR TITLE
Cover additional cases for docstring parsing

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -226,9 +226,9 @@ args_re = re.compile(r"\n\s*Args:\n\s*(.*?)[\n\s]*(Returns:|Raises:|\Z)", re.DOT
 args_split_re = re.compile(
     r"""
 (?:^|\n)  # Match the start of the args block, or a newline
-\s*(\w+)\s*(?:\([^)]*\))?:\s*  # Capture the argument name (ignore the type) and strip spacing
+\s*(\w+)\s*(?:\([^)]*?\))?:\s*  # Capture the argument name (ignore the type) and strip spacing
 (.*?)\s*  # Capture the argument description, which can span multiple lines, and strip trailing spacing
-(?=\n\s*\w+:|\Z)  # Stop when you hit the next argument or the end of the block
+(?=\n\s*\w+\s*(?:\([^)]*?\))?:|\Z)  # Stop when you hit the next argument (with or without type) or the end of the block
 """,
     re.DOTALL | re.VERBOSE,
 )

--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -233,7 +233,13 @@ args_split_re = re.compile(
     re.DOTALL | re.VERBOSE,
 )
 # Extracts the Returns: block from the docstring, if present. Note that most chat templates ignore the return type/doc!
-returns_re = re.compile(r"\n\s*Returns:\n\s*(.*?)[\n\s]*(Raises:|\Z)", re.DOTALL)
+returns_re = re.compile(
+    r"\n\s*Returns:\n\s*"
+    r"(?:[^)]*?:\s*)?"  # Ignore the return type if present
+    r"(.*?)"  # Capture the return description
+    r"[\n\s]*(Raises:|\Z)",
+    re.DOTALL,
+)
 
 
 def _parse_google_format_docstring(

--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -224,12 +224,10 @@ description_re = re.compile(r"^(.*?)[\n\s]*(Args:|Returns:|Raises:|\Z)", re.DOTA
 args_re = re.compile(r"\n\s*Args:\n\s*(.*?)[\n\s]*(Returns:|Raises:|\Z)", re.DOTALL)
 # Splits the Args: block into individual arguments
 args_split_re = re.compile(
-    r"""
-(?:^|\n)  # Match the start of the args block, or a newline
-\s*(\w+)\s*(?:\([^)]*?\))?:\s*  # Capture the argument name (ignore the type) and strip spacing
-(.*?)\s*  # Capture the argument description, which can span multiple lines, and strip trailing spacing
-(?=\n\s*\w+\s*(?:\([^)]*?\))?:|\Z)  # Stop when you hit the next argument (with or without type) or the end of the block
-""",
+    r"(?:^|\n)"  # Match the start of the args block, or a newline
+    r"\s*(\w+)\s*(?:\([^)]*?\))?:\s*"  # Capture the argument name (ignore the type) and strip spacing
+    r"(.*?)\s*"  # Capture the argument description, which can span multiple lines, and strip trailing spacing
+    r"(?=\n\s*\w+\s*(?:\([^)]*?\))?:|\Z)",  # Stop when you hit the next argument (with or without type) or the end of the block
     re.DOTALL | re.VERBOSE,
 )
 # Extracts the Returns: block from the docstring, if present. Note that most chat templates ignore the return type/doc!

--- a/tests/test_function_type_hints_utils.py
+++ b/tests/test_function_type_hints_utils.py
@@ -220,6 +220,33 @@ def complex_docstring_types_func():
     return process
 
 
+@pytest.fixture
+def with_enums_and_trailing_text_func():
+    def process(color: str) -> None:
+        """
+        Some description
+
+        Args:
+            color: The color to select (choices: ["red", "green", "blue"]) or not.
+        """
+        pass
+
+    return process
+
+
+@pytest.fixture
+def with_special_words_in_description_func():
+    def process(color: str) -> None:
+        """
+        In case you decide to play with Args: do not
+        Args:
+            color: The color to select (choices: ["red", "green", "blue"]) or not.
+        """
+        pass
+
+    return process
+
+
 class TestGetJsonSchema:
     def test_get_json_schema_example(self):
         def fn(x: int, y: Optional[Tuple[str, str, float]] = None) -> None:
@@ -414,6 +441,16 @@ class TestGetJsonSchema:
         # Description should include the type information from docstring
         assert data_prop["description"] == "Nested structure with types."
         assert return_prop["description"] == "Processed results with types."
+
+    def test_with_inline_code_func(self, with_enums_and_trailing_text_func):
+        schema = get_json_schema(with_enums_and_trailing_text_func)
+        color_prop = schema["function"]["parameters"]["properties"]["color"]
+        assert "enum" in color_prop
+        assert color_prop["enum"] == ["red", "green", "blue"]
+
+    def test_with_special_words_in_description_func(self, with_special_words_in_description_func):
+        schema = get_json_schema(with_special_words_in_description_func)
+        assert schema["function"]["description"] == "In case you decide to play with Args: do not"
 
     @pytest.mark.parametrize(
         "fixture_name,expected_description",

--- a/tests/test_function_type_hints_utils.py
+++ b/tests/test_function_type_hints_utils.py
@@ -12,15 +12,164 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from smolagents._function_type_hints_utils import get_imports, get_json_schema
+from smolagents._function_type_hints_utils import DocstringParsingException, get_imports, get_json_schema
+
+
+@pytest.fixture
+def valid_func():
+    """A well-formed function with docstring, type hints, and return block."""
+
+    def multiply(x: int, y: float) -> float:
+        """
+        Multiplies two numbers.
+
+        Args:
+            x: The first number.
+            y: The second number.
+        Returns:
+            Product of x and y.
+        """
+        return x * y
+
+    return multiply
+
+
+@pytest.fixture
+def no_docstring_func():
+    """Function with no docstring."""
+
+    def sample(x: int):
+        return x
+
+    return sample
+
+
+@pytest.fixture
+def missing_arg_doc_func():
+    """Function with docstring but missing an argument description."""
+
+    def add(x: int, y: int):
+        """
+        Adds two numbers.
+
+        Args:
+            x: The first number.
+        """
+        return x + y
+
+    return add
+
+
+@pytest.fixture
+def bad_return_func():
+    """Function docstring with missing return description (allowed)."""
+
+    def do_nothing(x: Optional[str] = None):
+        """
+        Does nothing.
+
+        Args:
+            x: Some optional string.
+        """
+        pass
+
+    return do_nothing
+
+
+@pytest.fixture
+def complex_types_func():
+    def process_data(items: List[str], config: Dict[str, float], point: Tuple[int, int]) -> Dict:
+        """
+        Process some data.
+
+        Args:
+            items: List of items to process.
+            config: Configuration parameters.
+            point: A position as (x,y).
+
+        Returns:
+            Processed data result.
+        """
+        return {"result": True}
+
+    return process_data
+
+
+@pytest.fixture
+def optional_types_func():
+    def process_with_optional(required_arg: str, optional_arg: Optional[int] = None) -> str:
+        """
+        Process with optional argument.
+
+        Args:
+            required_arg: A required string argument.
+            optional_arg: An optional integer argument.
+
+        Returns:
+            Processing result.
+        """
+        return "processed"
+
+    return process_with_optional
+
+
+@pytest.fixture
+def enum_choices_func():
+    def select_color(color: str) -> str:
+        """
+        Select a color.
+
+        Args:
+            color: The color to select (choices: ["red", "green", "blue"])
+
+        Returns:
+            Selected color.
+        """
+        return color
+
+    return select_color
+
+
+@pytest.fixture
+def union_types_func():
+    def process_union(value: Union[int, str]) -> Union[bool, str]:
+        """
+        Process a value that can be either int or string.
+
+        Args:
+            value: An integer or string value.
+
+        Returns:
+            Processing result.
+        """
+        return True if isinstance(value, int) else "string result"
+
+    return process_union
+
+
+@pytest.fixture
+def nested_types_func():
+    def process_nested_data(data: List[Dict[str, Any]]) -> List[str]:
+        """
+        Process nested data structure.
+
+        Args:
+            data: List of dictionaries to process.
+
+        Returns:
+            List of processed results.
+        """
+        return ["result"]
+
+    return process_nested_data
 
 
 class TestGetJsonSchema:
-    def test_get_json_schema(self):
+    def test_get_json_schema_example(self):
         def fn(x: int, y: Optional[Tuple[str, str, float]] = None) -> None:
             """
             Test function
@@ -51,6 +200,128 @@ class TestGetJsonSchema:
         }
         assert schema["function"]["parameters"]["properties"]["y"] == expected_schema["parameters"]["properties"]["y"]
         assert schema["function"] == expected_schema
+
+    @pytest.mark.parametrize(
+        "fixture_name,should_fail",
+        [
+            ("valid_func", False),
+            # ('no_docstring_func', True),
+            # ('missing_arg_doc_func', True),
+            ("bad_return_func", False),
+        ],
+    )
+    def test_get_json_schema(self, request, fixture_name, should_fail):
+        func = request.getfixturevalue(fixture_name)
+        schema = get_json_schema(func)
+        assert schema["type"] == "function"
+        assert "function" in schema
+        assert "parameters" in schema["function"]
+
+    @pytest.mark.parametrize(
+        "fixture_name,should_fail",
+        [
+            # ('valid_func', False),
+            ("no_docstring_func", True),
+            ("missing_arg_doc_func", True),
+            # ('bad_return_func', False),
+        ],
+    )
+    def test_get_json_schema_raises(self, request, fixture_name, should_fail):
+        func = request.getfixturevalue(fixture_name)
+        with pytest.raises(DocstringParsingException):
+            get_json_schema(func)
+
+    @pytest.mark.parametrize(
+        "fixture_name,expected_properties",
+        [
+            ("valid_func", {"x": "integer", "y": "number"}),
+            ("bad_return_func", {"x": "string"}),
+        ],
+    )
+    def test_property_types(self, request, fixture_name, expected_properties):
+        """Test that property types are correctly mapped."""
+        func = request.getfixturevalue(fixture_name)
+        schema = get_json_schema(func)
+
+        properties = schema["function"]["parameters"]["properties"]
+        for prop_name, expected_type in expected_properties.items():
+            assert properties[prop_name]["type"] == expected_type
+
+    def test_schema_basic_structure(self, valid_func):
+        """Test that basic schema structure is correct."""
+        schema = get_json_schema(valid_func)
+        # Check schema type
+        assert schema["type"] == "function"
+        assert "function" in schema
+        # Check function schema
+        function_schema = schema["function"]
+        assert function_schema["name"] == "multiply"
+        assert "description" in function_schema
+        assert function_schema["description"] == "Multiplies two numbers."
+        # Check parameters schema
+        assert "parameters" in function_schema
+        params = function_schema["parameters"]
+        assert params["type"] == "object"
+        assert "properties" in params
+        assert "required" in params
+        assert set(params["required"]) == {"x", "y"}
+        properties = params["properties"]
+        assert properties["x"]["type"] == "integer"
+        assert properties["y"]["type"] == "number"
+        # Check return schema
+        assert "return" in function_schema
+        return_schema = function_schema["return"]
+        assert return_schema["type"] == "number"
+        assert return_schema["description"] == "Product of x and y."
+
+    def test_complex_types(self, complex_types_func):
+        """Test schema generation for complex types."""
+        schema = get_json_schema(complex_types_func)
+        properties = schema["function"]["parameters"]["properties"]
+        # Check list type
+        assert properties["items"]["type"] == "array"
+        # Check dict type
+        assert properties["config"]["type"] == "object"
+        # Check tuple type
+        assert properties["point"]["type"] == "array"
+        assert len(properties["point"]["prefixItems"]) == 2
+        assert properties["point"]["prefixItems"][0]["type"] == "integer"
+        assert properties["point"]["prefixItems"][1]["type"] == "integer"
+
+    def test_optional_types(self, optional_types_func):
+        """Test schema generation for optional arguments."""
+        schema = get_json_schema(optional_types_func)
+        params = schema["function"]["parameters"]
+        # Required argument should be in required list
+        assert "required_arg" in params["required"]
+        # Optional argument should not be in required list
+        assert "optional_arg" not in params["required"]
+        # Optional argument should be nullable
+        assert params["properties"]["optional_arg"]["nullable"] is True
+        assert params["properties"]["optional_arg"]["type"] == "integer"
+
+    def test_enum_choices(self, enum_choices_func):
+        """Test schema generation for enum choices in docstring."""
+        schema = get_json_schema(enum_choices_func)
+        color_prop = schema["function"]["parameters"]["properties"]["color"]
+        assert "enum" in color_prop
+        assert color_prop["enum"] == ["red", "green", "blue"]
+
+    def test_union_types(self, union_types_func):
+        """Test schema generation for union types."""
+        schema = get_json_schema(union_types_func)
+        value_prop = schema["function"]["parameters"]["properties"]["value"]
+        return_prop = schema["function"]["return"]
+        # Check union in parameter
+        assert len(value_prop["type"]) == 2
+        # Check union in return type
+        assert len(return_prop["type"]) == 2
+
+    def test_nested_types(self, nested_types_func):
+        """Test schema generation for nested complex types."""
+        schema = get_json_schema(nested_types_func)
+        data_prop = schema["function"]["parameters"]["properties"]["data"]
+        assert data_prop["type"] == "array"
 
 
 class TestGetCode:

--- a/tests/test_function_type_hints_utils.py
+++ b/tests/test_function_type_hints_utils.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 from typing import List, Optional, Tuple
 
 import pytest
@@ -20,7 +19,7 @@ import pytest
 from smolagents._function_type_hints_utils import get_imports, get_json_schema
 
 
-class TestJsonSchema(unittest.TestCase):
+class TestGetJsonSchema:
     def test_get_json_schema(self):
         def fn(x: int, y: Optional[Tuple[str, str, float]] = None) -> None:
             """
@@ -50,10 +49,8 @@ class TestJsonSchema(unittest.TestCase):
             },
             "return": {"type": "null"},
         }
-        self.assertEqual(
-            schema["function"]["parameters"]["properties"]["y"], expected_schema["parameters"]["properties"]["y"]
-        )
-        self.assertEqual(schema["function"], expected_schema)
+        assert schema["function"]["parameters"]["properties"]["y"] == expected_schema["parameters"]["properties"]["y"]
+        assert schema["function"] == expected_schema
 
 
 class TestGetCode:


### PR DESCRIPTION
- **Refactor test get_json_schema**
- **Test get_json_schema**
- **Add tests for docstrings with type annotations**
- **Fix get_json_schema for arguments with docstring types**
- **Ignore the docstring return type if present**
- **Refactor**
- **cover addition edge-cases for docstring parsing**
