### PR TITLE
Move MCPClient to root-level lib and manage optional dependencies

### DIFF
--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -21,6 +21,7 @@ from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *
+from .mcp_client import *
 from .memory import *
 from .models import *
 from .monitoring import *

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import suppress
 __version__ = "1.15.0.dev0"
 
 from .agent_types import *  # noqa: I001
@@ -22,8 +21,7 @@ from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *
-with suppress(ImportError):
-    from .mcp_client import *
+from .mcp_client import *
 from .memory import *
 from .models import *
 from .monitoring import *

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from contextlib import suppress
 __version__ = "1.15.0.dev0"
 
 from .agent_types import *  # noqa: I001
@@ -21,7 +22,8 @@ from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *
-from .mcp_client import *
+with suppress(ImportError):
+    from .mcp_client import *
 from .memory import *
 from .models import *
 from .monitoring import *

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -65,7 +65,6 @@ class MCPClient:
         self,
         server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
     ):
-        super().__init__()
         try:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -21,7 +21,6 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Optional, Type
 
 from smolagents.tools import Tool
-from smolagents.utils import _is_package_available
 
 
 __all__ = ["MCPClient"]
@@ -66,18 +65,14 @@ class MCPClient:
         self,
         server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
     ):
-        if not _is_package_available("mcpadapt"):
-            raise ModuleNotFoundError(
-                "MCPClient needs optional dependencies to be installed, run `pip install smolagents[mcp]`"
-            )
         super().__init__()
-
-        from mcpadapt.core import MCPAdapt
-        from mcpadapt.smolagents_adapter import SmolAgentsAdapter
-
+        try:
+            from mcpadapt.core import MCPAdapt
+            from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Please install 'mcp' extra to use MCPClient: `pip install 'smolagents[mcp]'`")
         self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter())
         self._tools: list[Tool] | None = None
-
         self.connect()
 
     def connect(self):

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 from smolagents.tools import Tool
 from smolagents.utils import _is_package_available
@@ -62,7 +62,7 @@ class MCPClient:
 
     def __init__(
         self,
-        server_parameters: Union["StdioServerParameters", dict[str, Any], list[Union["StdioServerParameters", dict[str, Any]]]],
+        server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
     ):
         if not _is_package_available("mcpadapt"):
             raise ModuleNotFoundError(

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any, Optional, Type, Union
 
 from smolagents.tools import Tool
 from smolagents.utils import _is_package_available
@@ -62,7 +62,7 @@ class MCPClient:
 
     def __init__(
         self,
-        server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
+        server_parameters: Union["StdioServerParameters", dict[str, Any], list[Union["StdioServerParameters", dict[str, Any]]]],
     ):
         if not _is_package_available("mcpadapt"):
             raise ModuleNotFoundError(

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -14,22 +14,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-try:
-    from mcp import (
-        StdioServerParameters,
-    )
-    from mcpadapt.core import MCPAdapt
-    from mcpadapt.smolagents_adapter import SmolAgentsAdapter
-except ImportError:
-    raise ImportError("MCPClient needs optional dependencies to be installed, run `pip install smolagents[mcp]`")
 
 from types import TracebackType
-from typing import Any, Optional, Type
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 from smolagents.tools import Tool
+from smolagents.utils import _is_package_available
 
 
 __all__ = ["MCPClient"]
+
+if TYPE_CHECKING:
+    from mcpadapt.core import StdioServerParameters
 
 
 class MCPClient:
@@ -66,9 +62,17 @@ class MCPClient:
 
     def __init__(
         self,
-        server_parameters: StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]],
+        server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
     ):
+        if not _is_package_available("mcpadapt"):
+            raise ModuleNotFoundError(
+                "MCPClient needs optional dependencies to be installed, run `pip install smolagents[mcp]`"
+            )
         super().__init__()
+
+        from mcpadapt.core import MCPAdapt
+        from mcpadapt.smolagents_adapter import SmolAgentsAdapter
+
         self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter())
         self._tools: list[Tool] | None = None
 

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Optional, Type
 


### PR DESCRIPTION
The readme instructions added in https://github.com/huggingface/smolagents/pull/1200 

say to import MCPClient like

```
from smolagents import MCPClient, CodeAgent
```

This PR is to add MCPClient to the `__init__` so that the code in the readme is accurate