### PR TITLE
Support executor_kwargs in LocalPythonExecutor for initialization customization

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1279,8 +1279,7 @@ class CodeAgent(MultiStepAgent):
             case "local":
                 return LocalPythonExecutor(
                     self.additional_authorized_imports,
-                    max_print_outputs_length=self.max_print_outputs_length,
-                    **self.executor_kwargs,
+                    **{"max_print_outputs_length": self.max_print_outputs_length} | self.executor_kwargs,
                 )
             case _:  # if applicable
                 raise ValueError(f"Unsupported executor type: {self.executor_type}")

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1280,6 +1280,7 @@ class CodeAgent(MultiStepAgent):
                 return LocalPythonExecutor(
                     self.additional_authorized_imports,
                     max_print_outputs_length=self.max_print_outputs_length,
+                    **self.executor_kwargs,
                 )
             case _:  # if applicable
                 raise ValueError(f"Unsupported executor type: {self.executor_type}")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1260,7 +1260,7 @@ class TestCodeAgent:
             "description": "Test code agent description",
             "authorized_imports": ["pandas", "numpy"],
             "executor_type": "local",
-            "executor_kwargs": {"max_workers": 2},
+            "executor_kwargs": {"max_print_outputs_length": 10_000},
             "max_print_outputs_length": 1000,
         }
 
@@ -1273,7 +1273,7 @@ class TestCodeAgent:
         assert agent.model == mock_model_instance
         assert agent.additional_authorized_imports == ["pandas", "numpy"]
         assert agent.executor_type == "local"
-        assert agent.executor_kwargs == {"max_workers": 2}
+        assert agent.executor_kwargs == {"max_print_outputs_length": 10_000}
         assert agent.max_print_outputs_length == 1000
 
         # Test with missing optional parameters
@@ -1291,10 +1291,12 @@ class TestCodeAgent:
         # Test overriding with kwargs
         with patch("smolagents.models.InferenceClientModel"):
             agent = CodeAgent.from_dict(
-                agent_dict, additional_authorized_imports=["matplotlib"], executor_kwargs={"max_workers": 4}
+                agent_dict,
+                additional_authorized_imports=["matplotlib"],
+                executor_kwargs={"max_print_outputs_length": 5_000},
             )
         assert agent.additional_authorized_imports == ["matplotlib"]
-        assert agent.executor_kwargs == {"max_workers": 4}
+        assert agent.executor_kwargs == {"max_print_outputs_length": 5_000}
 
 
 class TestMultiAgents:
@@ -1316,7 +1318,7 @@ class TestMultiAgents:
             managed_agents=[web_agent, code_agent],
             max_print_outputs_length=1000,
             executor_type="local",
-            executor_kwargs={"max_workers": 2},
+            executor_kwargs={"max_print_outputs_length": 10_000},
         )
         agent.save(tmp_path)
 
@@ -1355,7 +1357,7 @@ class TestMultiAgents:
         assert set(agent2.authorized_imports) == set(["pandas", "datetime"] + BASE_BUILTIN_MODULES)
         assert agent2.max_print_outputs_length == 1000
         assert agent2.executor_type == "local"
-        assert agent2.executor_kwargs == {"max_workers": 2}
+        assert agent2.executor_kwargs == {"max_print_outputs_length": 10_000}
         assert (
             agent2.managed_agents["web_agent"].tools["web_search"].max_results == 10
         )  # For now tool init parameters are forgotten

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1204,8 +1204,7 @@ class TestCodeAgent:
         model = MagicMock()
         model.last_input_token_count = 10
         model.last_output_token_count = 5
-        agent = CodeAgent(tools=[], model=model)
-        agent.python_executor.additional_functions = {"open": open}
+        agent = CodeAgent(tools=[], model=model, executor_kwargs={"additional_functions": {"open": open}})
         agent.run("Test run")
         assert "open" in agent.python_executor.static_tools
 


### PR DESCRIPTION
Support passing `executor_kwargs` to `LocalPythonExecutor`, aligning its behavior with `RemotePythonExecutor`, which already accepts it.

This PR simplifies configuration and improves consistency across executor types.

With this change, we can now use
```python
agent = CodeAgent(tools=[], model=model, executor_kwargs={"additional_functions": {"open": open}})
```
as functionally equivalent to
```python
agent = CodeAgent(tools=[], model=model)
agent.python_executor.additional_functions = {"open": open}
```