### PR TITLE
Fix tool validation with multiple assignments

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -50,6 +50,10 @@ class MethodChecker(ast.NodeVisitor):
         for target in node.targets:
             if isinstance(target, ast.Name):
                 self.assigned_names.add(target.id)
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                for elt in target.elts:
+                    if isinstance(elt, ast.Name):
+                        self.assigned_names.add(elt.id)
         self.visit(node.value)
 
     def visit_With(self, node):

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -223,7 +223,8 @@ class Tool:
             method_checker.visit(forward_node)
 
             if len(method_checker.errors) > 0:
-                raise (ValueError("\n".join(method_checker.errors)))
+                errors = [f"- {error}" for error in method_checker.errors]
+                raise (ValueError(f"SimpleTool validation failed for {self.name}:\n" + "\n".join(errors)))
 
             forward_source_code = get_source(self.forward)
             tool_code = textwrap.dedent(


### PR DESCRIPTION
Fix tool validation with multiple assignments.

Currently, a tool with these code lines
```python
a, b = "1", "2"
c = a + b
```

raises an error:
```python
[
    "Name 'a' is undefined.",
    "Name 'b' is undefined.",
]
```