### PR TITLE
Fix WebSearchTool validation error

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -25,6 +25,7 @@ class MethodChecker(ast.NodeVisitor):
         self.errors = []
         self.check_imports = check_imports
         self.typing_names = {"Any"}
+        self.defined_classes = set()
 
     def visit_arguments(self, node):
         """Collect function arguments"""
@@ -115,6 +116,11 @@ class MethodChecker(ast.NodeVisitor):
         if not (isinstance(node.value, ast.Name) and node.value.id == "self"):
             self.generic_visit(node)
 
+    def visit_ClassDef(self, node):
+        """Track class definitions"""
+        self.defined_classes.add(node.name)
+        self.generic_visit(node)
+
     def visit_Name(self, node):
         if isinstance(node.ctx, ast.Load):
             if not (
@@ -127,6 +133,7 @@ class MethodChecker(ast.NodeVisitor):
                 or node.id in self.from_imports
                 or node.id in self.assigned_names
                 or node.id in self.typing_names
+                or node.id in self.defined_classes
             ):
                 self.errors.append(f"Name '{node.id}' is undefined.")
 
@@ -141,6 +148,7 @@ class MethodChecker(ast.NodeVisitor):
                 or node.func.id in self.imports
                 or node.func.id in self.from_imports
                 or node.func.id in self.assigned_names
+                or node.func.id in self.defined_classes
             ):
                 self.errors.append(f"Name '{node.func.id}' is undefined.")
         self.generic_visit(node)

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -3,7 +3,13 @@ from textwrap import dedent
 
 import pytest
 
-from smolagents.default_tools import DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool
+from smolagents.default_tools import (
+    DuckDuckGoSearchTool,
+    GoogleSearchTool,
+    SpeechToTextTool,
+    VisitWebpageTool,
+    WebSearchTool,
+)
 from smolagents.tool_validation import MethodChecker, validate_tool_attributes
 from smolagents.tools import Tool, tool
 
@@ -11,7 +17,9 @@ from smolagents.tools import Tool, tool
 UNDEFINED_VARIABLE = "undefined_variable"
 
 
-@pytest.mark.parametrize("tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool])
+@pytest.mark.parametrize(
+    "tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool, WebSearchTool]
+)
 def test_validate_tool_attributes_with_default_tools(tool_class):
     assert validate_tool_attributes(tool_class) is None, f"failed for {tool_class.name} tool"
 


### PR DESCRIPTION
Fix WebSearchTool validation error when calling to_dict.

Currently, `WebSearchTool().to_dict` raises a validation error:
```
ValueError: Tool validation failed for WebSearchTool:
- _create_duckduckgo_parser: Name 'SimpleResultParser' is undefined.
- _create_duckduckgo_parser: Name 'SimpleResultParser' is undefined.
```

The issue is caused by the MethodChecker, which does not track class definitions.

This PR ensures that internal class definitions are properly tracked during validation.