### PR TITLE
Fix live streaming when generating planning steps

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -452,9 +452,13 @@ You have been provided with these additional arguments, that you can access usin
             ]
             if self.stream_outputs and hasattr(self.model, "generate_stream"):
                 plan_message_content = ""
-                for completion_delta in self.model.generate_stream(input_messages, stop_sequences=["<end_plan>"]):  # type: ignore
-                    plan_message_content += completion_delta.content
-                    yield completion_delta
+                output_stream = self.model.generate_stream(input_messages, stop_sequences=["<end_plan>"])  # type: ignore
+                with Live("", console=self.logger.console, vertical_overflow="visible") as live:
+                    for event in output_stream:
+                        if event.content is not None:
+                            plan_message_content += event.content
+                            live.update(Markdown(plan_message_content))
+                        yield event
             else:
                 plan_message_content = self.model.generate(input_messages, stop_sequences=["<end_plan>"]).content
             plan = textwrap.dedent(


### PR DESCRIPTION
Issue #1347. A CodeAgent can't stream and plan at the same time. even if the code line : 
```
if self.stream_outputs and hasattr(self.model, "generate_stream"):
```
Was implemented, the behavior to stream was not right.

I took the same behavior as presented in [_step_stream](https://github.com/huggingface/smolagents/blob/main/src/smolagents/agents.py#L1314C1-L1314C13) and adapted it to the function to stream plan messages.

Now the streaming is working with planning.