### PR TITLE
Support passing additional params to MLXModel load and tokenizer.apply_chat_template

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -603,25 +603,21 @@ class MLXModel(Model):
     def __init__(
         self,
         model_id: str,
-        tool_name_key: str = "name",
-        tool_arguments_key: str = "arguments",
         trust_remote_code: bool = False,
         **kwargs,
     ):
-        super().__init__(
-            flatten_messages_as_text=True, model_id=model_id, **kwargs
-        )  # mlx-lm doesn't support vision models
+        # mlx-lm doesn't support vision models
+        super().__init__(flatten_messages_as_text=True, model_id=model_id, **kwargs)
         if not _is_package_available("mlx_lm"):
             raise ModuleNotFoundError(
                 "Please install 'mlx-lm' extra to use 'MLXModel': `pip install 'smolagents[mlx-lm]'`"
             )
         import mlx_lm  # type: ignore
 
-        self.model_id = model_id
-        self.model, self.tokenizer = mlx_lm.load(model_id, tokenizer_config={"trust_remote_code": trust_remote_code})
+        self.model, self.tokenizer = mlx_lm.load(
+            self.model_id, tokenizer_config={"trust_remote_code": trust_remote_code}
+        )
         self.stream_generate = mlx_lm.stream_generate
-        self.tool_name_key = tool_name_key
-        self.tool_arguments_key = tool_arguments_key
         self.is_vlm = False  # mlx-lm doesn't support vision models
 
     def generate(

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -575,8 +575,12 @@ class MLXModel(Model):
             The key, which can usually be found in the model's chat template, for retrieving a tool name.
         tool_arguments_key (str):
             The key, which can usually be found in the model's chat template, for retrieving tool arguments.
-        trust_remote_code (bool):
+        trust_remote_code (bool, default `False`):
             Some models on the Hub require running remote code: for this model, you would have to set this flag to True.
+        load_kwargs (dict[str, Any], *optional*):
+            Additional keyword arguments to pass to the `mlx.lm.load` method when loading the model and tokenizer.
+        apply_chat_template_kwargs (dict, *optional*):
+            Additional keyword arguments to pass to the `apply_chat_template` method of the tokenizer.
         kwargs (dict, *optional*):
             Any additional keyword arguments that you want to use in model.generate(), for instance `max_tokens`.
 
@@ -604,19 +608,24 @@ class MLXModel(Model):
         self,
         model_id: str,
         trust_remote_code: bool = False,
+        load_kwargs: dict[str, Any] | None = None,
+        apply_chat_template_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
-        # mlx-lm doesn't support vision models
-        super().__init__(flatten_messages_as_text=True, model_id=model_id, **kwargs)
         if not _is_package_available("mlx_lm"):
             raise ModuleNotFoundError(
                 "Please install 'mlx-lm' extra to use 'MLXModel': `pip install 'smolagents[mlx-lm]'`"
             )
-        import mlx_lm  # type: ignore
+        import mlx_lm
 
-        self.model, self.tokenizer = mlx_lm.load(
-            self.model_id, tokenizer_config={"trust_remote_code": trust_remote_code}
-        )
+        self.load_kwargs = load_kwargs or {}
+        self.load_kwargs.setdefault("tokenizer_config", {}).setdefault("trust_remote_code", trust_remote_code)
+        self.apply_chat_template_kwargs = apply_chat_template_kwargs or {}
+        self.apply_chat_template_kwargs.setdefault("add_generation_prompt", True)
+        # mlx-lm doesn't support vision models: flatten_messages_as_text=True
+        super().__init__(model_id=model_id, flatten_messages_as_text=True, **kwargs)
+
+        self.model, self.tokenizer = mlx_lm.load(self.model_id, **self.load_kwargs)
         self.stream_generate = mlx_lm.stream_generate
         self.is_vlm = False  # mlx-lm doesn't support vision models
 
@@ -641,11 +650,7 @@ class MLXModel(Model):
         tools = completion_kwargs.pop("tools", None)
         completion_kwargs.pop("tool_choice", None)
 
-        prompt_ids = self.tokenizer.apply_chat_template(
-            messages,
-            tools=tools,
-            add_generation_prompt=True,
-        )
+        prompt_ids = self.tokenizer.apply_chat_template(messages, tools=tools, **self.apply_chat_template_kwargs)
 
         output_tokens = 0
         text = ""


### PR DESCRIPTION
Support passing additional params to `MLXModel` `load` and `tokenizer.apply_chat_template`.

Fix #1307.

For example, with this PR we can pass `enable_thinking=True` to Qwen3 tokenizer:
```python
model = MLXModel(model_id="Qwen/Qwen3-30B-A3B", apply_chat_template_kwargs={"enable_thinking": True})
```