### PR TITLE
fix: creating tool should not affect function that is being wrapped

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -928,8 +928,12 @@ def tool(tool_function: Callable) -> Tool:
     SimpleTool.description = tool_json_schema["description"]
     SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
     SimpleTool.output_type = tool_json_schema["return"]["type"]
-    # Bind the tool function to the forward method
-    SimpleTool.forward = staticmethod(tool_function)
+    @wraps(tool_function)
+    def wrapped_function(*args, **kwargs):
+        return tool_function(*args, **kwargs)
+    
+    # Bind the copied function to the forward method
+    SimpleTool.forward = staticmethod(wrapped_function)
 
     # Get the signature parameters of the tool function
     sig = inspect.signature(tool_function)

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -928,10 +928,11 @@ def tool(tool_function: Callable) -> Tool:
     SimpleTool.description = tool_json_schema["description"]
     SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
     SimpleTool.output_type = tool_json_schema["return"]["type"]
+
     @wraps(tool_function)
     def wrapped_function(*args, **kwargs):
         return tool_function(*args, **kwargs)
-    
+
     # Bind the copied function to the forward method
     SimpleTool.forward = staticmethod(wrapped_function)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 import os
 from textwrap import dedent
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -518,6 +519,39 @@ class TestTool:
         with pytest.raises(ValueError) as e:
             Tool.from_dict({"name": "invalid_tool"})
         assert "must contain 'code' key" in str(e)
+
+    def test_tool_decorator_preserves_original_function(self):
+        # Define a test function with type hints and docstring
+        def test_function(items: List[str]) -> str:
+            """Join a list of strings.
+            
+            Args:
+                items: A list of strings to join
+                
+            Returns:
+                The joined string
+            """
+            return ", ".join(items)
+        
+        # Store original function signature, name, and source
+        original_signature = inspect.signature(test_function)
+        original_name = test_function.__name__
+        original_docstring = test_function.__doc__
+        
+        # Create a tool from the function
+        test_tool = tool(test_function)
+        
+        # Check that the original function is unchanged
+        assert original_signature == inspect.signature(test_function)
+        assert original_name == test_function.__name__
+        assert original_docstring == test_function.__doc__
+        
+        # Verify that the tool's forward method has a different signature (it has 'self')
+        tool_forward_sig = inspect.signature(test_tool.forward)
+        assert list(tool_forward_sig.parameters.keys())[0] == "self"
+        
+        # Original function should not have 'self' parameter
+        assert "self" not in original_signature.parameters
 
 
 @pytest.fixture

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -524,32 +524,30 @@ class TestTool:
         # Define a test function with type hints and docstring
         def test_function(items: List[str]) -> str:
             """Join a list of strings.
-            
             Args:
                 items: A list of strings to join
-                
             Returns:
                 The joined string
             """
             return ", ".join(items)
-        
+
         # Store original function signature, name, and source
         original_signature = inspect.signature(test_function)
         original_name = test_function.__name__
         original_docstring = test_function.__doc__
-        
+
         # Create a tool from the function
         test_tool = tool(test_function)
-        
+
         # Check that the original function is unchanged
         assert original_signature == inspect.signature(test_function)
         assert original_name == test_function.__name__
         assert original_docstring == test_function.__doc__
-        
+
         # Verify that the tool's forward method has a different signature (it has 'self')
         tool_forward_sig = inspect.signature(test_tool.forward)
         assert list(tool_forward_sig.parameters.keys())[0] == "self"
-        
+
         # Original function should not have 'self' parameter
         assert "self" not in original_signature.parameters
 


### PR DESCRIPTION
This PR addresses the bug where calling tool(a_function) was editing the function signature of the the function that was passed in. Instead of this, the function should be wrapped so that the smolagents code doesn't affect the function that was provided.