### PR TITLE
Change: expanded error exception for incorrect tool parameters

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -147,12 +147,12 @@ class Tool:
             and getattr(self, "skip_forward_signature_validation") is True
         ):
             signature = inspect.signature(self.forward)
-            found_keys = set(key for key in signature.parameters.keys() if key != "self")
+            actual_keys = set(key for key in signature.parameters.keys() if key != "self")
             expected_keys = set(self.inputs.keys())
-            if not found_keys == expected_keys:
+            if actual_keys != expected_keys:
                 raise Exception(
-                    f"In tool '{self.name}', 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'. "
-                    f"Got ({found_keys}), expected ({expected_keys})."
+                    f"In tool '{self.name}', 'forward' method parameters were {actual_keys}, but expected {expected_keys}. "
+                    f"It should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'."
                 )
 
             json_schema = _convert_type_hints_to_json_schema(self.forward, error_on_missing_type_hints=False)[

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -147,10 +147,12 @@ class Tool:
             and getattr(self, "skip_forward_signature_validation") is True
         ):
             signature = inspect.signature(self.forward)
-
-            if not set(key for key in signature.parameters.keys() if key != "self") == set(self.inputs.keys()):
+            found_keys = set(key for key in signature.parameters.keys() if key != "self")
+            expected_keys = set(self.inputs.keys())
+            if not found_keys == expected_keys:
                 raise Exception(
-                    f"In tool '{self.name}', 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'."
+                    f"In tool '{self.name}', 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'. "
+                    f"Got ({found_keys}), expected ({expected_keys})."
                 )
 
             json_schema = _convert_type_hints_to_json_schema(self.forward, error_on_missing_type_hints=False)[


### PR DESCRIPTION
Previously, a bad version of forward() in a tool would report an exception like:

```
Exception: In tool 'user_input', 'forward' method should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'.
```

Now, I've explicitly included the expected and actual parameters. I also hope this made the code clearer.

```
Exception: In tool 'user_input', 'forward' method parameters were {'prompt'}, but expected {'question'}. It should take 'self' as its first argument, then its next arguments should match the keys of tool attribute 'inputs'.
```

The code passes `make test` and `make quality` fwiw.

Thanks!

/charles


```
make quality
ruff check examples src tests utils
All checks passed!
ruff format --check examples src tests utils
63 files already formatted
python utils/check_tests_in_ci.py
✅ All good!
```