### PR TITLE
Fix: Add default value to optional argument

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -528,7 +528,7 @@ You have been provided with these additional arguments, that you can access usin
             )
         return rationale.strip(), action.strip()
 
-    def provide_final_answer(self, task: str, images: Optional[list["PIL.Image.Image"]]) -> str:
+    def provide_final_answer(self, task: str, images: Optional[list["PIL.Image.Image"]] = None) -> str:
         """
         Provide the final answer to the task, based on the logs of the agent's interactions.
 


### PR DESCRIPTION
`provide_final_answer()` has an optional argument `images`, but since no default value is provided, this can raise exceptions if you don't specify it. Simply defaulting to `None` should give the desired functionality.