### PR TITLE
Remove duckduckgo-search as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Full documentation can be found [here](https://huggingface.co/docs/smolagents/in
 
 ## Quick demo
 
-First install the package.
+First install the package with a default set of tools:
 ```bash
-pip install smolagents
+pip install smolagents[toolkit]
 ```
 Then define your agent, give it the tools it needs and run it!
 ```py

--- a/docs/source/en/examples/multiagents.mdx
+++ b/docs/source/en/examples/multiagents.mdx
@@ -25,7 +25,7 @@ Let's set up this system.
 Run the line below to install the required dependencies:
 
 ```py
-! pip install markdownify duckduckgo-search smolagents --upgrade -q
+!pip install markdownify smolagents[toolkit] --upgrade -q
 ```
 
 Let's login to HF in order to call Inference Providers:

--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -281,7 +281,7 @@ When the agent is initialized, the tool attributes are used to generate a tool d
 
 ### Default toolbox
 
-`smolagents` comes with a default toolbox for empowering agents, that you can add to your agent upon initialization with argument `add_base_tools=True`:
+If you install `smolagents` with the "toolkit" extra, it comes with a default toolbox for empowering agents, that you can add to your agent upon initialization with argument `add_base_tools=True`:
 
 - **DuckDuckGo web search***: performs a web search using DuckDuckGo browser.
 - **Python code interpreter**: runs your LLM generated Python code in a secure environment. This tool will only be added to [`ToolCallingAgent`] if you initialize it with `add_base_tools=True`, since code-based agent can already natively execute Python code
@@ -290,6 +290,7 @@ When the agent is initialized, the tool attributes are used to generate a tool d
 You can manually use a tool by calling it with its arguments.
 
 ```python
+# !pip install smolagents[toolkit]
 from smolagents import DuckDuckGoSearchTool
 
 search_tool = DuckDuckGoSearchTool()

--- a/docs/source/en/tutorials/inspect_runs.mdx
+++ b/docs/source/en/tutorials/inspect_runs.mdx
@@ -30,7 +30,7 @@ Here's how it then looks like on the platform:
 First install the required packages. Here we install [Phoenix by Arize AI](https://github.com/Arize-ai/phoenix) because that's a good solution to collect and inspect the logs, but there are other OpenTelemetry-compatible platforms that you could use for this collection & inspection part.
 
 ```shell
-pip install 'smolagents[telemetry]'
+pip install 'smolagents[telemetry,toolkit]'
 ```
 
 Then run the collector in the background.

--- a/examples/open_deep_research/visual_vs_text_browser.ipynb
+++ b/examples/open_deep_research/visual_vs_text_browser.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"smolagents[litellm]\" -q"
+    "!pip install \"smolagents[litellm,toolkit]\" -q"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ telemetry = [
   "opentelemetry-exporter-otlp",
   "openinference-instrumentation-smolagents>=0.1.4"
 ]
+toolkit = [
+  "duckduckgo-search>=6.3.7",  # DuckDuckGoSearchTool
+]
 transformers = [
   "accelerate",
   "transformers>=4.0.0",
@@ -78,7 +81,7 @@ vllm = [
   "torch"
 ]
 all = [
-  "smolagents[audio,docker,e2b,gradio,litellm,mcp,mlx-lm,openai,telemetry,transformers,vision,bedrock]",
+  "smolagents[audio,docker,e2b,gradio,litellm,mcp,mlx-lm,openai,telemetry,toolkit,transformers,vision,bedrock]",
 ]
 quality = [
   "ruff>=0.9.0",
@@ -92,7 +95,6 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
-  "duckduckgo-search>=6.3.7",  # DuckDuckGoSearchTool
 ]
 dev = [
   "smolagents[quality,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "jinja2>=3.1.4",
   "pillow>=11.0.0",
   "markdownify>=0.14.1",
-  "duckduckgo-search>=6.3.7",
   "python-dotenv"
 ]
 
@@ -93,6 +92,7 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
+  "duckduckgo-search>=6.3.7",  # DuckDuckGoSearchTool
 ]
 dev = [
   "smolagents[quality,test]",


### PR DESCRIPTION
Remove `duckduckgo-search` as required dependency.

This PR decouples the DuckDuckGo search tool from the core package.
- Reduce the install footprint for users who don't need the web search tool or prefer an alternative
- Keep core package lean and focused

Additionally, note that `duckduckgo-search` depends on `lxml`, that is not a pure-Python package. This is problematic for the Wasm executor:
- #1261