### PR TITLE
Update guided_tour.mdx

### DIFF
--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -433,7 +433,7 @@ model = InferenceClientModel()
 web_agent = CodeAgent(
     tools=[DuckDuckGoSearchTool()],
     model=model,
-    name="web_search",
+    name="my_web_search_agent",
     description="Runs web searches for you. Give it your query as an argument."
 )
 


### PR DESCRIPTION
## 1. Default DuckDuckGoSearchTool:

When you initialize a CodeAgent with add_base_tools=True (which is the default), it automatically includes a DuckDuckGoSearchTool.

This tool is internally assigned the name "web_search". This is done behind the scenes within the CodeAgent class. You don't see this explicitly in your code, but it's important to be aware of it.

## 2. Your Custom web_agent:

You create a CodeAgent instance called web_agent.
You explicitly give it the name "web_search" using the name="web_search" argument.

## 3. The Conflict:

Now you have two entities within the CodeAgent environment that share the same name: The default DuckDuckGoSearchTool (automatically named "web_search") Your custom web_agent (also named "web_search")