### PR TITLE
Support 'pass' statement in class definition in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -501,6 +501,8 @@ def evaluate_class_def(
                         custom_tools,
                         authorized_imports,
                     )
+        elif isinstance(stmt, ast.Pass):
+            pass
         elif (
             isinstance(stmt, ast.Expr)
             and stmt == class_def.body[0]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1116,6 +1116,19 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         assert res.__name__ == "target_function"
         assert res.__source__ == "def target_function():\n    return 'Hello world'"
 
+    def test_evaluate_class_def_with_pass(self):
+        code = dedent("""
+            class TestClass:
+                pass
+
+            instance = TestClass()
+            instance.attr = "value"
+            result = instance.attr
+        """)
+        state = {}
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state=state)
+        assert result == "value"
+
     def test_evaluate_class_def_with_ann_assign_name(self):
         """
         Test evaluate_class_def function when stmt is an instance of ast.AnnAssign with ast.Name target.


### PR DESCRIPTION
Support `pass` statement in class definition in LocalPythonExecutor.

Currently, this code raises an error:
```python
class A:
    pass
```
> InterpreterError: Code execution failed at line 'class TestClass: pass' due to: InterpreterError: Unsupported statement in class body: Pass