### PR TITLE
Unpin pillow < 11.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "requests>=2.32.3",
   "rich>=13.9.4",
   "jinja2>=3.1.4",
-  "pillow>=11.0.0,<11.2.0",
+  "pillow>=11.0.0",
   "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
   "python-dotenv"


### PR DESCRIPTION
Unpin pillow < 11.2.0.

As explained in the closing issue #1138:
- pillow 11.2.0 version was yanked: https://pypi.org/project/pillow/11.2.0/
  - https://github.com/python-pillow/Pillow/issues/8722#issuecomment-2771577726
- the root issue was reported to pillow:
  - https://github.com/python-pillow/Pillow/issues/8857
- and fixed:
  - https://github.com/python-pillow/Pillow/pull/8859

Fix #1138.