### PR TITLE
Remove deprecated from_hf_api methods

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -29,11 +29,6 @@ from .utils import _is_package_available, encode_image_base64, make_image_url, p
 
 
 if TYPE_CHECKING:
-    from huggingface_hub import (
-        ChatCompletionOutputFunctionDefinition,
-        ChatCompletionOutputMessage,
-        ChatCompletionOutputToolCall,
-    )
     from transformers import StoppingCriteriaList
 
 
@@ -65,32 +60,12 @@ class ChatMessageToolCallDefinition:
     name: str
     description: str | None = None
 
-    @classmethod
-    def from_hf_api(
-        cls, tool_call_definition: "ChatCompletionOutputFunctionDefinition"
-    ) -> "ChatMessageToolCallDefinition":
-        warnings.warn(
-            "ChatMessageToolCallDefinition.from_hf_api is deprecated and will be removed in version 1.16.0. "
-            "Please use ChatMessageToolCallDefinition with asdict() instead.",
-            FutureWarning,
-        )
-        return cls(**asdict(tool_call_definition))
-
 
 @dataclass
 class ChatMessageToolCall:
     function: ChatMessageToolCallDefinition
     id: str
     type: str
-
-    @classmethod
-    def from_hf_api(cls, tool_call: "ChatCompletionOutputToolCall") -> "ChatMessageToolCall":
-        warnings.warn(
-            "ChatMessageToolCall.from_hf_api is deprecated and will be removed in version 1.16.0. "
-            "Please use ChatMessageToolCall with asdict() instead.",
-            FutureWarning,
-        )
-        return cls(**asdict(tool_call))
 
 
 @dataclass
@@ -117,15 +92,6 @@ class ChatMessage:
 
     def dict(self):
         return json.dumps(get_dict_from_nested_dataclasses(self))
-
-    @classmethod
-    def from_hf_api(cls, message: "ChatCompletionOutputMessage", raw) -> "ChatMessage":
-        warnings.warn(
-            "ChatMessage.from_hf_api is deprecated and will be removed in version 1.16.0. "
-            "Please use ChatMessage.from_dict with asdict() instead.",
-            FutureWarning,
-        )
-        return cls.from_dict(asdict(message), raw=raw)
 
 
 def parse_json_if_needed(arguments: str | dict) -> str | dict:


### PR DESCRIPTION
Remove deprecated `from_hf_api` methods.

They were planned to be removed in version 1.16.0.