### PR TITLE
Pin mcpadapt >= 0.0.19 to include security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ litellm = [
   "litellm>=1.60.2",
 ]
 mcp = [
-  "mcpadapt>=0.0.15",
+  "mcpadapt>=0.0.19",  # Security fix
   "mcp",
 ]
 mlx-lm = [


### PR DESCRIPTION
Pin `mcpadapt` >= 0.0.19 to include security fix.

Close #1147.