### PR TITLE
Remove utils dir from Makefile check_dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: quality style test docs
 
-check_dirs := examples src tests utils
+check_dirs := examples src tests
 
 # Check code quality of the source code
 quality:


### PR DESCRIPTION
Update Makefile to reflect that `utils` dir was removed in #1218.