### PR TITLE
Fix CI test by updating LiteLLM error message

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -196,7 +196,7 @@ class TestLiteLLMModel:
     @pytest.mark.parametrize(
         "model_id, error_flag",
         [
-            ("groq/llama-3.3-70b", "Missing API Key"),
+            ("groq/llama-3.3-70b", "Invalid API Key"),
             ("cerebras/llama-3.3-70b", "The api_key client option must be set"),
             ("mistral/mistral-tiny", "The api_key client option must be set"),
         ],


### PR DESCRIPTION
Fix CI test by updating LiteLLM error message.

This fix is required after `litellm-1.66.2` release: https://pypi.org/project/litellm/1.66.2/

See: https://github.com/huggingface/smolagents/actions/runs/14510658163/job/40708376431?pr=1211
```
FAILED tests/test_models.py::TestLiteLLMModel::test_call_different_providers_without_key[groq/llama-3.3-70b-Missing API Key] - assert 'Missing API Key' in '<ExceptionInfo litellm.BadRequestError: GroqException - {"error":{"message":"Invalid API Key","type":"invalid_request_error","code":"invalid_api_key"}}\n tblen=7>'
 +  where '<ExceptionInfo litellm.BadRequestError: GroqException - {"error":{"message":"Invalid API Key","type":"invalid_request_error","code":"invalid_api_key"}}\n tblen=7>' = str(<ExceptionInfo litellm.BadRequestError: GroqException - {"error":{"message":"Invalid API Key","type":"invalid_request_error","code":"invalid_api_key"}}\n tblen=7>)
```