### PR TITLE
Make docs neutral about agent types

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Especially, since code execution can be a security concern (arbitrary code execu
   - a secure python interpreter to run code more safely in your environment (more secure than raw code execution but still risky)
   - a sandboxed environment using [E2B](https://e2b.dev/) or Docker (removes the risk to your own system).
 
-On top of this [`CodeAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.CodeAgent) class, we still support the standard [`ToolCallingAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.ToolCallingAgent) that writes actions as JSON/text blobs. But we recommend always using `CodeAgent`.
+Alongside [`CodeAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.CodeAgent), we also provide the standard [`ToolCallingAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.ToolCallingAgent) which writes actions as JSON/text blobs. You can pick whichever style best suits your use case.
 
 ## How smol is this library?
 

--- a/docs/source/en/conceptual_guides/intro_agents.mdx
+++ b/docs/source/en/conceptual_guides/intro_agents.mdx
@@ -90,7 +90,7 @@ In a multi-step agent, at each step, the LLM can write an action, in the form of
 
 [Multiple](https://huggingface.co/papers/2402.01030) [research](https://huggingface.co/papers/2411.01747) [papers](https://huggingface.co/papers/2401.00812) have shown that having the tool calling LLMs in code is much better.
 
-The reason for this simply that *we crafted our code languages specifically to be the best possible way to express actions performed by a computer*. If JSON snippets were a better expression, JSON would be the top programming language and programming would be hell on earth.
+Code is a flexible and expressive medium to represent actions. It can accommodate complex sequences and is widely understood by developers. JSON-based formats can also work well, but we often find that code snippets map more naturally to typical programming workflows.
 
 The figure below, taken from [Executable Code Actions Elicit Better LLM Agents](https://huggingface.co/papers/2402.01030), illustrates some advantages of writing actions in code:
 

--- a/docs/source/en/conceptual_guides/react.mdx
+++ b/docs/source/en/conceptual_guides/react.mdx
@@ -40,9 +40,9 @@ Here is a video overview of how that works:
     />
 </div>
 
-We implement two versions of agents: 
-- [`CodeAgent`] is the preferred type of agent: it generates its tool calls as blobs of code.
-- [`ToolCallingAgent`] generates tool calls as a JSON in its output, as is commonly done in agentic frameworks. We incorporate this option because it can be useful in some narrow cases where you can do fine with only one tool call per step: for instance, for web browsing, you need to wait after each action on the page to monitor how the page changes.
+We implement two versions of agents:
+- [`CodeAgent`] generates its tool calls as Python code snippets.
+- [`ToolCallingAgent`] writes its tool calls as JSON, as is common in many frameworks. Depending on your needs, either approach can be used. For instance, web browsing often requires waiting after each page interaction, so JSON tool calls can fit well.
 
 > [!TIP]
 > Read [Open-source LLMs as LangChain Agents](https://huggingface.co/blog/open-source-llms-as-agents) blog post to learn more about multi-step agents.

--- a/docs/source/en/examples/multiagents.mdx
+++ b/docs/source/en/examples/multiagents.mdx
@@ -129,7 +129,7 @@ Note that we gave this agent attributes `name` and `description`, mandatory attr
 
 Then we create a manager agent, and upon initialization we pass our managed agent to it in its `managed_agents` argument.
 
-Since this agent is the one tasked with the planning and thinking, advanced reasoning will be beneficial, so a `CodeAgent` will be the best choice.
+Since this agent is the one tasked with the planning and thinking, advanced reasoning will be beneficial, so a `CodeAgent` can work well here.
 
 Also, we want to ask a question that involves the current year and does additional data calculations: so let us add `additional_authorized_imports=["time", "numpy", "pandas"]`, just in case the agent needs these packages.
 

--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -223,7 +223,7 @@ agent.run("Could you give me the 118th number in the Fibonacci sequence?")
 
 #### CodeAgent and ToolCallingAgent
 
-The [`CodeAgent`] is our default agent. It will write and execute python code snippets at each step.
+`smolagents` comes with two agent classes: [`CodeAgent`] and [`ToolCallingAgent`]. `CodeAgent` is the default and writes Python code snippets that are then executed, while `ToolCallingAgent` outputs JSON tool calls. Both share the same interface so you can pick whichever style you prefer.
 
 By default, the execution is done in your local environment.
 This should be safe because the only functions that can be called are the tools you provided (especially if it's only tools by Hugging Face) and a set of predefined safe functions like `print` or functions from the `math` module, so you're already limited in what can be executed.

--- a/docs/source/en/reference/agents.mdx
+++ b/docs/source/en/reference/agents.mdx
@@ -15,7 +15,7 @@ contains the API docs for the underlying classes.
 Our agents inherit from [`MultiStepAgent`], which means they can act in multiple steps, each step consisting of one thought, then one tool call and execution. Read more in [this conceptual guide](../conceptual_guides/react).
 
 We provide two types of agents, based on the main [`Agent`] class.
-  - [`CodeAgent`] is the default agent, it writes its tool calls in Python code.
+  - [`CodeAgent`] writes its tool calls in Python code (this is the default used in most examples).
   - [`ToolCallingAgent`] writes its tool calls in JSON.
 
 Both require arguments `model` and list of tools `tools` at initialization.


### PR DESCRIPTION
## Summary
- update README to treat CodeAgent and ToolCallingAgent evenly
- adjust docs to present both agent types on equal footing
- tone down opinionated language in docs

## Testing
- `make quality`
- `make test` *(fails: ModuleNotFoundError: No module named 'smolagents')*