### PR TITLE
Fix planning_interval=1 bug in MultiStepAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -340,7 +340,7 @@ You have been provided with these additional arguments, that you can access usin
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
             step_start_time = time.time()
-            if self.planning_interval is not None and self.step_number % self.planning_interval == 1:
+            if self.planning_interval is not None and (self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0):
                 planning_step = self._create_planning_step(
                     task, is_first_step=(self.step_number == 1), step=self.step_number
                 )

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -340,7 +340,9 @@ You have been provided with these additional arguments, that you can access usin
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
             step_start_time = time.time()
-            if self.planning_interval is not None and (self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0):
+            if self.planning_interval is not None and (
+                self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0
+            ):
                 planning_step = self._create_planning_step(
                     task, is_first_step=(self.step_number == 1), step=self.step_number
                 )


### PR DESCRIPTION
**Bug Description**
When planning_interval=1 was set in MultiStepAgent, the agent would never execute planning steps. This was counter-intuitive, as users would expect planning to occur at every step with this setting.
This can be reproduced by using the example `agent_from_any_llm.py` with:

`agent = CodeAgent(tools=[get_weather], model=model, verbosity_level=2, planning_interval=1)
print("CodeAgent:", agent.run("What's the weather like in Paris? Once you have found out the current temperature, divide it by 2.345 and return the result as a string. Make sure to use Python code to do this. Then, as a third step, write a story about a cat that is a wizard and can fly and somehow use the calculated number in that story."))`

**Root Cause**
The issue was in the condition used to determine when planning should occur:
`if self.planning_interval is not None and self.step_number % self.planning_interval == 1:`
When planning_interval=1:
For any step number n, n % 1 is always 0 (not 1)
Thus, the condition was never satisfied and planning never occurred

**Fix**
Changed the planning condition to:
`if self.planning_interval is not None and (self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0):`
This ensures:
Planning always occurs on the first step (when step_number == 1)
2. For subsequent steps, planning occurs every planning_interval steps

**Testing**
The fix maintains correct behavior for all planning_interval values:
planning_interval=1: Planning occurs at every step
planning_interval=n: Planning occurs at step 1 and every nth step after that
planning_interval=None: No planning occurs

**Impact**
Users can now reliably use planning_interval=1 to request planning at every step, which is particularly useful for complex tasks requiring continuous planning and transparency and fexibility after each step. 🤗`
