### PR TITLE
Always pass add_generation_prompt=True to apply_chat_template

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -536,18 +536,12 @@ class VLLMModel(Model):
         tools = completion_kwargs.pop("tools", None)
         completion_kwargs.pop("tool_choice", None)
 
-        if tools_to_call_from is not None:
-            prompt = self.tokenizer.apply_chat_template(
-                messages,
-                tools=tools,
-                add_generation_prompt=True,
-                tokenize=False,
-            )
-        else:
-            prompt = self.tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-            )
+        prompt = self.tokenizer.apply_chat_template(
+            messages,
+            tools=tools,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
 
         sampling_params = SamplingParams(
             n=kwargs.get("n", 1),
@@ -846,7 +840,7 @@ class TransformersModel(Model):
             messages,  # type: ignore
             tools=[get_tool_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
             return_tensors="pt",
-            add_generation_prompt=True if tools_to_call_from else False,
+            add_generation_prompt=True,
             tokenize=True,
             return_dict=True,
         )

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -828,6 +828,7 @@ class TransformersModel(Model):
 
         messages = completion_kwargs.pop("messages")
         stop_sequences = completion_kwargs.pop("stop", None)
+        tools = completion_kwargs.pop("tools", None)
 
         max_new_tokens = (
             kwargs.get("max_new_tokens")
@@ -837,8 +838,8 @@ class TransformersModel(Model):
             or 1024
         )
         prompt_tensor = (self.processor if hasattr(self, "processor") else self.tokenizer).apply_chat_template(
-            messages,  # type: ignore
-            tools=[get_tool_json_schema(tool) for tool in tools_to_call_from] if tools_to_call_from else None,
+            messages,
+            tools=tools,
             return_tensors="pt",
             add_generation_prompt=True,
             tokenize=True,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,14 +163,14 @@ class TestModel:
             do_sample=False,
         )
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
-        output = model.generate(messages, stop_sequences=["great"]).content
-        assert output == "assistant\nHello"
+        output = model.generate(messages).content
+        assert output == "Hello! I'm here"
 
         output = model.generate_stream(messages, stop_sequences=["great"])
         output_str = ""
         for el in output:
             output_str += el.content
-        assert output_str == "assistant\nHello"
+        assert output_str == "Hello! I'm here"
 
     def test_transformers_message_vl_no_tool(self, shared_datadir, monkeypatch):
         monkeypatch.setattr("huggingface_hub.constants.HF_HUB_DOWNLOAD_TIMEOUT", 30)  # instead of 10
@@ -183,15 +183,17 @@ class TestModel:
             device_map="cpu",
             do_sample=False,
         )
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}, {"type": "image", "image": img}]}]
-        output = model.generate(messages, stop_sequences=["great"]).content
-        assert output == "I am"
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is this?"}, {"type": "image", "image": img}]}
+        ]
+        output = model.generate(messages).content
+        assert output == "This is a very"
 
         output = model.generate_stream(messages, stop_sequences=["great"])
         output_str = ""
         for el in output:
             output_str += el.content
-        assert output_str == "I am"
+        assert output_str == "This is a very"
 
     def test_parse_json_if_needed(self):
         args = "abc"


### PR DESCRIPTION
Always pass `add_generation_prompt=True` to `apply_chat_template`.

This PR passes `add_generation_prompt=True` to `apply_chat_template`, regardless of whether `tools` are provided or not, specifically to:
- VLLMModel
- TransformersModel

Note that before this PR, we always passed `add_generation_prompt=True` regardless of `tools` to:
- MLXModel

The goal is to serve as a basis to continue the discussion on how we want to handle prompt formatting. See previous discussion: https://github.com/huggingface/smolagents/issues/993#issuecomment-2944271019

Based on my own (non-expert) understanding of the [transformers documentation](https://huggingface.co/docs/transformers/main/en/chat_templating#addgenerationprompt), setting `add_generation_prompt=True` appends a generation prompt, which prepares the input so the model knows it should generate a **response from the assistant**. This seems to apply broadly in conversational contexts, which is the case when working with agents, regardless of whether tool calls are used. I would say:
- You should use `add_generation_prompt=True` when:
  - You're preparing an input that should lead to the assistant's next message
  - You want the model to generate a reply, whether that's plain text or a tool call
- The link to tools:
  - `add_generation_prompt=True` does not require `tools=...`
  - But if you are using tools, then `add_generation_prompt=True` is required

In a discussion with @molbap, he mentioned that in conversational contexts, regardless of whether tools are passed to `model.generate`, it is generally recommended to include the generation prompt. This is because the model's output is conditioned on special tokens (like `<|assistant|>`, `<|bos|>`, or `<|eos|>` defined in its config). Omitting them can often lead to suboptimal generation results.

Fix #993.