### PR TITLE
Replace AgentGenerationError with AgentParsingError for ToolCallingAgent

### DIFF
--- a/examples/agent_from_any_llm.py
+++ b/examples/agent_from_any_llm.py
@@ -7,7 +7,7 @@ from smolagents.agents import CodeAgent, ToolCallingAgent
 # Choose which inference type to use!
 
 available_inferences = ["hf_api", "hf_api_provider", "transformers", "ollama", "litellm", "openai"]
-chosen_inference = "openai"
+chosen_inference = "hf_api_provider"
 
 print(f"Chose model: '{chosen_inference}'")
 

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -975,7 +975,7 @@ class ToolCallingAgent(MultiStepAgent):
             )
             memory_step.model_output_message = model_message
         except Exception as e:
-            raise AgentParsingError(f"Error in generating tool call with model:\n{e}", self.logger) from e
+            raise AgentParsingError(f"Error while generating or parsing output:\n{e}", self.logger) from e
 
         self.logger.log_markdown(
             content=model_message.content if model_message.content else str(model_message.raw),

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -975,7 +975,7 @@ class ToolCallingAgent(MultiStepAgent):
             )
             memory_step.model_output_message = model_message
         except Exception as e:
-            raise AgentGenerationError(f"Error in generating tool call with model:\n{e}", self.logger) from e
+            raise AgentParsingError(f"Error in generating tool call with model:\n{e}", self.logger) from e
 
         self.logger.log_markdown(
             content=model_message.content if model_message.content else str(model_message.raw),


### PR DESCRIPTION
`AgentGenerationErrors` are designed to be caught, because they mean that inference was improperly setup: however for `ToolCallingAgent` where sometimes the model can just output bad formatted tool calls **_on the api side_** that do not get extracted as a proper tool call, we can be more indulgent and let the model retry by making the error an `AgentParsingError` instead, which is not raised but returned to the agent. This is mostly a hotfix, to be refined later. Also, reminder: `ToolCallingAgent` is not the primary class that we support, the preferred class is `CodeAgent`.