### PR TITLE
Allow list of authorized input types for `Tool`

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -147,9 +147,18 @@ class Tool:
             assert "type" in input_content and "description" in input_content, (
                 f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
             )
-            if input_content["type"] not in AUTHORIZED_TYPES:
+            input_type = input_content["type"]
+            # Allow list of authorized input types
+            if isinstance(input_type, list):
+                invalid_types = [t for t in input_type if t not in AUTHORIZED_TYPES]
+                if invalid_types:
+                    raise Exception(
+                        f"Input '{input_name}': type '{input_type}' contains unauthorized type(s) '{invalid_types}', should be one of {AUTHORIZED_TYPES}."
+                    )            
+            
+            elif input_type not in AUTHORIZED_TYPES:
                 raise Exception(
-                    f"Input '{input_name}': type '{input_content['type']}' is not an authorized value, should be one of {AUTHORIZED_TYPES}."
+                    f"Input '{input_name}': type '{input_type}' is not an authorized value, should be one of {AUTHORIZED_TYPES}."
                 )
         # Validate output type
         assert getattr(self, "output_type", None) in AUTHORIZED_TYPES


### PR DESCRIPTION
Allow list of authorized input types for `Tool`, not limited to only one authorized input type. 