### PR TITLE
Set __name__ to "__main__" in local Python interpreter

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1497,7 +1497,7 @@ class LocalPythonExecutor(PythonExecutor):
         max_print_outputs_length: Optional[int] = None,
     ):
         self.custom_tools = {}
-        self.state = {}
+        self.state = {"__name__": "__main__"}
         self.max_print_outputs_length = max_print_outputs_length
         if max_print_outputs_length is None:
             self.max_print_outputs_length = DEFAULT_MAX_LEN_OUTPUT

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1682,6 +1682,10 @@ def test_check_import_authorized(module: str, authorized_imports: list[str], exp
 
 
 class TestLocalPythonExecutor:
+    def test_state_name(self):
+        executor = LocalPythonExecutor(additional_authorized_imports=[])
+        assert executor.state.get("__name__") == "__main__"
+
     @pytest.mark.parametrize(
         "code",
         [


### PR DESCRIPTION
Set `__name__` to `"__main__"` in local Python interpreter.

Fix #1229.