### PR TITLE
Improve LaTeX rendering in GradioUI with extended delimiter support

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -410,6 +410,12 @@ class GradioUI:
                 ),
                 resizeable=True,
                 scale=1,
+                latex_delimiters=[
+                    {"left": r"$$", "right": r"$$", "display": True},
+                    {"left": r"$", "right": r"$", "display": False},
+                    {"left": r"\[", "right": r"\]", "display": True},
+                    {"left": r"\(", "right": r"\)", "display": False},
+                ],
             )
 
             # Set up event handlers


### PR DESCRIPTION
Improve LaTeX rendering in GradioUI with extended delimiter support.

Fix #1020.