### PR TITLE
[FEAT]: add support for preloaded customized Hugging Face Transformers models

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -621,9 +621,7 @@ class MLXModel(Model):
 
 
 class TransformersModel(Model):
-    """
-    A class that uses Hugging Face's Transformers library for language model interaction. 
-    ## Now with support to model params and qlora
+    """A class that uses Hugging Face's Transformers library for language model interaction.
 
     This model allows you to load and use Hugging Face's models locally using the Transformers library. It supports features like stop sequences and grammar customization.
 
@@ -640,54 +638,35 @@ class TransformersModel(Model):
             The torch_dtype to initialize your model with.
         trust_remote_code (bool, default `False`):
             Some models on the Hub require running remote code: for this model, you would have to set this flag to True.
-        model_config:
-            Params for model configuration that you want to use in AutoModelForImageTextToText.from_pretrained or AutoModelForCausalLM.from_pretrained
         kwargs (dict, *optional*):
             Any additional keyword arguments that you want to use in model.generate(), for instance `max_new_tokens` or `device`.
-        
+        **kwargs:
+            Additional keyword arguments to pass to `model.generate()`, for instance `max_new_tokens` or `device`.
     Raises:
         ValueError:
             If the model name is not provided.
 
     Example:
     ```python
-    >>> from transformers import BitsAndBytesConfig
-    >>> from smolagents_v1.smolagents.src.smolagents import CodeAgent, TransformersModel
-
-    >>> model_id = "Qwen/Qwen2.5-Coder-32B-Instruct"
-
-    >>> bnb_config = BitsAndBytesConfig(
-    ...     load_in_4bit=True,
-    ...     bnb_4bit_compute_dtype="float16",
-    ...     bnb_4bit_use_double_quant=True,
-    ...     bnb_4bit_quant_type="nf4"
+    >>> engine = TransformersModel(
+    ...     model_id="Qwen/Qwen2.5-Coder-32B-Instruct",
+    ...     device="cuda",
+    ...     max_new_tokens=5000,
     ... )
-
-    >>> model = TransformersModel(
-    ...     model_id,
-    ...     device_map="auto",
-    ...     torch_dtype="auto",
-    ...     trust_remote_code=True,
-    ...     model_config={'quantization_config': bnb_config},
-    ...     max_new_tokens=2000
-    ... )
-
-    >>> agent = CodeAgent(tools=[], model=model)
-
-    >>> result = agent.run("Explain quantum mechanics in simple terms.")
-    >>> print(result)
-    "Quantum mechanics is a branch of physics that studies the behavior of particles at the smallest scales, such as atoms and subatomic particles. Unlike classical physics, which..."
+    >>> messages = [{"role": "user", "content": "Explain quantum mechanics in simple terms."}]
+    >>> response = engine(messages, stop_sequences=["END"])
+    >>> print(response)
+    "Quantum mechanics is the branch of physics that studies..."
     ```
     """
 
     def __init__(
         self,
-        model_id:           Optional[str] = None,
-        device_map:         Optional[str] = None,
-        torch_dtype:        Optional[str] = None,
-        trust_remote_code:  bool = False,
-        model_config:       dict = dict(),  # Variável que armazena parâmetros do modelo como dicionário
-        **kwargs,                           # Armazena parâmetros do model.generate
+        model_id: Optional[str] = None,
+        device_map: Optional[str] = None,
+        torch_dtype: Optional[str] = None,
+        trust_remote_code: bool = False,
+        **kwargs,
     ):
         try:
             import torch
@@ -705,7 +684,6 @@ class TransformersModel(Model):
                 FutureWarning,
             )
             model_id = "HuggingFaceTB/SmolLM2-1.7B-Instruct"
-
         self.model_id = model_id
 
         default_max_tokens = 5000
@@ -723,10 +701,9 @@ class TransformersModel(Model):
         try:
             self.model = AutoModelForImageTextToText.from_pretrained(
                 model_id,
-                device_map          = device_map,
-                torch_dtype         = torch_dtype,
-                trust_remote_code   = trust_remote_code,
-                **model_config                              # Adiciona os kwargs, agora permite quantização
+                device_map=device_map,
+                torch_dtype=torch_dtype,
+                trust_remote_code=trust_remote_code,
             )
             self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
             self._is_vlm = True
@@ -734,19 +711,16 @@ class TransformersModel(Model):
             if "Unrecognized configuration class" in str(e):
                 self.model = AutoModelForCausalLM.from_pretrained(
                     model_id,
-                    device_map          = device_map,
-                    torch_dtype         = torch_dtype,
-                    trust_remote_code   = trust_remote_code,
-                    **model_config                                  # Adiciona os kwargs, agora permite quantização
+                    device_map=device_map,
+                    torch_dtype=torch_dtype,
+                    trust_remote_code=trust_remote_code,
                 )
                 self.tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
             else:
                 raise e
         except Exception as e:
             raise ValueError(f"Failed to load tokenizer and model for {model_id=}: {e}") from e
-        
         super().__init__(flatten_messages_as_text=not self._is_vlm, **kwargs)
-
 
     def make_stopping_criteria(self, stop_sequences: List[str], tokenizer) -> "StoppingCriteriaList":
         from transformers import StoppingCriteria, StoppingCriteriaList
@@ -768,7 +742,7 @@ class TransformersModel(Model):
                 return False
 
         return StoppingCriteriaList([StopOnStrings(stop_sequences, tokenizer)])
-    
+
     def __call__(
         self,
         messages: List[Dict[str, str]],
@@ -778,9 +752,9 @@ class TransformersModel(Model):
         **kwargs,
     ) -> ChatMessage:
         completion_kwargs = self._prepare_completion_kwargs(
-            messages        = messages,
-            stop_sequences  = stop_sequences,
-            grammar         = grammar,
+            messages=messages,
+            stop_sequences=stop_sequences,
+            grammar=grammar,
             **kwargs,
         )
 
@@ -827,10 +801,9 @@ class TransformersModel(Model):
 
         out = self.model.generate(
             **prompt_tensor,
-            stopping_criteria   = stopping_criteria,
+            stopping_criteria=stopping_criteria,
             **completion_kwargs,
         )
-
         generated_tokens = out[0, count_prompt_tokens:]
         if hasattr(self, "processor"):
             output_text = self.processor.decode(generated_tokens, skip_special_tokens=True)
@@ -852,7 +825,6 @@ class TransformersModel(Model):
                 get_tool_call_from_text(output_text, self.tool_name_key, self.tool_arguments_key)
             ]
         return chat_message
-
 
 
 class ApiModel(Model):
@@ -1405,6 +1377,210 @@ class AmazonBedrockServerModel(ApiModel):
         return self.postprocess_message(first_message, tools_to_call_from)
 
 
+class PreloadedTransformersModel(Model):
+    """A class that uses Hugging Face's Transformers library for language model interaction.
+
+    This model allows you to load and use Hugging Face's models locally using the Transformers library. It supports features like stop sequences and grammar customization.
+
+    > [!TIP]
+    > You must have `transformers` and `torch` installed on your machine. Please run `pip install smolagents[transformers]` if it's not the case.
+
+    Parameters:
+        model:
+            Model from transformers.AutoModelForCausalLM or transformers.AutoModelForImageTextToText
+        tokenizer (*optional*):
+            Tokenizer from transformers.AutoTokenizer
+        processor (*optional*):
+            Processor from transformers.AutoProcessor
+        is_vlm (bool, default `False`):
+            Flag used to indicate whether the model is a VLM (Vision-Language Model) or not. Set to true if it is a VLM.
+        kwargs (dict, *optional*):
+            Any additional keyword arguments that you want to use in model.generate(), for instance `max_new_tokens` or `device`.
+        **kwargs:
+            Additional keyword arguments to pass to `model.generate()`, for instance `max_new_tokens` or `device`.
+    Raises:
+        ValueError:
+            If the model name is not provided.
+
+    Example:
+    ```python
+    >>> from transformers import BitsAndBytesConfig
+    >>> from smolagents_v1.smolagents.src.smolagents import CodeAgent, TransformersModel
+
+    >>> model_id = "Qwen/Qwen2.5-Coder-32B-Instruct"
+
+    >>> bnb_config = BitsAndBytesConfig(
+    ...     load_in_4bit=True,
+    ...     bnb_4bit_compute_dtype="float16",
+    ...     bnb_4bit_use_double_quant=True,
+    ...     bnb_4bit_quant_type="nf4"
+    ... )
+
+    >>> model = TransformersModel(
+    ...     model_id,
+    ...     device_map="auto",
+    ...     torch_dtype="auto",
+    ...     trust_remote_code=True,
+    ...     model_config={'quantization_config': bnb_config},
+    ...     max_new_tokens=2000
+    ... )
+
+    >>> agent = CodeAgent(tools=[], model=model)
+
+    >>> result = agent.run("Explain quantum mechanics in simple terms.")
+    >>> print(result)
+    "Quantum mechanics is a branch of physics that studies the behavior of particles at the smallest scales, such as atoms and subatomic particles. Unlike classical physics, which..."
+    ```
+    """
+
+    def __init__(
+        self,
+        model,
+        tokenizer           = None,
+        processor           = None,
+        is_vlm:     bool    = False,
+        **kwargs,
+    ):
+        #############################
+        # IMPORTANDO AS BIBLIOTECAS #
+        #############################
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "Please install 'transformers' extra to use 'TransformersModel': `pip install 'smolagents[transformers]'`"
+            )
+
+        ######################################################
+        # DEFININDO OS TOKENS E CONFIGURAÇÕES COMPLEMENTARES #
+        ######################################################
+        default_max_tokens  = 5000
+        max_new_tokens      = kwargs.get("max_new_tokens") or kwargs.get("max_tokens")
+        if not max_new_tokens:
+            kwargs["max_new_tokens"] = default_max_tokens
+            logger.warning(f"`max_new_tokens` not provided, using this default value for `max_new_tokens`: {default_max_tokens}")
+        self._is_vlm = False
+
+        #################################################
+        # VERIFICANDO SE É MODELO DE IMAGEM OU DE TEXTO #
+        #################################################
+        self.model      = model
+        self._is_vlm    = is_vlm
+
+        if self._is_vlm:
+            self.processor  = processor
+        else:
+            self.tokenizer  = tokenizer
+        
+
+        super().__init__(flatten_messages_as_text=not self._is_vlm, **kwargs)
+
+    def make_stopping_criteria(self, stop_sequences: List[str], tokenizer) -> "StoppingCriteriaList":
+        from transformers import StoppingCriteria, StoppingCriteriaList
+
+        class StopOnStrings(StoppingCriteria):
+            def __init__(self, stop_strings: List[str], tokenizer):
+                self.stop_strings = stop_strings
+                self.tokenizer = tokenizer
+                self.stream = ""
+
+            def reset(self):
+                self.stream = ""
+
+            def __call__(self, input_ids, scores, **kwargs):
+                generated = self.tokenizer.decode(input_ids[0][-1], skip_special_tokens=True)
+                self.stream += generated
+                if any([self.stream.endswith(stop_string) for stop_string in self.stop_strings]):
+                    return True
+                return False
+
+        return StoppingCriteriaList([StopOnStrings(stop_sequences, tokenizer)])
+
+    def __call__(
+        self,
+        messages: List[Dict[str, str]],
+        stop_sequences: Optional[List[str]] = None,
+        grammar: Optional[str] = None,
+        tools_to_call_from: Optional[List[Tool]] = None,
+        **kwargs,
+    ) -> ChatMessage:
+        completion_kwargs = self._prepare_completion_kwargs(
+            messages=messages,
+            stop_sequences=stop_sequences,
+            grammar=grammar,
+            **kwargs,
+        )
+
+        messages = completion_kwargs.pop("messages")
+        stop_sequences = completion_kwargs.pop("stop", None)
+
+        max_new_tokens = (
+            kwargs.get("max_new_tokens")
+            or kwargs.get("max_tokens")
+            or self.kwargs.get("max_new_tokens")
+            or self.kwargs.get("max_tokens")
+        )
+
+        if max_new_tokens:
+            completion_kwargs["max_new_tokens"] = max_new_tokens
+
+        if hasattr(self, "processor"):
+            prompt_tensor = self.processor.apply_chat_template(
+                messages,
+                tools=[get_tool_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
+                return_tensors="pt",
+                tokenize=True,
+                return_dict=True,
+                add_generation_prompt=True if tools_to_call_from else False,
+            )
+        else:
+            prompt_tensor = self.tokenizer.apply_chat_template(
+                messages,
+                tools=[get_tool_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
+                return_tensors="pt",
+                return_dict=True,
+                add_generation_prompt=True if tools_to_call_from else False,
+            )
+
+        prompt_tensor = prompt_tensor.to(self.model.device)
+        count_prompt_tokens = prompt_tensor["input_ids"].shape[1]
+
+        if stop_sequences:
+            stopping_criteria = self.make_stopping_criteria(
+                stop_sequences, tokenizer=self.processor if hasattr(self, "processor") else self.tokenizer
+            )
+        else:
+            stopping_criteria = None
+
+        out = self.model.generate(
+            **prompt_tensor,
+            stopping_criteria=stopping_criteria,
+            **completion_kwargs,
+        )
+        generated_tokens = out[0, count_prompt_tokens:]
+        if hasattr(self, "processor"):
+            output_text = self.processor.decode(generated_tokens, skip_special_tokens=True)
+        else:
+            output_text = self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
+        self.last_input_token_count = count_prompt_tokens
+        self.last_output_token_count = len(generated_tokens)
+
+        if stop_sequences is not None:
+            output_text = remove_stop_sequences(output_text, stop_sequences)
+
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content=output_text,
+            raw={"out": output_text, "completion_kwargs": completion_kwargs},
+        )
+        if tools_to_call_from:
+            chat_message.tool_calls = [
+                get_tool_call_from_text(output_text, self.tool_name_key, self.tool_arguments_key)
+            ]
+        return chat_message
+
+
 __all__ = [
     "MessageRole",
     "tool_role_conversions",
@@ -1412,6 +1588,7 @@ __all__ = [
     "Model",
     "MLXModel",
     "TransformersModel",
+    "PreloadedTransformersModel",
     "ApiModel",
     "HfApiModel",
     "LiteLLMModel",

--- a/test.py
+++ b/test.py
@@ -1,0 +1,93 @@
+import sys
+sys.path.insert(0, r"C:\Users\jonna\Desktop\projetos\2_HUGGING_FACE_AGENT_AI\2_1_THE_SMOLAGENS_FRAMEWORK\smolagents_v1\smolagents\src")  
+
+from transformers   import BitsAndBytesConfig
+from src.smolagents import CodeAgent, TransformersModel
+
+model_id = "Qwen/Qwen2.5-Coder-32B-Instruct"
+
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit                =True,
+    bnb_4bit_compute_dtype      = "float16",
+    bnb_4bit_use_double_quant   = True,
+    bnb_4bit_quant_type         = "nf4"
+)
+
+model = TransformersModel(
+    model_id,
+    device_map          = "auto",
+    torch_dtype         = "auto",  # pode ser omitido se quiser
+    trust_remote_code   = True,
+    model_config        = {'quantization_config': bnb_config},
+    max_new_tokens      = 2000
+)
+
+'''
+agent = CodeAgent(tools=[], model=model)
+agent.run("Explain quantum mechanics in simple terms.")
+'''
+
+from langchain.docstore.document    import Document
+from langchain.text_splitter        import RecursiveCharacterTextSplitter
+from smolagents                     import Tool
+from langchain_community.retrievers import BM25Retriever
+from smolagents                     import CodeAgent, LiteLLMModel, FinalAnswerTool
+
+# tool
+class PartyPlanningRetrieverTool(Tool):
+    name        = "party_planning_retriever"
+    description = "Uses semantic search to retrieve relevant party planning ideas for Alfred's superhero-themed party at Wayne Manor."
+    inputs      = {
+        "query": {
+            "type":         "string",
+            "description":  "The query to perform. This should be a query related to party planning or superhero themes."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, docs, **kwargs):
+        super().__init__(**kwargs)
+        self.retriever = BM25Retriever.from_documents(docs, k=5)
+
+    def forward(self, query: str) -> str:
+        assert isinstance(query, str), "Your search query must be a string"
+
+        docs = self.retriever.invoke(query)
+
+        return "\nRetrieved ideas:\n" + "".join([f"\n\n===== Idea {str(i)} =====\n" + doc.page_content for i, doc in enumerate(docs)])
+
+
+# doc
+party_ideas = [
+    {"text": "A superhero-themed masquerade ball with luxury decor, including gold accents and velvet curtains.", "source": "Party Ideas 1"},
+    {"text": "Hire a professional DJ who can play themed music for superheroes like Batman and Wonder Woman.", "source": "Entertainment Ideas"},
+    {"text": "For catering, serve dishes named after superheroes, like 'The Hulk's Green Smoothie' and 'Iron Man's Power Steak.'", "source": "Catering Ideas"},
+    {"text": "Decorate with iconic superhero logos and projections of Gotham and other superhero cities around the venue.", "source": "Decoration Ideas"},
+    {"text": "Interactive experiences with VR where guests can engage in superhero simulations or compete in themed games.", "source": "Entertainment Ideas"}
+]
+
+source_docs = [Document(page_content=doc["text"], metadata={"source": doc["source"]}) for doc in party_ideas]
+
+# Split the documents into smaller chunks for more efficient search
+text_splitter = RecursiveCharacterTextSplitter(
+    chunk_size          = 500,
+    chunk_overlap       = 50,
+    add_start_index     = True,
+    strip_whitespace    = True,
+    separators          = ["\n\n", "\n", ".", " ", ""]
+)
+doc_processed = text_splitter.split_documents(source_docs)
+
+# Create the retriever tool
+party_planning_retriever = PartyPlanningRetrieverTool(doc_processed)
+
+# Initialize the agned
+agent = CodeAgent(tools=[party_planning_retriever, FinalAnswerTool()], model=model, verbosity_level = 3)
+
+# Response
+response = agent.run("Find ideas for a luxury superhero-themed party, including entertainment, catering, and decoration options.")
+
+print(response)
+'''
+{'Entertainment Ideas': ['Interactive experiences with VR where guests can engage in superhero simulations or compete in themed games.', 'Hire a professional DJ who can play themed music for superheroes like Batman and Wonder Woman.'], 'Catering Ideas': ["Serve dishes named after superheroes, such as 'The Hulk's Green Smoothie' and 'Iron Man's Power Steak.'"], 'Decoration Ideas': ['A superhero-themed masquerade ball with luxury decor, including gold accents and velvet curtains.', 'Decorate with iconic superhero logos and projections of Gotham and other superhero cities around the venue.']}
+'''


### PR DESCRIPTION
💡 Summary
This PR introduces a new class PreloadedTransformersModel to enable using preloaded and customized Hugging Face models directly in the SmolAgents framework. It is particularly useful for scenarios where models are already loaded (e.g., quantized with QLoRA or other custom configurations) and cannot be instantiated using only model_args or from_pretrained.


✨ What’s New
Added PreloadedTransformersModel, a wrapper that allows passing a custom transformers model instance (e.g., already loaded with BitsAndBytesConfig, QLoRA, or other low-level tweaks).

Supports AutoTokenizer, AutoProcessor, and model.generate kwargs.

Fully compatible with CodeAgent, including stop sequences and grammar handling.

Useful when models are loaded with configurations that can't be passed through the traditional constructor, such as:

model.config.use_cache = False

quantization configs like bnb_4bit_use_double_quant

shared weights across adapters or fine-tuned heads

Added optional is_vlm flag to handle Vision-Language Models (VLMs).
When is_vlm=True, the model expects an transformers.AutoModelForImageTextToText instead of a from transformers.AutoModelForCausalLM, and uses raw input/output logic suited for image-text models.

📦 Example Usage

import torch
from transformers   import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig
from smolagents     import CodeAgent, PreloadedTransformersModel

model_id = "Qwen/Qwen2.5-Coder-32B-Instruct"

bnb_config = BitsAndBytesConfig(
    load_in_4bit                = True,
    bnb_4bit_quant_type         = "nf4",
    bnb_4bit_compute_dtype      = torch.bfloat16,
    bnb_4bit_use_double_quant   = True
)

tokenizer       = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
model_engine    = AutoModelForCausalLM.from_pretrained(
    model_id,
    quantization_config = bnb_config,
    device_map          = "auto",
    trust_remote_code   = True
)

model = PreloadedTransformersModel(
    model_engine,
    tokenizer = tokenizer
)

agent   = CodeAgent(tools=[], model=model)
result  = agent.run("Explain quantum mechanics in simple terms.")
print(result)

✅ Motivation
The current TransformersModel assumes the model is always instantiated via from_pretrained with model_args. This PR enables greater flexibility, allowing advanced users to inject preloaded or customized models directly.