### PR TITLE
Refactor RemotePythonExecutor.send_tools to call install_packages

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -53,7 +53,6 @@ class RemotePythonExecutor(PythonExecutor):
         raise NotImplementedError
 
     def send_tools(self, tools: dict[str, Tool]):
-        code = ""
         # Install tool packages
         packages_to_install = {
             pkg
@@ -62,11 +61,9 @@ class RemotePythonExecutor(PythonExecutor):
             if pkg not in self.installed_packages + ["smolagents"]
         }
         if packages_to_install:
-            self.installed_packages.extend(packages_to_install)
-            code += f"!pip install {' '.join(packages_to_install)}\n"
+            self.installed_packages += self.install_packages(list(packages_to_install))
         # Get tool definitions
-        tool_definition_code = get_tools_definition_code(tools)
-        code += tool_definition_code
+        code = get_tools_definition_code(tools)
         if code:
             execution = self.run_code_raise_errors(code)
             self.logger.log(execution[1])


### PR DESCRIPTION
Refactor `RemotePythonExecutor.send_tools` to delegate package installation to `install_packages`.

This PR refactors the `RemotePythonExecutor.send_tools` method to improve code clarity and separation of concerns by delegating package installation logic to the existing `install_packages` method. This change avoids duplication and centralizes package management behavior in a single location, making the codebase easier to maintain and extend. Note that after this change `run_code_raise_errors` is called twice instead of one time.

This refactor also improves extensibility by ensuring that subclasses overriding the `install_packages` method can customize package installation behavior when `send_tools` is called. See:
- #1261