### PR TITLE
Fix: Support custom inputs execution for custom Final Answer Tool

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1221,9 +1221,11 @@ class ToolCallingAgent(MultiStepAgent):
             level=LogLevel.INFO,
         )
         if tool_name == "final_answer":
+            tool_keywords = dict()
             if isinstance(tool_arguments, dict):
+                tool_keywords = tool_arguments.copy()
                 if "answer" in tool_arguments:
-                    answer = tool_arguments["answer"]
+                    answer = tool_keywords.pop("answer")
                 else:
                     answer = tool_arguments
             else:
@@ -1237,7 +1239,7 @@ class ToolCallingAgent(MultiStepAgent):
                     level=LogLevel.INFO,
                 )
             else:
-                final_answer = self.execute_tool_call("final_answer", {"answer": answer})
+                final_answer = self.execute_tool_call("final_answer", {"answer": answer, **tool_keywords}) # Allow arbitrary keywords
                 self.logger.log(
                     Text(f"Final answer: {final_answer}", style=f"bold {YELLOW_HEX}"),
                     level=LogLevel.INFO,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1221,15 +1221,11 @@ class ToolCallingAgent(MultiStepAgent):
             level=LogLevel.INFO,
         )
         if tool_name == "final_answer":
-            tool_keywords = dict()
-            if isinstance(tool_arguments, dict):
-                tool_keywords = tool_arguments.copy()
-                if "answer" in tool_arguments:
-                    answer = tool_keywords.pop("answer")
-                else:
-                    answer = tool_arguments
-            else:
-                answer = tool_arguments
+            answer = (
+                tool_arguments["answer"]
+                if isinstance(tool_arguments, dict) and "answer" in tool_arguments
+                else tool_arguments
+            )
             if isinstance(answer, str) and answer in self.state.keys():
                 # if the answer is a state variable, return the value
                 # State variables are not JSON-serializable (AgentImage, AgentAudio) so can't be passed as arguments to execute_tool_call
@@ -1240,7 +1236,7 @@ class ToolCallingAgent(MultiStepAgent):
                 )
             else:
                 # Allow arbitrary keywords
-                final_answer = self.execute_tool_call("final_answer", {"answer": answer, **tool_keywords})
+                final_answer = self.execute_tool_call("final_answer", tool_arguments)
                 self.logger.log(
                     Text(f"Final answer: {final_answer}", style=f"bold {YELLOW_HEX}"),
                     level=LogLevel.INFO,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1239,7 +1239,8 @@ class ToolCallingAgent(MultiStepAgent):
                     level=LogLevel.INFO,
                 )
             else:
-                final_answer = self.execute_tool_call("final_answer", {"answer": answer, **tool_keywords}) # Allow arbitrary keywords
+                # Allow arbitrary keywords
+                final_answer = self.execute_tool_call("final_answer", {"answer": answer, **tool_keywords})
                 self.logger.log(
                     Text(f"Final answer: {final_answer}", style=f"bold {YELLOW_HEX}"),
                     level=LogLevel.INFO,

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1477,8 +1477,8 @@ def evaluate_python_code(
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]
 
-        def final_answer(answer):  # Using 'answer' as the argument like in the original function
-            raise FinalAnswerException(previous_final_answer(answer))
+        def final_answer(*args, **kwargs):  # Allow arbitrary arguments to be passed
+            raise FinalAnswerException(previous_final_answer(*args, **kwargs))
 
         static_tools["final_answer"] = final_answer
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1052,7 +1052,7 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
 
     def test_final_answer_accepts_kwarg_answer(self):
         code = "final_answer(answer=2)"
-        result, _ = evaluate_python_code(code, {"final_answer": (lambda x: 2 * x)}, state={})
+        result, _ = evaluate_python_code(code, {"final_answer": (lambda answer: 2 * answer)}, state={})
         assert result == 4
 
     def test_dangerous_builtins_are_callable_if_explicitly_added(self):


### PR DESCRIPTION
An attempt at fixing #1382 

It will accept arbitrary arguments and keywords when calling `final_answer` tool, instead of the unique `answer` argument.

If appropriate please feel free to make changes directly.

Tested locally and only with agent's local python interpreter.