### PR TITLE
Add back call ID to TOOL_RESPONSE messages

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -122,7 +122,8 @@ class ActionStep(MemoryStep):
                     content=[
                         {
                             "type": "text",
-                            "text": f"Observation:\n{self.observations}",
+                            "text": (f"Call id: {self.tool_calls[0].id}\n" if self.tool_calls else "")
+                            + f"Observation:\n{self.observations}",
                         }
                     ],
                 )


### PR DESCRIPTION
Add back "Call id:" section to `TOOL_RESEPONSE` messages which was removed in https://github.com/huggingface/smolagents/pull/1148.

This fixes a regression in the v1.14.0 release. See https://github.com/huggingface/smolagents/issues/1224 for additional details.