### PR TITLE
Fix no more tool calls exception in ToolCallingAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -62,6 +62,7 @@ from .utils import (
     AgentExecutionError,
     AgentGenerationError,
     AgentMaxStepsError,
+    AgentNoMoreToolCallError,
     AgentParsingError,
     AgentToolCallError,
     AgentToolExecutionError,
@@ -352,6 +353,10 @@ You have been provided with these additional arguments, that you can access usin
             except AgentGenerationError as e:
                 # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
                 raise e
+            except AgentNoMoreToolCallError as e:
+                # No more tool calls are available, so we should stop iteration and provide final answer.
+                action_step.error = e
+                final_answer = self.provide_final_answer(task, images)
             except AgentError as e:
                 # Other AgentError types are caused by the Model, so we should log them and iterate.
                 action_step.error = e
@@ -984,7 +989,7 @@ class ToolCallingAgent(MultiStepAgent):
         )
 
         if model_message.tool_calls is None or len(model_message.tool_calls) == 0:
-            raise AgentParsingError(
+            raise AgentNoMoreToolCallError(
                 "Model did not call any tools. Call `final_answer` tool to return a final answer.", self.logger
             )
 

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -122,6 +122,11 @@ class AgentGenerationError(AgentError):
 
     pass
 
+class AgentNoMoreToolCallError(AgentError):
+    """Exception raised when there are no more tool calls to action"""
+
+    pass
+
 
 def make_json_serializable(obj: Any) -> Any:
     """Recursive function to make objects JSON serializable"""


### PR DESCRIPTION
When the ToolCallingAgent doesn't return any toolcall after executing a step, it should trigger provide_final_answer function to provide the final answer and stop iteration. However, the current logic doesn't implement this behavior. This PR aims to fix this issue.