### PR TITLE
add provider to CLI

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -90,7 +90,7 @@ def load_model(
     model_id: str,
     api_base: str | None = None,
     api_key: str | None = None,
-    provider: str | None,
+    provider: str | None = None,
 ) -> Model:
     if model_type == "OpenAIServerModel":
         return OpenAIServerModel(
@@ -124,7 +124,7 @@ def run_smolagent(
     model_id: str,
     api_base: str | None = None,
     api_key: str | None = None,
-    provider: str | None,
+    provider: str | None = None,
     imports: list[str] | None = None,
 ) -> None:
     load_dotenv()

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -85,7 +85,13 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def load_model(model_type: str, model_id: str, api_base: str | None = None, api_key: str | None = None, provider: str | None = "hf-inference") -> Model:
+def load_model(
+    model_type: str,
+    model_id: str,
+    api_base: str | None = None,
+    api_key: str | None = None,
+    provider: str | None = "hf-inference",
+) -> Model:
     if model_type == "OpenAIServerModel":
         return OpenAIServerModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -76,10 +76,16 @@ def parse_arguments():
         type=str,
         help="The API key for the model",
     )
+    group.add_argument(
+        "--provider",
+        type=str,
+        default="hf-inference",
+        help="The inference provider to use for the model",
+    )
     return parser.parse_args()
 
 
-def load_model(model_type: str, model_id: str, api_base: str | None = None, api_key: str | None = None) -> Model:
+def load_model(model_type: str, model_id: str, api_base: str | None = None, api_key: str | None = None, provider: str | None = "hf-inference") -> Model:
     if model_type == "OpenAIServerModel":
         return OpenAIServerModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
@@ -95,9 +101,11 @@ def load_model(model_type: str, model_id: str, api_base: str | None = None, api_
     elif model_type == "TransformersModel":
         return TransformersModel(model_id=model_id, device_map="auto")
     elif model_type == "HfApiModel":
+        print(f"Using provider: {provider}")
         return HfApiModel(
             model_id=model_id,
             token=api_key or os.getenv("HF_API_KEY"),
+            provider=provider,
         )
     else:
         raise ValueError(f"Unsupported model type: {model_type}")
@@ -110,11 +118,12 @@ def run_smolagent(
     model_id: str,
     api_base: str | None = None,
     api_key: str | None = None,
+    provider: str | None = "hf-inference",
     imports: list[str] | None = None,
 ) -> None:
     load_dotenv()
 
-    model = load_model(model_type, model_id, api_base=api_base, api_key=api_key)
+    model = load_model(model_type, model_id, api_base=api_base, api_key=api_key, provider=provider)
 
     available_tools = []
     for tool_name in tools:
@@ -141,6 +150,7 @@ def main() -> None:
         args.model_id,
         api_base=args.api_base,
         api_key=args.api_key,
+        provider=args.provider,
         imports=args.imports,
     )
 

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -79,7 +79,7 @@ def parse_arguments():
     group.add_argument(
         "--provider",
         type=str,
-        default="hf-inference",
+        default=None,
         help="The inference provider to use for the model",
     )
     return parser.parse_args()

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -90,7 +90,7 @@ def load_model(
     model_id: str,
     api_base: str | None = None,
     api_key: str | None = None,
-    provider: str | None = "hf-inference",
+    provider: str | None,
 ) -> Model:
     if model_type == "OpenAIServerModel":
         return OpenAIServerModel(

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -124,7 +124,7 @@ def run_smolagent(
     model_id: str,
     api_base: str | None = None,
     api_key: str | None = None,
-    provider: str | None = "hf-inference",
+    provider: str | None,
     imports: list[str] | None = None,
 ) -> None:
     load_dotenv()

--- a/src/smolagents/vision_web_browser.py
+++ b/src/smolagents/vision_web_browser.py
@@ -198,7 +198,7 @@ def run_webagent(prompt: str, model_type: str, model_id: str, provider: str) -> 
     load_dotenv()
 
     # Initialize the model based on the provided arguments
-    model = load_model(model_type, model_id, provider=provider)
+    model = load_model(model_type, model_id, provider=provider, api_base=None, api_key=None)
 
     global driver
     driver = initialize_driver()

--- a/src/smolagents/vision_web_browser.py
+++ b/src/smolagents/vision_web_browser.py
@@ -45,6 +45,12 @@ def parse_arguments():
         default="gpt-4o",
         help="The model ID to use for the specified model type",
     )
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default="hf-inference",
+        help="The inference provider to use for the model",
+    )
     return parser.parse_args()
 
 
@@ -187,12 +193,12 @@ When you have modals or cookie banners on screen, you should get rid of them bef
 """
 
 
-def run_webagent(prompt: str, model_type: str, model_id: str) -> None:
+def run_webagent(prompt: str, model_type: str, model_id: str, provider: str) -> None:
     # Load environment variables
     load_dotenv()
 
     # Initialize the model based on the provided arguments
-    model = load_model(model_type, model_id)
+    model = load_model(model_type, model_id, provider=provider)
 
     global driver
     driver = initialize_driver()
@@ -206,7 +212,7 @@ def run_webagent(prompt: str, model_type: str, model_id: str) -> None:
 def main() -> None:
     # Parse command line arguments
     args = parse_arguments()
-    run_webagent(args.prompt, args.model_type, args.model_id)
+    run_webagent(args.prompt, args.model_type, args.model_id, args.provider)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,11 +65,11 @@ def test_cli_main(capsys):
         with patch("smolagents.cli.CodeAgent") as mock_code_agent:
             from smolagents.cli import run_smolagent
 
-            run_smolagent("test_prompt", [], "HfApiModel", "test_model_id")
+            run_smolagent("test_prompt", [], "HfApiModel", "test_model_id", provider="hf-inference")
     # load_model
     assert len(mock_load_model.call_args_list) == 1
     assert mock_load_model.call_args.args == ("HfApiModel", "test_model_id")
-    assert mock_load_model.call_args.kwargs == {"api_base": None, "api_key": None}
+    assert mock_load_model.call_args.kwargs == {"api_base": None, "api_key": None, "provider": "hf-inference"}
     # CodeAgent
     assert len(mock_code_agent.call_args_list) == 1
     assert mock_code_agent.call_args.args == ()
@@ -93,10 +93,11 @@ def test_vision_web_browser_main():
             with patch("smolagents.vision_web_browser.CodeAgent") as mock_code_agent:
                 from smolagents.vision_web_browser import helium_instructions, run_webagent
 
-                run_webagent("test_prompt", "HfApiModel", "test_model_id")
+                run_webagent("test_prompt", "HfApiModel", "test_model_id", provider="hf-inference")
     # load_model
     assert len(mock_load_model.call_args_list) == 1
     assert mock_load_model.call_args.args == ("HfApiModel", "test_model_id")
+    assert mock_load_model.call_args.kwargs == {"api_base": None, "api_key": None, "provider": "hf-inference"}
     # CodeAgent
     assert len(mock_code_agent.call_args_list) == 1
     assert mock_code_agent.call_args.args == ()


### PR DESCRIPTION
I used CLI and inference providers to test things, so I modified CLI, and thought I'd push this in case you think this is helpful

tested with following: 
`smolagent "Plan a trip to Tokyo, Kyoto and Osaka between Mar 28 and Apr 7."  --model-type "HfApiModel" --model-id "meta-llama/Llama-4-Scout-17B-16E-Instruct" --imports "pandas numpy" --tools "web_search" --provider "fireworks-ai"`