### PR TITLE
add api_base and api_keys to preparation of kwargs for generate stream

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1053,6 +1053,8 @@ class LiteLLMModel(ApiModel):
             grammar=grammar,
             tools_to_call_from=tools_to_call_from,
             model=self.model_id,
+            api_base=self.api_base,
+            api_key=self.api_key,
             custom_role_conversions=self.custom_role_conversions,
             convert_images_to_image_urls=True,
             **kwargs,


### PR DESCRIPTION
From the Issue : #1343 

Seems like that the api_base and api_keys args were forgot when setting stream_outputs=True in a CodeAgent.

I don't see any reason to not put them in case of a streamed output, so I added them.

Calling a ollama server with custom api_base and stream_outputs=True is now working. 👋 