### PR TITLE
Fix broken link in agentic RAG examples page

### DIFF
--- a/docs/source/en/examples/rag.mdx
+++ b/docs/source/en/examples/rag.mdx
@@ -166,7 +166,7 @@ agent = CodeAgent(
 ```
 
 > [!TIP]
-> The Inference API hosts models based on various criteria, and deployed models may be updated or replaced without prior notice. Learn more about it [here](https://huggingface.co/docs/api-inference/supported-models).
+> The Inference API hosts models based on various criteria, and deployed models may be updated or replaced without prior notice. Learn more about it [here](https://huggingface.co/docs/inference-providers/index).
 
 ### Step 5: Run the Agent to Answer Questions
 


### PR DESCRIPTION
Fixes #1362 

Fixed the broken link in the agentic RAG examples page to correctly point to https://huggingface.co/docs/inference-providers/index