### PR TITLE
SmolAgents MCP Client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,11 @@ jobs:
           pytest ./tests/test_tool_validation.py
         if: ${{ success() || failure() }}
 
+      - name: MCP client tests
+        run: |
+          pytest ./tests/test_mcp_client.py
+        if: ${{ success() || failure() }}
+
       - name: Types tests
         run: |
           pytest ./tests/test_types.py

--- a/docs/source/en/reference/tools.mdx
+++ b/docs/source/en/reference/tools.mdx
@@ -62,6 +62,10 @@ contains the API docs for the underlying classes.
 
 [[autodoc]] ToolCollection
 
+## MCP Client
+
+[[autodoc]] MCPClient
+
 ## Agent Types
 
 Agents can handle any type of object in-between tools; tools, being completely multimodal, can accept and return

--- a/docs/source/en/reference/tools.mdx
+++ b/docs/source/en/reference/tools.mdx
@@ -64,7 +64,7 @@ contains the API docs for the underlying classes.
 
 ## MCP Client
 
-[[autodoc]] MCPClient
+[[autodoc]] smolagents.mcp_client.MCPClient
 
 ## Agent Types
 

--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -248,3 +248,85 @@ with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}, trust_remote_
     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```
+
+#### Using MCPClient directly
+
+You can also work with MCP tools by using the `MCPClient` directly, which gives you more control over the connection and tool management:
+
+For stdio-based MCP servers:
+```python
+from smolagents import MCPClient, CodeAgent
+from mcp import StdioServerParameters
+import os
+
+server_parameters = StdioServerParameters(
+    command="uvx",  # Using uvx ensures dependencies are available
+    args=["--quiet", "pubmedmcp@0.1.3"],
+    env={"UV_PYTHON": "3.12", **os.environ},
+)
+
+with MCPClient(server_parameters) as tools:
+    agent = CodeAgent(tools=tools, model=model, add_base_tools=True)
+    agent.run("Please find the latest research on COVID-19 treatment.")
+```
+
+For SSE-based MCP servers:
+```python
+from smolagents import MCPClient, CodeAgent
+
+with MCPClient({"url": "http://127.0.0.1:8000/sse"}) as tools:
+    agent = CodeAgent(tools=tools, model=model, add_base_tools=True)
+    agent.run("Please find a remedy for hangover.")
+```
+
+You can also manually manage the connection lifecycle with the try...finally pattern:
+
+```python
+from smolagents import MCPClient, CodeAgent
+from mcp import StdioServerParameters
+import os
+
+# Initialize server parameters
+server_parameters = StdioServerParameters(
+    command="uvx",
+    args=["--quiet", "pubmedmcp@0.1.3"],
+    env={"UV_PYTHON": "3.12", **os.environ},
+)
+
+# Manually manage the connection
+try:
+    mcp_client = MCPClient(server_parameters)
+    tools = mcp_client.get_tools()
+
+    # Use the tools with your agent
+    agent = CodeAgent(tools=tools, model=model, add_base_tools=True)
+    result = agent.run("What are the recent therapeutic approaches for Alzheimer's disease?")
+
+    # Process the result as needed
+    print(f"Agent response: {result}")
+finally:
+    # Always ensure the connection is properly closed
+    mcp_client.disconnect()
+```
+
+You can also connect to multiple MCP servers at once by passing a list of server parameters:
+```python
+from smolagents import MCPClient, CodeAgent
+from mcp import StdioServerParameters
+import os
+
+server_params1 = StdioServerParameters(
+    command="uvx",
+    args=["--quiet", "pubmedmcp@0.1.3"],
+    env={"UV_PYTHON": "3.12", **os.environ},
+)
+
+server_params2 = {"url": "http://127.0.0.1:8000/sse"}
+
+with MCPClient([server_params1, server_params2]) as tools:
+    agent = CodeAgent(tools=tools, model=model, add_base_tools=True)
+    agent.run("Please analyze the latest research and suggest remedies for headaches.")
+```
+
+> [!WARNING]
+> **Security Warning:** The same security warnings mentioned for `ToolCollection.from_mcp` apply when using `MCPClient` directly.

--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -249,7 +249,7 @@ with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/sse"}, trust_remote_
     agent.run("Please find a remedy for hangover.")
 ```
 
-#### Using MCPClient directly
+### Use MCP tools with MCPClient directly
 
 You can also work with MCP tools by using the `MCPClient` directly, which gives you more control over the connection and tool management:
 

--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -233,7 +233,7 @@ Leverage tools from the hundreds of MCP servers available on [glama.ai](https://
 > **Security Warning:** Using MCP servers comes with security risks:
 > - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
-> - **SSE-based MCP servers** in the current implementation may be vulnerable to remote code execution attacks. A fix is being developed, but caution is still advised.
+> - **SSE-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
 >
 > Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
 

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -21,6 +21,7 @@ from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *
+from .mcp_client import *
 from .memory import *
 from .models import *
 from .monitoring import *

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -21,7 +21,6 @@ from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *
-from .mcp_client import *
 from .memory import *
 from .models import *
 from .monitoring import *

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -39,7 +39,7 @@ class MCPClient:
     **Attributes**:
         tools: The SmolAgents tools available from the MCP server.
 
-    Usage:
+    Example:
         # fully managed context manager + stdio
         with MCPClient(...) as tools:
             # tools are now available

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -90,9 +90,12 @@ class MCPClient:
         """Disconnect from the MCP server"""
         self._adapter.__exit__(exc_type, exc_value, exc_traceback)
 
-    @property
-    def tools(self) -> list[Tool]:
+    def get_tools(self) -> list[Tool]:
         """The SmolAgents tools available from the MCP server.
+
+        Note: for now, this always returns the tools available at the creation of the session
+        but it will in a future release return also new tools available from the MCP server if
+        any at call time.
 
         Raises:
             ValueError: If the MCP server tools is None (usually assuming the server is not started).
@@ -112,7 +115,7 @@ class MCPClient:
         Note that because of the `.connect` in the init, the mcp_client
         is already connected at this point.
         """
-        return self.tools
+        return self._tools
 
     def __exit__(
         self,

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    from mcp import (
+        StdioServerParameters,
+    )
+    from mcpadapt.core import MCPAdapt
+    from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+except ImportError:
+    raise ImportError("MCPClient needs optional dependencies to be installed, run `pip install smolagents[mcp]`")
+
+from typing import Any, Optional, Type, TracebackType
+
+from smolagents.tools import Tool
+
+
+class MCPClient:
+    """Manages the connection to an MCP server and make its tools available to SmolAgents.
+
+    Note: tools can only be accessed after the connection has been started with the
+        `connect()` method, done during the init. If you don't use the context manager
+        we strongly encourage to use "try ... finally" to ensure the connection is cleaned up.
+
+    Attributes:
+        tools: The SmolAgents tools available from the MCP server.
+
+    Usage:
+        # fully managed context manager + stdio
+        with MCPClient(...) as tools:
+            # tools are now available
+
+        # context manager + sse
+        with MCPClient({"url": "http://localhost:8000/sse"}) as tools:
+            # tools are now available
+
+        # manually manage the connection via the mcp_client object:
+        try:
+            mcp_client = MCPClient(...)
+            tools = mcp_client.tools
+
+            # use your tools here.
+        finally:
+            mcp_client.stop()
+    """
+
+    def __init__(
+        self,
+        serverparams: StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]],
+    ):
+        """Initialize the MCP Client
+
+        Args:
+            serverparams (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):
+                MCP server parameters (stdio or sse). Can be a list if you want to connect multiple MCPs at once.
+
+        """
+        super().__init__()
+        self._adapter = MCPAdapt(serverparams, SmolAgentsAdapter())
+        self._tools = None
+
+        self.connect()
+
+    def connect(self):
+        """Connect to the MCP server and initialize the tools."""
+        self._tools = self._adapter.__enter__()
+
+    def disconnect(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        exc_traceback: Optional[TracebackType] = None,
+    ):
+        """Disconnect from the MCP server"""
+        self._adapter.__exit__(exc_type, exc_value, exc_traceback)
+
+    @property
+    def tools(self) -> list[Tool]:
+        """The SmolAgents tools available from the MCP server.
+
+        Raises:
+            ValueError: If the MCP server tools is None (usually assuming the server is not started).
+
+        Returns:
+            The SmolAgents tools available from the MCP server.
+        """
+        if self._tools is None:
+            raise ValueError(
+                "Couldn't retrieve tools from MCP server, run `mcp_client.connect()` first before accessing `tools`"
+            )
+        return self._tools
+
+    def __enter__(self):
+        """Connect to the MCP server and return the tools directly."""
+        self.connect()
+        return self.tools
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Disconnect from the MCP server."""
+        self.disconnect(exc_type, exc_value, traceback)

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -23,7 +23,8 @@ try:
 except ImportError:
     raise ImportError("MCPClient needs optional dependencies to be installed, run `pip install smolagents[mcp]`")
 
-from typing import Any, Optional, Type, TracebackType
+from types import TracebackType
+from typing import Any, Optional, Type
 
 from smolagents.tools import Tool
 
@@ -70,13 +71,13 @@ class MCPClient:
         """
         super().__init__()
         self._adapter = MCPAdapt(serverparams, SmolAgentsAdapter())
-        self._tools = None
+        self._tools: list[Tool] | None = None
 
         self.connect()
 
     def connect(self):
         """Connect to the MCP server and initialize the tools."""
-        self._tools = self._adapter.__enter__()
+        self._tools: list[Tool] = self._adapter.__enter__()
 
     def disconnect(
         self,
@@ -104,10 +105,18 @@ class MCPClient:
         return self._tools
 
     def __enter__(self) -> list[Tool]:
-        """Connect to the MCP server and return the tools directly."""
-        self.connect()
+        """Connect to the MCP server and return the tools directly.
+
+        Note that because of the `.connect` in the init, the mcp_client
+        is already connected at this point.
+        """
         return self.tools
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        exc_traceback: Optional[TracebackType],
+    ):
         """Disconnect from the MCP server."""
-        self.disconnect(exc_type, exc_value, traceback)
+        self.disconnect(exc_type, exc_value, exc_traceback)

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -36,7 +36,7 @@ class MCPClient:
         `connect()` method, done during the init. If you don't use the context manager
         we strongly encourage to use "try ... finally" to ensure the connection is cleaned up.
 
-    Attributes:
+    **Attributes**:
         tools: The SmolAgents tools available from the MCP server.
 
     Usage:

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -103,7 +103,7 @@ class MCPClient:
             )
         return self._tools
 
-    def __enter__(self):
+    def __enter__(self) -> list[Tool]:
         """Connect to the MCP server and return the tools directly."""
         self.connect()
         return self.tools

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -52,7 +52,7 @@ class MCPClient:
         # manually manage the connection via the mcp_client object:
         try:
             mcp_client = MCPClient(...)
-            tools = mcp_client.tools
+            tools = mcp_client.get_tools()
 
             # use your tools here.
         finally:

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -39,6 +39,10 @@ class MCPClient:
         `connect()` method, done during the init. If you don't use the context manager
         we strongly encourage to use "try ... finally" to ensure the connection is cleaned up.
 
+    Args:
+        server_parameters (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):
+            MCP server parameters (stdio or sse). Can be a list if you want to connect multiple MCPs at once.
+
     Example:
         ```python
         # fully managed context manager + stdio
@@ -64,13 +68,6 @@ class MCPClient:
         self,
         server_parameters: StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]],
     ):
-        """Initialize the MCP Client
-
-        Args:
-            server_parameters (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):
-                MCP server parameters (stdio or sse). Can be a list if you want to connect multiple MCPs at once.
-
-        """
         super().__init__()
         self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter())
         self._tools: list[Tool] | None = None
@@ -93,7 +90,7 @@ class MCPClient:
     def get_tools(self) -> list[Tool]:
         """The SmolAgents tools available from the MCP server.
 
-        Note: for now, this always returns the tools available at the creation of the session
+        Note: for now, this always returns the tools available at the creation of the session,
         but it will in a future release return also new tools available from the MCP server if
         any at call time.
 
@@ -101,7 +98,7 @@ class MCPClient:
             ValueError: If the MCP server tools is None (usually assuming the server is not started).
 
         Returns:
-            The SmolAgents tools available from the MCP server.
+            list[Tool]: The SmolAgents tools available from the MCP server.
         """
         if self._tools is None:
             raise ValueError(

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -29,6 +29,9 @@ from typing import Any, Optional, Type
 from smolagents.tools import Tool
 
 
+__all__ = ["MCPClient"]
+
+
 class MCPClient:
     """Manages the connection to an MCP server and make its tools available to SmolAgents.
 

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -57,6 +57,7 @@ class MCPClient:
             # use your tools here.
         finally:
             mcp_client.stop()
+        ```
     """
 
     def __init__(

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -40,6 +40,7 @@ class MCPClient:
         tools: The SmolAgents tools available from the MCP server.
 
     Example:
+        ```python
         # fully managed context manager + stdio
         with MCPClient(...) as tools:
             # tools are now available

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -59,17 +59,17 @@ class MCPClient:
 
     def __init__(
         self,
-        serverparams: StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]],
+        server_parameters: StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]],
     ):
         """Initialize the MCP Client
 
         Args:
-            serverparams (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):
+            server_parameters (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):
                 MCP server parameters (stdio or sse). Can be a list if you want to connect multiple MCPs at once.
 
         """
         super().__init__()
-        self._adapter = MCPAdapt(serverparams, SmolAgentsAdapter())
+        self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter())
         self._tools: list[Tool] | None = None
 
         self.connect()

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -36,9 +36,6 @@ class MCPClient:
         `connect()` method, done during the init. If you don't use the context manager
         we strongly encourage to use "try ... finally" to ensure the connection is cleaned up.
 
-    **Attributes**:
-        tools: The SmolAgents tools available from the MCP server.
-
     Example:
         ```python
         # fully managed context manager + stdio

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -27,8 +27,8 @@ def echo_server_script():
 
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
-    serverparams = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
-    with MCPClient(serverparams) as tools:
+    server_parameters = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    with MCPClient(server_parameters) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
         assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
@@ -36,8 +36,8 @@ def test_mcp_client_with_syntax(echo_server_script: str):
 
 def test_mcp_client_try_finally_syntax(echo_server_script: str):
     """Test the MCPClient with the try ... finally syntax."""
-    serverparams = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
-    mcp_client = MCPClient(serverparams)
+    server_parameters = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    mcp_client = MCPClient(server_parameters)
     try:
         tools = mcp_client.get_tools()
         assert len(tools) == 1
@@ -49,11 +49,11 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
 
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
-    serverparams = [
+    server_parameters = [
         StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
         StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
     ]
-    with MCPClient(serverparams) as tools:
+    with MCPClient(server_parameters) as tools:
         assert len(tools) == 2
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "echo_tool"

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,4 +1,3 @@
-# TODO(@grll): add tests for the MCPClient when designed accepted.
 from textwrap import dedent
 
 import pytest
@@ -27,22 +26,22 @@ def echo_server_script():
 
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
-    server_parameters = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
     with MCPClient(server_parameters) as tools:
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+        assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
 
 
 def test_mcp_client_try_finally_syntax(echo_server_script: str):
     """Test the MCPClient with the try ... finally syntax."""
-    server_parameters = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
     mcp_client = MCPClient(server_parameters)
     try:
         tools = mcp_client.get_tools()
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
-        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+        assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
     finally:
         mcp_client.disconnect()
 
@@ -50,12 +49,12 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
     server_parameters = [
-        StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
-        StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
+        StdioServerParameters(command="python", args=["-c", echo_server_script]),
+        StdioServerParameters(command="python", args=["-c", echo_server_script]),
     ]
     with MCPClient(server_parameters) as tools:
         assert len(tools) == 2
         assert tools[0].name == "echo_tool"
         assert tools[1].name == "echo_tool"
-        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
-        assert tools[1].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+        assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
+        assert tools[1].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,47 @@
+# TODO(@grll): add tests for the MCPClient when designed accepted.
+from textwrap import dedent
+
+import pytest
+from mcp import StdioServerParameters
+
+from smolagents.mcp_client import MCPClient
+
+
+@pytest.fixture
+def echo_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Echo Server")
+
+        @mcp.tool()
+        def echo_tool(text: str) -> str:
+            """Echo the input text"""
+            return f"Echo: {text}"
+
+        mcp.run()
+        '''
+    )
+
+
+def test_mcp_client_with_syntax(echo_server_script: str):
+    """Test the MCPClient with the context manager syntax."""
+    serverparams = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    with MCPClient(serverparams) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "echo_tool"
+        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+
+
+def test_mcp_client_try_finally_syntax(echo_server_script: str):
+    """Test the MCPClient with the try ... finally syntax."""
+    serverparams = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
+    mcp_client = MCPClient(serverparams)
+    try:
+        tools = mcp_client.tools
+        assert len(tools) == 1
+        assert tools[0].name == "echo_tool"
+        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+    finally:
+        mcp_client.disconnect()

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -46,6 +46,7 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
     finally:
         mcp_client.disconnect()
 
+
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
     serverparams = [

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -39,9 +39,22 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
     serverparams = StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script])
     mcp_client = MCPClient(serverparams)
     try:
-        tools = mcp_client.tools
+        tools = mcp_client.get_tools()
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
         assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
     finally:
         mcp_client.disconnect()
+
+def test_multiple_servers(echo_server_script: str):
+    """Test the MCPClient with multiple servers."""
+    serverparams = [
+        StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
+        StdioServerParameters(command="uv", args=["run", "python", "-c", echo_server_script]),
+    ]
+    with MCPClient(serverparams) as tools:
+        assert len(tools) == 2
+        assert tools[0].name == "echo_tool"
+        assert tools[1].name == "echo_tool"
+        assert tools[0].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"
+        assert tools[1].forward({"text": "Hello, world!"}) == "Echo: Hello, world!"


### PR DESCRIPTION
Fixes #1179

As discussed in the issue above the idea is to introduce a new class: `MCPClient` allowing our users to manage the connection with one or several MCP servers.

It supports 2 syntaxes:
1. with a context manager for a fully managed connection with the MCP server, similar to what `ToolCollection.from_mcp` is doing today.
2. a new try / finally syntax which allow more fine grained control over the connection and its lifecycle via a new mcp_client instance.

Note 1: I have moved the `.connect()` inside the __init__ of the MCPClient I am not sure it is desirable here. Initially I kept it outside even though it's one more call in my opinion it makes things more explicit while if you want less boilerplate you can always use the with syntax.

Note 2: I have added a couple of tests but documentation is missing, waiting for a confirmation of the design and then I can add.

cc: @aymeric-roucher / @albertvillanova 