### PR TITLE
Fix: adjust PlanningStep user message to avoid azure's content filter

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -154,7 +154,7 @@ class PlanningStep(MemoryStep):
             return []
         return [
             Message(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.plan.strip()}]),
-            Message(role=MessageRole.USER, content=[{"type": "text", "text": "Now go on and execute this plan."}]),
+            Message(role=MessageRole.USER, content=[{"type": "text", "text": "Now proceed and carry out this plan."}]),
             # This second message creates a role change to prevent models models from simply continuing the plan message
         ]
 


### PR DESCRIPTION
I encountered the same issue described in #1139 and have identified user message in PlanningStep as the cause. After testing it directly in Azure's playground, I was able to reproduce the error. The new message resolves the problem for me.