### PR TITLE
Pass vLLM (VLLMModel) model client params as `client_kwargs`

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -400,6 +400,7 @@ class VLLMModel(Model):
         client_kwargs (`dict[str, Any]`, *optional*):
             Additional keyword arguments to pass to the vLLM model (like revision, max_model_len, etc.).
     """
+
     def __init__(
         self,
         model_id,

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -401,8 +401,8 @@ class VLLMModel(Model):
             Additional keyword arguments to pass to the vLLM model (like revision, max_model_len, etc.).
     """
     def __init__(
-        self, 
-        model_id, 
+        self,
+        model_id,
         client_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -397,14 +397,14 @@ class VLLMModel(Model):
         model_id (`str`):
             The Hugging Face model ID to be used for inference.
             This can be a path or model identifier from the Hugging Face model hub.
-        client_kwargs (`dict[str, Any]`, *optional*):
+        model_kwargs (`dict[str, Any]`, *optional*):
             Additional keyword arguments to pass to the vLLM model (like revision, max_model_len, etc.).
     """
 
     def __init__(
         self,
         model_id,
-        client_kwargs: dict[str, Any] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
         if not _is_package_available("vllm"):
@@ -413,13 +413,13 @@ class VLLMModel(Model):
         from vllm import LLM
         from vllm.transformers_utils.tokenizer import get_tokenizer
 
-        self.client_kwargs = {
-            **(client_kwargs or {}),
+        self.model_kwargs = {
+            **(model_kwargs or {}),
             "model": model_id,
         }
         super().__init__(**kwargs)
         self.model_id = model_id
-        self.model = LLM(**self.client_kwargs)
+        self.model = LLM(**self.model_kwargs)
         self.tokenizer = get_tokenizer(model_id)
         self._is_vlm = False  # VLLMModel does not support vision models yet.
 

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -397,19 +397,28 @@ class VLLMModel(Model):
         model_id (`str`):
             The Hugging Face model ID to be used for inference.
             This can be a path or model identifier from the Hugging Face model hub.
+        client_kwargs (`dict[str, Any]`, *optional*):
+            Additional keyword arguments to pass to the vLLM model (like revision, max_model_len, etc.).
     """
-
-    def __init__(self, model_id, **kwargs):
+    def __init__(
+        self, 
+        model_id, 
+        client_kwargs: dict[str, Any] | None = None,
+        **kwargs,
+    ):
         if not _is_package_available("vllm"):
             raise ModuleNotFoundError("Please install 'vllm' extra to use VLLMModel: `pip install 'smolagents[vllm]'`")
 
         from vllm import LLM
         from vllm.transformers_utils.tokenizer import get_tokenizer
 
+        self.client_kwargs = {
+            **(client_kwargs or {}),
+            "model": model_id,
+        }
         super().__init__(**kwargs)
-
         self.model_id = model_id
-        self.model = LLM(model=model_id)
+        self.model = LLM(**self.client_kwargs)
         self.tokenizer = get_tokenizer(model_id)
         self._is_vlm = False  # VLLMModel does not support vision models yet.
 


### PR DESCRIPTION
fix #1136

This support is already present in another model client such as `HfApiModel` and `OpenAIServerModel`.

I've tested it with the following code:

```python
from smolagents import CodeAgent, DuckDuckGoSearchTool, VLLMModel

# Import search tool
search_tool = DuckDuckGoSearchTool()

# Load model
model_name = "google/gemma-3-4b-it"
# model = VLLMModel(model_id=model_name)
model = VLLMModel(model_id=model_name, client_kwargs={"max_model_len": 65536}) # new functionality!

# Initialize the agent with search_tool
agent = CodeAgent(tools=[search_tool], model=model)

# Run it!
result = agent.run("How did Real Madrid do in their last La Liga match?")
result
```

BTW, there are currently no tests for `VLLMModel` in `test_models.py` and it's not described in the guided tour docs.