### PR TITLE
add the clear_memory to the chatbot.clear

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -271,6 +271,9 @@ class GradioUI:
             gr.Button(interactive=False),
         )
 
+    def clear_memory(self):
+        self.agent.memory.reset()
+
     def launch(self, share: bool = True, **kwargs):
         self.create_app().launch(debug=True, share=share, **kwargs)
 
@@ -328,6 +331,9 @@ class GradioUI:
                 resizeable=True,
                 scale=1,
             )
+
+            # Clear the agent memory also
+            chatbot.clear(self.clear_memory)
 
             # Set up event handlers
             text_input.submit(


### PR DESCRIPTION
The issues: https://github.com/huggingface/smolagents/issues/1205
Chatbot clear button didn't clear the agent memory. I will waste tokens on old messages and return unexpected results.
Using the chatbot.clear and clear_memory function to clear memory.