### PR TITLE
Update Open DeepResearch requirements

### DIFF
--- a/examples/open_deep_research/requirements.txt
+++ b/examples/open_deep_research/requirements.txt
@@ -20,7 +20,6 @@ pypdf>=5.1.0
 python-dotenv>=1.0.1
 python_pptx>=1.0.2
 Requests>=2.32.3
-serpapi>=0.1.5
 tqdm>=4.66.4
 torch>=2.2.2
 torchvision>=0.17.2


### PR DESCRIPTION
Update Open DeepResearch requirements: only `google-search-results` is required.

Note that depending on the installation order, `serpapi` and `google-search-results` will overwrite each other.

As discussed with @A-Mahla.

Related to:
- #1054
  - CC: @edlee123