### PR TITLE
Lower minimum rich version for compatibility with litellm[proxy]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
   "huggingface-hub>=0.30.0",
   "requests>=2.32.3",
-  "rich>=13.9.4",
+  "rich>=13.7.1",
   "jinja2>=3.1.4",
   "pillow>=10.0.1",  # Security fix for CVE-2023-4863: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html
   "python-dotenv"


### PR DESCRIPTION
`litellm[proxy]` depends on a lower version of `rich`. If there's not a reason for pinning this one so high, it would be nice to lower the minimum version for compatibility.