### PR TITLE
Default to `0` for `prompt_tokens` when `response.usage` is None.

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1043,8 +1043,8 @@ class LiteLLMModel(ApiModel):
 
         response = self.client.completion(**completion_kwargs)
 
-        self._last_input_token_count = response.usage.prompt_tokens
-        self._last_output_token_count = response.usage.completion_tokens
+        self._last_input_token_count = response.usage.prompt_tokens if response.usage is not None else 0
+        self._last_output_token_count = response.usage.completion_tokens if response.usage is not None else 0
         return ChatMessage.from_dict(
             response.choices[0].message.model_dump(include={"role", "content", "tool_calls"}),
             raw=response,


### PR DESCRIPTION
The openrouter API has `response.usage` as optional, while the OpenAI API does not.