### PR TITLE
Lower Pillow dependency minimum version to 10.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "requests>=2.32.3",
   "rich>=13.9.4",
   "jinja2>=3.1.4",
-  "pillow>=11.0.0",
+  "pillow>=10.0.1",  # Security fix for CVE-2023-4863: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html
   "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
   "python-dotenv"


### PR DESCRIPTION
Lower Pillow dependency minimum version to 10.0.1:
- 10.0.1 addressed the security vulnerability CVE-2023-4863

The library doesn't use any Pillow 11‑only APIs; this change improves compatibility with older packages.

Additionally, lower versions are built in pyodide, which is used by the Wasm executor:
- #1261