### PR TITLE
Remove unnecessary dependencies from DockerExecutor image

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -217,14 +217,18 @@ class DockerExecutor(RemotePythonExecutor):
                 dockerfile_path = Path(__file__).parent / "Dockerfile"
                 if not dockerfile_path.exists():
                     with open(dockerfile_path, "w") as f:
-                        f.write("""FROM python:3.12-slim
+                        f.write(
+                            dedent(
+                                """\
+                                FROM python:3.12-slim
 
-RUN pip install jupyter_kernel_gateway requests numpy pandas
-RUN pip install jupyter_client notebook
+                                RUN pip install jupyter_kernel_gateway jupyter_client
 
-EXPOSE 8888
-CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", "--KernelGatewayApp.allow_origin='*'"]
-""")
+                                EXPOSE 8888
+                                CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", "--KernelGatewayApp.allow_origin='*'"]
+                                """
+                            )
+                        )
                 _, build_logs = self.client.images.build(
                     path=str(dockerfile_path.parent), dockerfile=str(dockerfile_path), tag=self.image_name
                 )


### PR DESCRIPTION
Remove unnecessary dependencies from DockerExecutor image.

This PR updates the DockerExecutor's embedded Dockerfile to only install the packages required for the Jupyter Kernel Gateway. 

Unused dependencies like `numpy`, `pandas`, and the `notebook` UI have been removed to reduce image size and build time:
- Smaller Docker image footprint
- Faster build times

Tests: I have locally tested TestDockerExecutor with `RUN_ALL=1`.