### PR TITLE
Support `Literal` type annotations in `@tool` for defining enums

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import os
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import mcp
@@ -418,6 +418,49 @@ class TestTool:
 
         assert get_weather.inputs["locations"]["type"] == "array"
         assert get_weather.inputs["months"]["type"] == "array"
+
+    def test_tool_supports_string_literal(self):
+        @tool
+        def get_weather(unit: Literal["celsius", "fahrenheit"] = "celsius") -> None:
+            """
+            Get weather in the next days at given location.
+
+            Args:
+                unit: The unit of temperature
+            """
+            return
+
+        assert get_weather.inputs["unit"]["type"] == "string"
+        assert get_weather.inputs["unit"]["enum"] == ["celsius", "fahrenheit"]
+
+    def test_tool_supports_numeric_literal(self):
+        @tool
+        def get_choice(choice: Literal[1, 2, 3]) -> None:
+            """
+            Get choice based on the provided numeric literal.
+
+            Args:
+                choice: The numeric choice to be made.
+            """
+            return
+
+        assert get_choice.inputs["choice"]["type"] == "integer"
+        assert get_choice.inputs["choice"]["enum"] == [1, 2, 3]
+
+    def test_tool_supports_nullable_literal(self):
+        @tool
+        def get_choice(choice: Literal[1, 2, 3, None]) -> None:
+            """
+            Get choice based on the provided value.
+
+            Args:
+                choice: The numeric choice to be made.
+            """
+            return
+
+        assert get_choice.inputs["choice"]["type"] == "integer"
+        assert get_choice.inputs["choice"]["nullable"] is True
+        assert get_choice.inputs["choice"]["enum"] == [1, 2, 3]
 
     def test_saving_tool_produces_valid_pyhon_code_with_multiline_description(self, tmp_path):
         @tool


### PR DESCRIPTION
Allows defining enum choices with `@tool` using native [`Literal` type annotations](https://typing.python.org/en/latest/spec/literal.html#literal) instead of via docstring.

Closes https://github.com/huggingface/smolagents/issues/1194.

This is my first contribution, so let me know if there is anything I can improve, thank you! 🙂 

- ✅ `make quality` passes
- ✅ `make tests` passes
- ✅ New tests added for the functionality