### PR TITLE
Enable parsing malformed structured generation outputs.

### DIFF
--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -3,14 +3,13 @@ from smolagents import CodeAgent, GradioUI, InferenceClientModel
 
 agent = CodeAgent(
     tools=[],
-    model=InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct", provider="fireworks-ai"),
+    model=InferenceClientModel(),
     verbosity_level=1,
     planning_interval=3,
     name="example_agent",
     description="This is an example agent.",
     step_callbacks=[],
-    stream_outputs=False,
-    use_structured_outputs_internally=True,
+    stream_outputs=True,
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()


### PR DESCRIPTION
Just putting here @akseljoonas's commits from https://github.com/huggingface/smolagents/pull/1346/files#diff-3efefb79d738090c51049e6ef432ac488c1f8b1ecb2ed2310ceae8e64c114450, to continue this work!

I'd advise to keep it as simple as possible: clearly identify some edge cases, make sure that we do want to fix them (as opposed to just not enabling structured outputs for these providers who don't implement structured outputs properly), then use a fix that's as simple as possible.