### PR TITLE
Fix deprecation of HfApiModel

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1317,7 +1317,7 @@ class InferenceClientModel(ApiModel):
 class HfApiModel(InferenceClientModel):
     def __new__(cls, *args, **kwargs):
         warnings.warn(
-            "HfApiModel has been renamed to InferenceClientModel to more closely follow the name of the underlying Inference library.",
+            "HfApiModel was renamed to InferenceClientModel in version 1.14.0 and will be removed in 1.17.0.",
             FutureWarning,
         )
         return super().__new__(cls)

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1318,7 +1318,7 @@ class HfApiModel(InferenceClientModel):
     def __new__(cls, *args, **kwargs):
         warnings.warn(
             "HfApiModel has been renamed to InferenceClientModel to more closely follow the name of the underlying Inference library.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return super().__new__(cls)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -206,41 +206,16 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
         model(messages, stop_sequences=["great"])
 
-
-class TestHfApiModel:
-    def test_init_model_with_tokens(self):
-        model = HfApiModel(model_id="test-model", token="abc")
-        assert model.client.token == "abc"
-
-        model = HfApiModel(model_id="test-model", api_key="abc")
-        assert model.client.token == "abc"
-
-        with pytest.raises(ValueError) as e:
-            _ = HfApiModel(model_id="test-model", token="abc", api_key="def")
-        assert "Received both `token` and `api_key` arguments." in str(e)
-
-    @require_run_all
-    def test_get_hfapi_message_no_tool(self):
-        model = HfApiModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", max_tokens=10)
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
-        model.generate(messages, stop_sequences=["great"])
-
-    @require_run_all
-    def test_get_hfapi_message_no_tool_external_provider(self):
-        model = HfApiModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", provider="together", max_tokens=10)
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
-        model.generate(messages, stop_sequences=["great"])
-
     @require_run_all
     def test_get_hfapi_message_stream_no_tool(self):
-        model = HfApiModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", max_tokens=10)
+        model = InferenceClientModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", max_tokens=10)
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
         for el in model.generate_stream(messages, stop_sequences=["great"]):
             assert el.content is not None
 
     @require_run_all
     def test_get_hfapi_message_stream_no_tool_external_provider(self):
-        model = HfApiModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", provider="together", max_tokens=10)
+        model = InferenceClientModel(model_id="Qwen/Qwen2.5-Coder-32B-Instruct", provider="together", max_tokens=10)
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
         for el in model.generate_stream(messages, stop_sequences=["great"]):
             assert el.content is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -221,6 +221,21 @@ class TestInferenceClientModel:
             assert el.content is not None
 
 
+class TestHfApiModel:
+    def test_deprecation_warning(self):
+        """Test that HfApiModel raises a deprecation warning when instantiated."""
+        # Should raise FutureWarning with specific message
+        with pytest.warns(
+            FutureWarning,
+            match="HfApiModel was renamed to InferenceClientModel in version 1.14.0 and will be removed in 1.17.0.",
+        ):
+            model = HfApiModel(model_id="test-model")
+        # Verify it returns an instance of InferenceClientModel
+        assert isinstance(model, InferenceClientModel)
+        # Verify the model_id was properly passed through
+        assert model.model_id == "test-model"
+
+
 class TestLiteLLMModel:
     @pytest.mark.parametrize(
         "model_id, error_flag",


### PR DESCRIPTION
Fix deprecation of HfApiModel:
- raise `FutureWarning` instead of `DeprecationWarning`: the latter is not intended for end users and is filtered out by default 
- fix warning message specifying in which version the class will be removed
- fix tests: testing deprecated `HfApiModel` raises deprecation warnings in the CI
- explicitly test `HfApiModel` raises deprecation warning when instantiated

Follow up to:
- #1198