### PR TITLE
Unpin mcp < 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ litellm = [
 ]
 mcp = [
   "mcpadapt>=0.0.19",  # Security fix
-  "mcp<1.7.0",  # Hotfix for GH-1284
+  "mcp",
 ]
 mlx-lm = [
   "mlx-lm"


### PR DESCRIPTION
Unpin mcp < 1.7.0, once the issue has been fixed on their side:
- https://github.com/modelcontextprotocol/python-sdk/pull/619

They have made a patch release: 1.7.1
- https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.7.1
- https://pypi.org/project/mcp/1.7.1/

Close #1287.