### PR TITLE
Fix logging of Docker build logs

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -233,7 +233,8 @@ class DockerExecutor(RemotePythonExecutor):
                 _, build_logs = self.client.images.build(
                     path=str(dockerfile_path.parent), dockerfile=str(dockerfile_path), tag=self.image_name
                 )
-                self.logger.log(build_logs, level=LogLevel.DEBUG)
+                build_logs = "".join([x.get("stream", "") for x in build_logs])
+                self.logger.log(build_logs.rstrip(), level=LogLevel.DEBUG)
 
             self.logger.log(f"Starting container on {host}:{port}...", level=LogLevel.INFO)
             # Create base container parameters


### PR DESCRIPTION
Log the actual build logs instead of the generator object `<itertools._tee object at 0x102566100>`. Note that this requires `LogLevel.DEBUG`.

**Before:**
```
Initializing executor, hold on...
Building Docker image jupyter-kernel...
<itertools._tee object at 0x102566100>
Starting container on 127.0.0.1:8888...
Container status: created, waiting...
Container e75fc3014e66 is running with kernel e47a7e1a-9723-4c5a-8157-fcffd14bfdae
```

**After:**
```
Initializing executor, hold on...
Building Docker image jupyter-kernel...
Step 1/6 : FROM python:3.12-slim
 ---> 31a416db24bd
Step 2/6 : RUN pip install jupyter_kernel_gateway requests numpy pandas
 ---> Using cache
 ---> b827be6d2dc6
Step 3/6 : RUN pip install jupyter_client notebook
 ---> Using cache
 ---> 93de55e39b1a
Step 4/6 : RUN pip install smolagents
 ---> Using cache
 ---> d7d84341b0db
Step 5/6 : EXPOSE 8888
 ---> Using cache
 ---> 63f8f9c5545c
Step 6/6 : CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", 
"--KernelGatewayApp.allow_origin='*'"]
 ---> Using cache
 ---> 5f44d4c65961
Successfully built 5f44d4c65961
Successfully tagged jupyter-kernel:latest
Starting container on 127.0.0.1:8888...
Container status: created, waiting...
Container 6e1b62d6a49e is running with kernel 5a573a4d-46b0-40a4-a52e-707e8754bb01
```

**Test app:**
```
from smolagents import CodeAgent, InferenceClientModel
from smolagents.monitoring import LogLevel

model = InferenceClientModel()

agent = CodeAgent(
    model=model,
    tools=[],
    executor_type="docker",
    verbosity_level=LogLevel.DEBUG
)
```