### PR TITLE
Fix AttributeError when using GradioUI with minimum supported Gradio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ e2b = [
   "python-dotenv>=1.0.1",
 ]
 gradio = [
-  "gradio>=5.13.2",
+  "gradio>=5.14.0",  # Sidebar component GH-797
 ]
 litellm = [
   "litellm>=1.60.2",


### PR DESCRIPTION
Fix AttributeError when using GradioUI with minimum supported Gradio version by updating the minimum supported gradio version to >= 5.14.0.

The issue was introduced in smolagents-1.10.0 via:
- #797

That PR introduced the use of `gradio.Sidebar`, which is a component that was only introduced in gradio-5.14.0:
- PR: https://github.com/gradio-app/gradio/pull/10435
- gradio@5.14.0 Release Notes: https://github.com/gradio-app/gradio/releases/tag/gradio%405.14.0

Fix #1308.