### PR TITLE
Remove markdownify as required dependency

### DIFF
--- a/docs/source/en/examples/multiagents.mdx
+++ b/docs/source/en/examples/multiagents.mdx
@@ -25,7 +25,7 @@ Let's set up this system.
 Run the line below to install the required dependencies:
 
 ```py
-!pip install markdownify smolagents[toolkit] --upgrade -q
+!pip install smolagents[toolkit] --upgrade -q
 ```
 
 Let's login to HF in order to call Inference Providers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ telemetry = [
 ]
 toolkit = [
   "duckduckgo-search>=6.3.7",  # DuckDuckGoSearchTool
+  "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 transformers = [
   "accelerate",
@@ -94,7 +95,6 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
-  "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 dev = [
   "smolagents[quality,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "rich>=13.9.4",
   "jinja2>=3.1.4",
   "pillow>=11.0.0",
-  "markdownify>=0.14.1",
   "duckduckgo-search>=6.3.7",
   "python-dotenv"
 ]
@@ -93,6 +92,7 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
+  "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 dev = [
   "smolagents[quality,test]",


### PR DESCRIPTION
Remove `markdownify` as required dependency.

This PR decouples the `VisitWebpageTool` from the core package.
- Reduce the install footprint for users who don't need this tool or prefer an alternative
- Keep core package lean and focused

Related to:
- #1271
