### PR TITLE
Stop streaming if LiteLLM provide a finish_reason

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1059,12 +1059,7 @@ class LiteLLMModel(ApiModel):
         )
         for event in self.client.completion(**completion_kwargs, stream=True, stream_options={"include_usage": True}):
             if event.choices:
-                if event.choices[0].delta is None or event.choices[0].delta.content is None:
-                    if getattr(event.choices[0], "finish_reason", None):
-                        break  # Stop streaming if a finish reason is provided
-                    else:
-                        raise ValueError(f"No content or tool calls in event: {event}")
-                else:
+                if event.choices[0].delta.content:
                     yield ChatMessageStreamDelta(
                         content=event.choices[0].delta.content,
                     )

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1061,7 +1061,7 @@ class LiteLLMModel(ApiModel):
             if event.choices:
                 if event.choices[0].delta is None or event.choices[0].delta.content is None:
                     if getattr(event.choices[0], "finish_reason", None):
-                        break # Stop straming if a finish reason is provided
+                        break # Stop streaming if a finish reason is provided
                     else:
                         raise ValueError(f"No content or tool calls in event: {event}")
                 else:

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1061,7 +1061,7 @@ class LiteLLMModel(ApiModel):
             if event.choices:
                 if event.choices[0].delta is None or event.choices[0].delta.content is None:
                     if getattr(event.choices[0], "finish_reason", None):
-                        break # Stop streaming if a finish reason is provided
+                        break  # Stop streaming if a finish reason is provided
                     else:
                         raise ValueError(f"No content or tool calls in event: {event}")
                 else:

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1059,8 +1059,10 @@ class LiteLLMModel(ApiModel):
         )
         for event in self.client.completion(**completion_kwargs, stream=True, stream_options={"include_usage": True}):
             if event.choices:
-                if event.choices[0].delta is None:
-                    if not getattr(event.choices[0], "finish_reason", None):
+                if event.choices[0].delta is None or event.choices[0].delta.content is None:
+                    if getattr(event.choices[0], "finish_reason", None):
+                        break # Stop straming if a finish reason is provided
+                    else:
                         raise ValueError(f"No content or tool calls in event: {event}")
                 else:
                     yield ChatMessageStreamDelta(


### PR DESCRIPTION
Issue #1349. 

Sometimes LiteLLM send a last message with finish_reason when generation is done.

example : 
```
StreamingChoices(finish_reason='stop', index=0, delta=Delta(provider_specific_fields=None, content=None, role=None, function_call=None, tool_calls=None, audio=None), logprobs=None)
```

The code in generate_stream only check is the key delta is None. But if finish_reason is provided, there might be a Delta object provided under the key delta, but with a content to None. In that case we should not append the None to the generation and we should just stop generation.