### PR TITLE
fix: set memory step tool call even if code parsing fails

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1242,6 +1242,13 @@ class CodeAgent(MultiStepAgent):
             code_action = fix_final_answer_code(parse_code_blobs(model_output))
         except Exception as e:
             error_msg = f"Error in code parsing:\n{e}\nMake sure to provide correct code blobs."
+            memory_step.tool_calls = [
+                ToolCall(
+                    name="python_interpreter",
+                    arguments=model_output,
+                    id=f"call_{len(self.memory.steps)}",
+                )
+            ]
             raise AgentParsingError(error_msg, self.logger)
 
         memory_step.tool_calls = [


### PR DESCRIPTION
Hello huggingface team and thank you for this package, I'm making wonder with it 😄 

Long story short, I'm currently working on integrating Google's Gemini API into `smolagents` using the `google-genai` package. To achieve this, I've developed a bridge that translates your `ChatMessages` into the format expected by the Gemini API.

However, I've encountered the following error when sending message lists to Gemini with my agent:
```
Error in generating model output:
400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.', 'status': 'INVALID_ARGUMENT'}}
```

This error appears to stem from instances where the `List[ChatMessage]` contains a `tool-response` without a preceding `tool-call`. Notably, this issue arises exclusively with `CodeAgent`. Specifically, when code parsing fails, the `tool_calls` attribute for that step isn't set, yet the tool response is still present.

Is this behavior intentional? If so, it might pose challenges in effectively leveraging Gemini with `smolagents`. 😢

Best regards,
Antoine