### PR TITLE
Add timeout mechanism for code execution

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -53,6 +53,7 @@ ERRORS = {
 DEFAULT_MAX_LEN_OUTPUT = 50000
 MAX_OPERATIONS = 10000000
 MAX_WHILE_ITERATIONS = 1000000
+MAX_EXECUTION_TIME_SECONDS = 10
 
 
 def custom_print(*args):
@@ -1451,6 +1452,7 @@ class FinalAnswerException(Exception):
         self.value = value
 
 
+@timeout(MAX_EXECUTION_TIME_SECONDS)
 def evaluate_python_code(
     code: str,
     static_tools: dict[str, Callable] | None = None,


### PR DESCRIPTION
This PR implements a timeout mechanism for code execution to prevent code from running indefinitely or consuming excessive resources.

As privately discussed with @akseljoonas, certain computations (such as extremely large exponentiations) can lead to unresponsive behavior or exhaust available memory. For example:
```python
log_5_result = 3 ** 2048
log_7_n_result = 5 ** log_5_result
```

To mitigate such risks, this update enforces a configurable timeout limit, ensuring that execution is safely interrupted if it exceeds the allowed duration.