### PR TITLE
Fix ValueError on Guided Tour docs

### DIFF
--- a/docs/source/en/guided_tour.mdx
+++ b/docs/source/en/guided_tour.mdx
@@ -473,7 +473,7 @@ model = InferenceClientModel()
 web_agent = CodeAgent(
     tools=[WebSearchTool()],
     model=model,
-    name="web_search",
+    name="web_search_agent",
     description="Runs web searches for you. Give it your query as an argument."
 )
 


### PR DESCRIPTION
Fix ValueError on Guided Tour docs.

Currently, following the docs example raises a ValueError:
> ValueError: Each tool or managed_agent should have a unique name! You passed these duplicate names: ['web_search', 'web_search']

Supersede and close #847.