### PR TITLE
actually pass executor_kwargs to docker environment container creatio…

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -167,6 +167,7 @@ class DockerExecutor(RemotePythonExecutor):
         logger,
         host: str = "127.0.0.1",
         port: int = 8888,
+        **kwargs,
     ):
         """
         Initialize the Docker-based Jupyter Kernel Gateway executor.
@@ -209,7 +210,7 @@ CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGat
 
             self.logger.log(f"Starting container on {host}:{port}...", level=LogLevel.INFO)
             self.container = self.client.containers.run(
-                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True
+                "jupyter-kernel", ports={"8888/tcp": (host, port)}, detach=True, **kwargs
             )
 
             retries = 0


### PR DESCRIPTION
Actually passing executor_kwargs to the docker executor.

Motivation: Allows to get more control over a secure local environment. It allows to mount read only files into the docker container so smolagents can have access to local data sources within docker.