### PR TITLE
Support class docstrings in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -461,6 +461,14 @@ def evaluate_class_def(
                         custom_tools,
                         authorized_imports,
                     )
+        elif (
+            isinstance(stmt, ast.Expr)
+            and stmt == class_def.body[0]
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        ):
+            # Check if it is a docstring: first statement in class body which is a string literal expression
+            class_dict["__doc__"] = stmt.value.value
         else:
             raise InterpreterError(f"Unsupported statement in class body: {stmt.__class__.__name__}")
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -97,6 +97,25 @@ class PythonInterpreterTester(unittest.TestCase):
         with pytest.raises(InterpreterError, match="Forbidden function evaluation: 'add_two'"):
             evaluate_python_code(code, {}, state=state)
 
+    def test_evaluate_class_def(self):
+        code = dedent('''\
+            class MyClass:
+                """A class with a value."""
+
+                def __init__(self, value):
+                    self.value = value
+
+                def get_value(self):
+                    return self.value
+
+            instance = MyClass(42)
+            result = instance.get_value()
+        ''')
+        state = {}
+        result, _ = evaluate_python_code(code, {}, state=state)
+        assert result == 42
+        assert state["instance"].__doc__ == "A class with a value."
+
     def test_evaluate_constant(self):
         code = "x = 3"
         state = {}
@@ -1249,26 +1268,6 @@ def test_evaluate_delete(code, state, expectation):
         evaluate_delete(delete_node, state, {}, {}, [])
         _ = state.pop("_operations_count", None)
         assert state == expectation
-
-
-def test_evaluate_class_def():
-    code = dedent('''\
-        class MyClass:
-            """A class with a value."""
-
-            def __init__(self, value):
-                self.value = value
-
-            def get_value(self):
-                return self.value
-
-        instance = MyClass(42)
-        result = instance.get_value()
-    ''')
-    state = {}
-    result, _ = evaluate_python_code(code, {}, state=state)
-    assert result == 42
-    assert state["instance"].__doc__ == "A class with a value."
 
 
 @pytest.mark.parametrize(

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1251,6 +1251,26 @@ def test_evaluate_delete(code, state, expectation):
         assert state == expectation
 
 
+def test_evaluate_class_def():
+    code = dedent('''\
+        class MyClass:
+            """A class with a value."""
+
+            def __init__(self, value):
+                self.value = value
+
+            def get_value(self):
+                return self.value
+
+        instance = MyClass(42)
+        result = instance.get_value()
+    ''')
+    state = {}
+    result, _ = evaluate_python_code(code, {}, state=state)
+    assert result == 42
+    assert state["instance"].__doc__ == "A class with a value."
+
+
 @pytest.mark.parametrize(
     "condition, state, expected_result",
     [


### PR DESCRIPTION
Support class docstrings in LocalPythonExecutor.

Fix #1189.