### PR TITLE
Update ToolCollection.from_mcp docstring examples

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -884,24 +884,27 @@ class ToolCollection:
 
         Example with a Stdio MCP server:
         ```py
-        >>> from smolagents import ToolCollection, CodeAgent
+        >>> import os
+        >>> from smolagents import ToolCollection, CodeAgent, InferenceClientModel
         >>> from mcp import StdioServerParameters
 
+        >>> model = InferenceClientModel()
+
         >>> server_parameters = StdioServerParameters(
-        >>>     command="uv",
+        >>>     command="uvx",
         >>>     args=["--quiet", "pubmedmcp@0.1.3"],
         >>>     env={"UV_PYTHON": "3.12", **os.environ},
         >>> )
 
         >>> with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
-        >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
+        >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True, model=model)
         >>>     agent.run("Please find a remedy for hangover.")
         ```
 
         Example with a Streamable HTTP MCP server:
         ```py
         >>> with ToolCollection.from_mcp({"url": "http://127.0.0.1:8000/mcp", "transport": "streamable-http"}, trust_remote_code=True) as tool_collection:
-        >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True)
+        >>>     agent = CodeAgent(tools=[*tool_collection.tools], add_base_tools=True, model=model)
         >>>     agent.run("Please find a remedy for hangover.")
         ```
         """


### PR DESCRIPTION
Updates to examples in `from_mcp` docstrings to allow for easier out-of-the box usage including:

- use `uv` instead of `uvx` to remove the need to manually install `pubmedclient` in order to use `pubmedmcp@0.1.3` and better isolating the tool usage
- pass [required arg `model`](https://github.com/huggingface/smolagents/blob/6a12ebdf210207eec22d5940157f522463fc1c59/src/smolagents/agents.py#L1345) to `CodeAgent` init to prevent `TypeError: CodeAgent.__init__() missing 1 required positional argument: 'model'`from arising with current implementation
- import and add init for `model = InferenceClientModel()` to pass to `CodeAgent`