### PR TITLE
Update gradio_ui.py to remove unexpected keyword argument error

### DIFF
--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -10,7 +10,6 @@ agent = CodeAgent(
     description="This is an example agent.",
     step_callbacks=[],
     stream_outputs=False,
-    use_structured_outputs_internally=True,
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()


### PR DESCRIPTION
Remove the argument from the CodeAgent constructor to run the example code successfully, as described in this issue: https://github.com/huggingface/smolagents/issues/1372