### PR TITLE
Fix evaluate_class_def for Assign Attribute target in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -457,23 +457,13 @@ def evaluate_class_def(
         if isinstance(stmt, ast.FunctionDef):
             class_dict[stmt.name] = evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
         elif isinstance(stmt, ast.Assign):
+            value = evaluate_ast(stmt.value, state, static_tools, custom_tools, authorized_imports)
             for target in stmt.targets:
                 if isinstance(target, ast.Name):
-                    class_dict[target.id] = evaluate_ast(
-                        stmt.value,
-                        state,
-                        static_tools,
-                        custom_tools,
-                        authorized_imports,
-                    )
+                    class_dict[target.id] = value
                 elif isinstance(target, ast.Attribute):
-                    class_dict[target.attr] = evaluate_ast(
-                        stmt.value,
-                        state,
-                        static_tools,
-                        custom_tools,
-                        authorized_imports,
-                    )
+                    obj = evaluate_ast(target.value, class_dict, static_tools, custom_tools, authorized_imports)
+                    setattr(obj, target.attr, value)
         elif (
             isinstance(stmt, ast.Expr)
             and stmt == class_def.body[0]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -782,7 +782,8 @@ counts_list = [1, 2, 3]
 counts_list += [4, 5, 6]
 
 class Counter:
-    self.count = 0
+    def __init__(self):
+        self.count = 0
 
 a = Counter()
 a.count += 1

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -117,6 +117,28 @@ class PythonInterpreterTester(unittest.TestCase):
         assert result == 42
         assert state["instance"].__doc__ == "A class with a value."
 
+    def test_evaluate_class_def_with_assign_attribute_target(self):
+        """
+        Test evaluate_class_def function when stmt is an instance of ast.Assign with ast.Attribute target.
+        """
+        code = dedent("""
+        class TestSubClass:
+            attr1 = 1
+        class TestClass:
+            data = TestSubClass()
+            data.attr1 = "value1"
+            data.attr2 = "value2"
+        result = (TestClass.data.attr1, TestClass.data.attr2)
+        """)
+
+        state = {}
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state=state)
+
+        assert result == ("value1", "value2")
+        assert isinstance(state["TestClass"], type)
+        assert state["TestClass"].data.attr1 == "value1"
+        assert state["TestClass"].data.attr2 == "value2"
+
     def test_evaluate_constant(self):
         code = "x = 3"
         state = {}


### PR DESCRIPTION
Fix `evaluate_class_def` for Assign Attribute target in `LocalPythonExecutor`.

Currently, the following code raises an error:
```python
class B:
    dummy = 1

class A:
    b = B()
    b.c = "value"

A.b.c
```
> InterpreterError: Code execution failed at line 'A.b.c' due to: AttributeError: 'B' object has no attribute 'c'

Additionally, currently it behaves unexpectedly:
```python
class B:
    c = 1

class A:
    b = B()
    b.c = "value"

A.b.c  # equals 1 instead of "value"
```
