### PR TITLE
Use `gr.Number` for mapping integer and number type components in `launch_gradio_demo`

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -704,8 +704,8 @@ def launch_gradio_demo(tool: Tool):
         "image": gr.Image,
         "audio": gr.Audio,
         "string": gr.Textbox,
-        "integer": gr.Textbox,
-        "number": gr.Textbox,
+        "integer": gr.Number,
+        "number": gr.Number,
     }
 
     def tool_forward(*args, **kwargs):


### PR DESCRIPTION
### Issue
`gr.Textbox` is used for mapping integer and number type components in `launch_gradio_demo`, so need to manually convert data type from string to int/float in custom script. 

### Solution
Use `gr.Number` to avoid avoid manual data type conversion. 