### PR TITLE
Gradio UI: log observations images

### DIFF
--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,28 +1,25 @@
+from io import BytesIO
+
+import requests
+from PIL import Image
+
 from smolagents import CodeAgent, GradioUI, HfApiModel
 
 
 def add_agent_image(memory_step, agent):
-    # Actually loads an image from a url
-    from io import BytesIO
-
-    import requests
-    from PIL import Image
-
-    url = "https://upload.wikimedia.org/wikipedia/commons/3/3f/JPEG_example_flower.jpg"
+    url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/smolagents.png"
     response = requests.get(url)
     memory_step.observations_images = [Image.open(BytesIO(response.content))]
 
 
 agent = CodeAgent(
     tools=[],
-    model=HfApiModel(provider="together"),
+    model=HfApiModel(),
     verbosity_level=1,
-    # planning_interval=2,
+    planning_interval=3,
     name="example_agent",
     description="This is an example agent that has not tool but will always see an agent at the end of its step.",
     step_callbacks=[add_agent_image],
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()
-agent.run("Make me an image of a cow")
-print("OBSERVATION IMAGES:", agent.memory.steps)

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,13 +1,28 @@
 from smolagents import CodeAgent, GradioUI, HfApiModel
 
 
+def add_agent_image(memory_step, agent):
+    # Actually loads an image from a url
+    from io import BytesIO
+
+    import requests
+    from PIL import Image
+
+    url = "https://upload.wikimedia.org/wikipedia/commons/3/3f/JPEG_example_flower.jpg"
+    response = requests.get(url)
+    memory_step.observations_images = [Image.open(BytesIO(response.content))]
+
+
 agent = CodeAgent(
     tools=[],
-    model=HfApiModel(),
+    model=HfApiModel(provider="together"),
     verbosity_level=1,
-    planning_interval=2,
+    # planning_interval=2,
     name="example_agent",
-    description="This is an example agent that has no tools and uses only code.",
+    description="This is an example agent that has not tool but will always see an agent at the end of its step.",
+    step_callbacks=[add_agent_image],
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()
+agent.run("Make me an image of a cow")
+print("OBSERVATION IMAGES:", agent.memory.steps)

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -361,9 +361,7 @@ You have been provided with these additional arguments, that you can access usin
         if final_answer is None and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task, images, step_start_time)
             yield action_step
-        final_step = FinalAnswerStep(handle_agent_output_types(final_answer))
-        self.memory.steps.append(final_step)
-        yield final_step
+        yield FinalAnswerStep(handle_agent_output_types(final_answer))
 
     def _create_action_step(self, step_start_time: float, images: List["PIL.Image.Image"] | None) -> ActionStep:
         return ActionStep(step_number=self.step_number, start_time=step_start_time, observations_images=images)

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -91,48 +91,45 @@ def pull_messages_from_step(
                 metadata={
                     "title": f"🛠️ Used tool {first_tool_call.name}",
                     "id": parent_id,
-                    "status": "pending",
+                    "status": "done",
                 },
             )
             yield parent_message_tool
 
-            # Nesting execution logs under the tool call if they exist
-            if hasattr(step_log, "observations") and (
-                step_log.observations is not None and step_log.observations.strip()
-            ):  # Only yield execution logs if there's actual content
-                log_content = step_log.observations.strip()
-                if log_content:
-                    log_content = re.sub(r"^Execution logs:\s*", "", log_content)
-                    yield gr.ChatMessage(
-                        role="assistant",
-                        content=f"```bash\n{log_content}\n",
-                        metadata={"title": "📝 Execution Logs", "parent_id": parent_id, "status": "done"},
-                    )
-
-            # Nesting any errors under the tool call
-            if hasattr(step_log, "error") and step_log.error is not None:
+        # Display execution logs if they exist
+        if hasattr(step_log, "observations") and (
+            step_log.observations is not None and step_log.observations.strip()
+        ):  # Only yield execution logs if there's actual content
+            log_content = step_log.observations.strip()
+            if log_content:
+                log_content = re.sub(r"^Execution logs:\s*", "", log_content)
                 yield gr.ChatMessage(
                     role="assistant",
-                    content=str(step_log.error),
-                    metadata={"title": "💥 Error", "parent_id": parent_id, "status": "done"},
+                    content=f"```bash\n{log_content}\n",
+                    metadata={"title": "📝 Execution Logs", "status": "done"},
                 )
 
-            # Update parent message metadata to done status without yielding a new message
-            parent_message_tool.metadata["status"] = "done"
+        # Display any errors
+        if hasattr(step_log, "error") and step_log.error is not None:
+            yield gr.ChatMessage(
+                role="assistant",
+                content=str(step_log.error),
+                metadata={"title": "💥 Error", "status": "done"},
+            )
 
-        # Handle standalone errors but not from tool calls
-        elif hasattr(step_log, "error") and step_log.error is not None:
-            yield gr.ChatMessage(role="assistant", content=str(step_log.error), metadata={"title": "💥 Error"})
-
+        # Update parent message metadata to done status without yielding a new message
         if getattr(step_log, "observations_images", []):
             for image in step_log.observations_images:
                 path_image = AgentImage(image).to_string()
                 yield gr.ChatMessage(
                     role="assistant",
                     content={"path": path_image, "mime_type": f"image/{path_image.split('.')[-1]}"},
-                    metadata={"title": "🖼️ Observed Image", "parent_id": parent_id, "status": "done"},
+                    metadata={"title": "🖼️ Output Image", "status": "done"},
                 )
-            # TODO: check mime type
+
+        # Handle standalone errors but not from tool calls
+        if hasattr(step_log, "error") and step_log.error is not None:
+            yield gr.ChatMessage(role="assistant", content=str(step_log.error), metadata={"title": "💥 Error"})
 
         yield gr.ChatMessage(role="assistant", content=get_step_footnote_content(step_log, step_number))
         yield gr.ChatMessage(role="assistant", content="-----", metadata={"status": "done"})

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -124,6 +124,16 @@ def pull_messages_from_step(
         elif hasattr(step_log, "error") and step_log.error is not None:
             yield gr.ChatMessage(role="assistant", content=str(step_log.error), metadata={"title": "💥 Error"})
 
+
+        if getattr(step_log, "observations_images", []):
+            for image in step_log.observations_images:
+                yield gr.ChatMessage(
+                    role="assistant",
+                    content={"path": AgentImage(image).to_string(), "mime_type": "image/png"},
+                    metadata={"title": "🖼️ Observed Image", "parent_id": parent_id, "status": "done"},
+                )
+            #TODO: check mime type
+
         yield gr.ChatMessage(role="assistant", content=get_step_footnote_content(step_log, step_number))
         yield gr.ChatMessage(role="assistant", content="-----", metadata={"status": "done"})
 

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -124,15 +124,15 @@ def pull_messages_from_step(
         elif hasattr(step_log, "error") and step_log.error is not None:
             yield gr.ChatMessage(role="assistant", content=str(step_log.error), metadata={"title": "💥 Error"})
 
-
         if getattr(step_log, "observations_images", []):
             for image in step_log.observations_images:
+                path_image = AgentImage(image).to_string()
                 yield gr.ChatMessage(
                     role="assistant",
-                    content={"path": AgentImage(image).to_string(), "mime_type": "image/png"},
+                    content={"path": path_image, "mime_type": f"image/{path_image.split('.')[-1]}"},
                     metadata={"title": "🖼️ Observed Image", "parent_id": parent_id, "status": "done"},
                 )
-            #TODO: check mime type
+            # TODO: check mime type
 
         yield gr.ChatMessage(role="assistant", content=get_step_footnote_content(step_log, step_number))
         yield gr.ChatMessage(role="assistant", content="-----", metadata={"status": "done"})

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -180,7 +180,7 @@ class MonitoringTester(unittest.TestCase):
         # Use stream_to_gradio to capture the output
         outputs = list(stream_to_gradio(agent, task="Test task"))
 
-        self.assertEqual(len(outputs), 11)
+        self.assertEqual(len(outputs), 13)
         final_message = outputs[-1]
         self.assertEqual(final_message.role, "assistant")
         self.assertIn("Malformed call", final_message.content)


### PR DESCRIPTION
This PR adds a specific field in gradio ChatMessages to display possible `observations_images`: very useful for instance when running VLM-based browser agents, with a callback at the end of each step to log screenshots!