### PR TITLE
Support context managers for agent cleanup

### DIFF
--- a/docs/source/en/tutorials/secure_code_execution.mdx
+++ b/docs/source/en/tutorials/secure_code_execution.mdx
@@ -143,7 +143,8 @@ from smolagents import InferenceClientModel, CodeAgent
 
 agent = CodeAgent(model=InferenceClientModel(), tools=[], executor_type="e2b")
 
-agent.run("Can you give me the 100th Fibonacci number?")
+with agent:
+    agent.run("Can you give me the 100th Fibonacci number?")
 ```
 
 This solution send the agent state to the server at the start of each `agent.run()`.
@@ -158,6 +159,9 @@ This is illustrated in the figure below.
 
 However, since any call to a [managed agent](../examples/multiagents) would require model calls, since we do not transfer secrets to the remote sandbox, the model call would lack credentials.
 Hence this solution does not work (yet) with more complicated multi-agent setups.
+
+> [!TIP]
+> Using a context manager for the agent, like the `with` statement above, ensures immediate cleanup of the E2B sandbox when the agent has finished its task. If you prefer not to use a context manager, you may also call the agent's `cleanup` method directly.
 
 #### Running your agent in E2B: multi-agents
 
@@ -234,8 +238,12 @@ from smolagents import InferenceClientModel, CodeAgent
 
 agent = CodeAgent(model=InferenceClientModel(), tools=[], executor_type="docker")
 
-agent.run("Can you give me the 100th Fibonacci number?")
+with agent:
+    agent.run("Can you give me the 100th Fibonacci number?")
 ```
+
+> [!TIP]
+> As for the E2B Sandbox above, using a context manager for the agent ensures cleanup of the Docker container when the agent has finished its task. An alternative approach is to call the agent's `cleanup` method directly.
 
 #### Advanced docker usage
 

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -297,6 +297,16 @@ class MultiStepAgent(ABC):
         self.step_callbacks.append(self.monitor.update_metrics)
         self.stream_outputs = False
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources used by the agent."""
+        pass
+
     @property
     def system_prompt(self) -> str:
         return self.initialize_system_prompt()
@@ -1474,6 +1484,9 @@ class CodeAgent(MultiStepAgent):
         self.executor_type = executor_type or "local"
         self.executor_kwargs = executor_kwargs or {}
         self.python_executor = self.create_python_executor()
+
+    def cleanup(self):
+        self.python_executor.cleanup()
 
     def create_python_executor(self) -> PythonExecutor:
         match self.executor_type:

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1547,7 +1547,9 @@ def evaluate_python_code(
 
 
 class PythonExecutor:
-    pass
+    def cleanup(self):
+        """Clean up resources used by the executor."""
+        pass
 
 
 class LocalPythonExecutor(PythonExecutor):

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -156,6 +156,16 @@ class E2BExecutor(RemotePythonExecutor):
                 raise AgentError("No main result returned by executor!", self.logger)
             return None, execution_logs
 
+    def cleanup(self):
+        try:
+            if hasattr(self, "sandbox"):
+                self.logger.log("Shutting down sandbox...", level=LogLevel.INFO)
+                self.sandbox.kill()
+                self.logger.log("Sandbox cleanup completed", level=LogLevel.INFO)
+                del self.sandbox
+        except Exception as e:
+            self.logger.log_error(f"Error during cleanup: {e}")
+
 
 class DockerExecutor(RemotePythonExecutor):
     """
@@ -374,13 +384,13 @@ class DockerExecutor(RemotePythonExecutor):
         return msg_id
 
     def cleanup(self):
-        """Clean up resources."""
         try:
             if hasattr(self, "container"):
                 self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)
                 self.container.stop()
                 self.container.remove()
                 self.logger.log("Container cleanup completed", level=LogLevel.INFO)
+                del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")
 


### PR DESCRIPTION
Support context managers for cleanup of resources used by agents.

- Support context managers like `with` statements.
- Support calling the agent's `cleanup` method directly.
- Implement cleanup for the E2B executor. The E2B sandbox would previously stay alive for up to the default timeout of 5 minutes as per the [E2B documentation](https://e2b.dev/docs/sandbox).

### Intended usage patterns

**With**
```python
agent = CodeAgent(
    model=model,
    tools=[],
    executor_type="docker"
)

with agent:
    task = "... some task ..."
    agent.run(task)
```

**With-As**
```python
with CodeAgent(model=model,
    tools=[],
    executor_type="docker"
) as agent:
    task = "... some task ..."
    agent.run(task)
```

**Try-Finally**
```python
agent = CodeAgent(
    model=model,
    tools=[],
    executor_type="docker"
)

try:
    task = "... some task ..."
    agent.run(task)
finally:
    agent.cleanup()
```

**Manual**
```python
agent = CodeAgent(
    model=model,
    tools=[],
    executor_type="docker"
)

task = "... some task ..."
agent.run(task)

agent.cleanup()
```