### PR TITLE
Clarify tool usage in agent step tutorial

### DIFF
--- a/docs/source/en/tutorials/memory.mdx
+++ b/docs/source/en/tutorials/memory.mdx
@@ -118,8 +118,7 @@ This will also let you update the memory on each step.
 from smolagents import HfApiModel, CodeAgent, ActionStep, TaskStep
 
 agent = CodeAgent(tools=[], model=HfApiModel(), verbosity_level=1)
-# If tools are provided, you need to send them to the Python executor using `send_tools`.
-# agent.python_executor.send_tools({**agent.tools})
+agent.python_executor.send_tools({**agent.tools})
 print(agent.memory.system_prompt)
 
 task = "What is the 20th Fibonacci number?"

--- a/docs/source/en/tutorials/memory.mdx
+++ b/docs/source/en/tutorials/memory.mdx
@@ -118,6 +118,8 @@ This will also let you update the memory on each step.
 from smolagents import HfApiModel, CodeAgent, ActionStep, TaskStep
 
 agent = CodeAgent(tools=[], model=HfApiModel(), verbosity_level=1)
+# If tools are provided, you need to send them to the Python executor using `send_tools`.
+# agent.python_executor.send_tools({**agent.tools})
 print(agent.memory.system_prompt)
 
 task = "What is the 20th Fibonacci number?"


### PR DESCRIPTION
Clarify tool usage in agent step tutorial.

I would consider this as a hotfix needed to have the docs aligned with the code implementation. However, I think we should simplify the procedure.

Fix #1170.

Also related to:
- #1165