### PR TITLE
Fix CI DuckDuckGoSearchTool tests raising 202 Ratelimit

### DIFF
--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -26,6 +26,7 @@ from smolagents.default_tools import (
 )
 
 from .test_tools import ToolTesterMixin
+from .utils.markers import require_run_all
 
 
 class DefaultToolTests(unittest.TestCase):
@@ -35,6 +36,7 @@ class DefaultToolTests(unittest.TestCase):
         assert isinstance(result, str)
         assert "* [About Wikipedia](/wiki/Wikipedia:About)" in result  # Proper wikipedia pages have an About
 
+    @require_run_all
     def test_ddgs_with_kwargs(self):
         result = DuckDuckGoSearchTool(timeout=20)("DeepSeek parent company")
         assert isinstance(result, str)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -29,3 +29,7 @@ class TestDuckDuckGoSearchTool(ToolTesterMixin):
     def test_exact_match_arg(self):
         result = self.tool("Agents")
         assert isinstance(result, str)
+
+    @require_run_all
+    def test_agent_type_output(self):
+        super().test_agent_type_output()


### PR DESCRIPTION
Fix CI DuckDuckGoSearchTool tests raising 202 Ratelimit:
- Require RUN_ALL for DuckDuckGoSearchTool calling tests

Fix #1323.