### PR TITLE
Add audio input to gradioUI

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -307,7 +307,7 @@ class GradioUI:
                     )
                     if speech2text_func:
                         audio_input = gr.Audio(
-                            sources=["microphone"], 
+                            sources=["upload", "microphone"], 
                             label="Voice Input",
                             waveform_options=gr.WaveformOptions(
                             waveform_color="#01C6FF",

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -271,10 +271,17 @@ class GradioUI:
             gr.Button(interactive=False),
         )
 
-    def launch(self, share: bool = True, **kwargs):
-        self.create_app().launch(debug=True, share=share, **kwargs)
+    def launch(self, share: bool = True, speech2text_func = None, **kwargs):
+        self.create_app(speech2text_func).launch(debug=True, share=share, **kwargs)
 
-    def create_app(self):
+    def create_app(self, speech2text_func = None):
+
+        def handle_input(text_input, audio_input):
+            if audio_input: 
+                return speech2text_func(audio_input)
+            return text_input
+
+
         import gradio as gr
 
         with gr.Blocks(theme="ocean", fill_height=True) as demo:
@@ -298,6 +305,10 @@ class GradioUI:
                         container=False,
                         placeholder="Enter your prompt here and press Shift+Enter or press the button",
                     )
+                    if speech2text_func:
+                        audio_input = gr.Audio(source="microphone", type="filepath", label="Voice Input")
+                    else:
+                        audio_input = None
                     submit_btn = gr.Button("Submit", variant="primary")
 
                 # If an upload folder is provided, enable the upload feature
@@ -346,10 +357,18 @@ class GradioUI:
             )
 
             submit_btn.click(
+                handle_input,
+                inputs=[text_input, audio_input], 
+                outputs=[text_input],  # Update the text input with transcribed text if audio is provided
+            ).then(
                 self.log_user_message,
                 [text_input, file_uploads_log],
                 [stored_messages, text_input, submit_btn],
-            ).then(self.interact_with_agent, [stored_messages, chatbot, session_state], [chatbot]).then(
+            ).then(
+                self.interact_with_agent,
+                [stored_messages, chatbot, session_state],
+                [chatbot],
+            ).then(
                 lambda: (
                     gr.Textbox(
                         interactive=True, placeholder="Enter your prompt here and press Shift+Enter or the button"

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -369,6 +369,10 @@ class GradioUI:
                 inputs=[text_input, audio_input], 
                 outputs=[text_input],  # Update the text input with transcribed text if audio is provided
             ).then(
+                lambda: None,
+                inputs=None,
+                outputs=[audio_input],  # Clear audio_input
+            ).then(
                 self.log_user_message,
                 [text_input, file_uploads_log],
                 [stored_messages, text_input, submit_btn],

--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -306,7 +306,15 @@ class GradioUI:
                         placeholder="Enter your prompt here and press Shift+Enter or press the button",
                     )
                     if speech2text_func:
-                        audio_input = gr.Audio(source="microphone", type="filepath", label="Voice Input")
+                        audio_input = gr.Audio(
+                            sources=["microphone"], 
+                            label="Voice Input",
+                            waveform_options=gr.WaveformOptions(
+                            waveform_color="#01C6FF",
+                            waveform_progress_color="#0066B4",
+                            skip_length=2,
+                            show_controls=False,
+                        ),)
                     else:
                         audio_input = None
                     submit_btn = gr.Button("Submit", variant="primary")


### PR DESCRIPTION
Hi, 

I am experimenting with smolagents and the first thing I wanted to do was to simply give a vocal command and get a result from it. Unfortunately the default gradio interface does not implement voice command. Hence this PR.

I simply added the possibility to input a vocal command, be it from microphone or audio file. 

You can find the demo here https://huggingface.co/spaces/GTimothee/smolagent

Basically what I implemented works as follows:  if you want to input voice command, you need a function to process it. So the idea is that you must pass a function to process the audio as you like, and adding it will enable gradio UI to just display an audio input. Then on submit it will run your function to extract the text out of the audio, and pass it to the agent. Of course the next step will be to enable audio output for the agent. 

```python
GradioUI(agent).launch(speech2text_func=speech2text_func)
```

You can find all the code in the app.py of my space.