### PR TITLE
Hotfix CI AttributeError: 'PngImageFile' object has no attribute 'filename'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "requests>=2.32.3",
   "rich>=13.9.4",
   "jinja2>=3.1.4",
-  "pillow>=11.0.0",
+  "pillow>=11.0.0,<11.2.0",
   "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
   "python-dotenv"


### PR DESCRIPTION
Hotfix CI AttributeError: 'PngImageFile' object has no attribute 'filename'

After pillow-11.2.0 release, our CI fails: https://github.com/huggingface/smolagents/actions/runs/14202410892/job/39792180077?pr=1126
```
FAILED tests/test_models.py::TestModel::test_transformers_message_vl_no_tool - AttributeError: 'PngImageFile' object has no attribute 'filename'
```

This PR pins pillow < 11.2.0.

