### PR TITLE
Add MCP tools doc section

### DIFF
--- a/docs/source/en/tutorials/tools.mdx
+++ b/docs/source/en/tutorials/tools.mdx
@@ -168,7 +168,10 @@ with MCPClient([server_params1, server_params2]) as tools:
 ```
 
 > [!WARNING]
-> **Security Warning:** The same security warnings mentioned for `ToolCollection.from_mcp` apply when using `MCPClient` directly.
+> **Security Warning:** Using MCP servers comes with security risks:
+> - **Trust is essential:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments. Malicious servers can execute harmful code on your machine.
+> - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
+> - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
 
 ### Import a Space as a tool
 
@@ -271,15 +274,11 @@ You can leverage tool collections by using [`ToolCollection`]. It supports loadi
 
 Leverage tools from the hundreds of MCP servers available on [glama.ai](https://glama.ai/mcp/servers) or [smithery.ai](https://smithery.ai/).
 
-> [!WARNING]
-> **Security Warning:** Using MCP servers comes with security risks:
-> - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
-> - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
-> - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
->
-> Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
-
 The MCP servers tools can be loaded with [`ToolCollection.from_mcp`].
+
+> [!WARNING]
+> **Security Warning:** The same security warnings mentioned for `MCPClient` apply when using `MCPClient` directly.
+
 
 For stdio-based MCP servers, pass the server parameters as an instance of `mcp.StdioServerParameters`:
 ```py


### PR DESCRIPTION
## Summary
- mention MCP tools prominently in the tools tutorial
- collect all MCP usage into a dedicated section

## Testing
- `make quality`
- `make test` *(fails: ModuleNotFoundError)*