### PR TITLE
Support annotated assignment in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -469,6 +469,23 @@ def evaluate_class_def(
     return new_class
 
 
+def evaluate_annassign(
+    annassign: ast.AnnAssign,
+    state: Dict[str, Any],
+    static_tools: Dict[str, Callable],
+    custom_tools: Dict[str, Callable],
+    authorized_imports: List[str],
+) -> Any:
+    # If there's a value to assign, evaluate it
+    if annassign.value:
+        value = evaluate_ast(annassign.value, state, static_tools, custom_tools, authorized_imports)
+        # Set the value for the target
+        set_value(annassign.target, value, state, static_tools, custom_tools, authorized_imports)
+        return value
+    # For declarations without values (x: int), just return None
+    return None
+
+
 def evaluate_augassign(
     expression: ast.AugAssign,
     state: Dict[str, Any],
@@ -1259,6 +1276,8 @@ def evaluate_ast(
         # Assignment -> we evaluate the assignment which should update the state
         # We return the variable assigned as it may be used to determine the final result.
         return evaluate_assign(expression, *common_params)
+    elif isinstance(expression, ast.AnnAssign):
+        return evaluate_annassign(expression, *common_params)
     elif isinstance(expression, ast.AugAssign):
         return evaluate_augassign(expression, *common_params)
     elif isinstance(expression, ast.Call):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1072,6 +1072,36 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         assert res.__source__ == "def target_function():\n    return 'Hello world'"
 
 
+def test_evaluate_annassign():
+    code = dedent("""\
+        # Basic annotated assignment
+        x: int = 42
+
+        # Type annotations with expressions
+        y: float = x / 2
+
+        # Type annotation without assignment
+        z: list
+
+        # Type annotation with complex value
+        names: list = ["Alice", "Bob", "Charlie"]
+
+        # Type hint shouldn't restrict values at runtime
+        s: str = 123  # Would be a type error in static checking, but valid at runtime
+
+        # Access the values
+        result = (x, y, names, s)
+    """)
+    state = {}
+    evaluate_python_code(code, BASE_PYTHON_TOOLS, state=state)
+    assert state["x"] == 42
+    assert state["y"] == 21.0
+    assert "z" not in state  # z should be not be defined
+    assert state["names"] == ["Alice", "Bob", "Charlie"]
+    assert state["s"] == 123  # Type hints don't restrict at runtime
+    assert state["result"] == (42, 21.0, ["Alice", "Bob", "Charlie"], 123)
+
+
 @pytest.mark.parametrize(
     "code, expected_result",
     [


### PR DESCRIPTION
Support annotated assignment in LocalPythonExecutor.

Fix #1189 second issue.