### PR TITLE
Transfer aggregation of streaming events off the Model class

### DIFF
--- a/docs/source/en/reference/models.mdx
+++ b/docs/source/en/reference/models.mdx
@@ -66,7 +66,7 @@ print(model([{"role": "user", "content": [{"type": "text", "text": "Ok!"}]}], st
 
 ### InferenceClientModel
 
-The `HfApiModel` wraps huggingface_hub's [InferenceClient](https://huggingface.co/docs/huggingface_hub/main/en/guides/inference) for the execution of the LLM. It supports all [Inference Providers](https://huggingface.co/docs/inference-providers/index) available on the Hub: Cerebras, Cohere, Fal, Fireworks, HF-Inference, Hyperbolic, Nebius, Novita, Replicate, SambaNova, Together, and more.
+The `InferenceClientModel` wraps huggingface_hub's [InferenceClient](https://huggingface.co/docs/huggingface_hub/main/en/guides/inference) for the execution of the LLM. It supports all [Inference Providers](https://huggingface.co/docs/inference-providers/index) available on the Hub: Cerebras, Cohere, Fal, Fireworks, HF-Inference, Hyperbolic, Nebius, Novita, Replicate, SambaNova, Together, and more.
 
 ```python
 from smolagents import InferenceClientModel

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,7 +1,7 @@
-from smolagents import GradioUI, ToolCallingAgent, TransformersModel, WebSearchTool
+from smolagents import CodeAgent, GradioUI, TransformersModel, WebSearchTool
 
 
-agent = ToolCallingAgent(
+agent = CodeAgent(
     tools=[WebSearchTool()],
     model=TransformersModel(model_id="HuggingFaceTB/SmolLM2-1.7B-Instruct"),
     verbosity_level=1,
@@ -11,5 +11,5 @@ agent = ToolCallingAgent(
     step_callbacks=[],
     stream_outputs=True,
 )
-
+print(agent.initialize_system_prompt())
 GradioUI(agent, file_upload_folder="./data").launch()

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,9 +1,9 @@
-from smolagents import GradioUI, OpenAIServerModel, ToolCallingAgent, WebSearchTool
+from smolagents import GradioUI, ToolCallingAgent, TransformersModel, WebSearchTool
 
 
 agent = ToolCallingAgent(
     tools=[WebSearchTool()],
-    model=OpenAIServerModel(model_id="gpt-4o"),
+    model=TransformersModel(model_id="HuggingFaceTB/SmolLM2-1.7B-Instruct"),
     verbosity_level=1,
     # planning_interval=3,
     name="example_agent",

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,16 +1,15 @@
-from smolagents import CodeAgent, GradioUI, InferenceClientModel, WebSearchTool
+from smolagents import GradioUI, OpenAIServerModel, ToolCallingAgent, WebSearchTool
 
 
-agent = CodeAgent(
+agent = ToolCallingAgent(
     tools=[WebSearchTool()],
-    model=InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct", provider="fireworks-ai"),
+    model=OpenAIServerModel(model_id="gpt-4o"),
     verbosity_level=1,
-    planning_interval=3,
+    # planning_interval=3,
     name="example_agent",
     description="This is an example agent.",
     step_callbacks=[],
     stream_outputs=True,
-    use_structured_outputs_internally=True,
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -10,7 +10,7 @@ agent = CodeAgent(
     description="This is an example agent.",
     step_callbacks=[],
     stream_outputs=True,
-    use_structured_outputs_internally=True,
+    # use_structured_outputs_internally=True,
 )
 
 GradioUI(agent, file_upload_folder="./data").launch()

--- a/examples/gradio_ui.py
+++ b/examples/gradio_ui.py
@@ -1,15 +1,16 @@
-from smolagents import CodeAgent, GradioUI, TransformersModel, WebSearchTool
+from smolagents import CodeAgent, GradioUI, InferenceClientModel, WebSearchTool
 
 
 agent = CodeAgent(
     tools=[WebSearchTool()],
-    model=TransformersModel(model_id="HuggingFaceTB/SmolLM2-1.7B-Instruct"),
+    model=InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct", provider="fireworks-ai"),
     verbosity_level=1,
-    # planning_interval=3,
+    planning_interval=3,
     name="example_agent",
     description="This is an example agent.",
     step_callbacks=[],
     stream_outputs=True,
+    use_structured_outputs_internally=True,
 )
-print(agent.initialize_system_prompt())
+
 GradioUI(agent, file_upload_folder="./data").launch()

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -269,15 +269,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert (
-                not missing_keys
-            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            assert not missing_keys, (
+                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            )
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert (
-                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
-                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
+                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        )
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -331,9 +331,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(
-                agent.name and agent.description for agent in managed_agents
-            ), "All managed agents need both a name and a description!"
+            assert all(agent.name and agent.description for agent in managed_agents), (
+                "All managed agents need both a name and a description!"
+            )
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -256,15 +256,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            assert (
+                not missing_keys
+            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        assert (
+                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
+                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -318,9 +318,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            assert all(
+                agent.name and agent.description for agent in managed_agents
+            ), "All managed agents need both a name and a description!"
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1227,6 +1227,7 @@ class ToolCallingAgent(MultiStepAgent):
                             Markdown(agglomerate_stream_deltas(chat_message_stream_deltas).render_as_markdown())
                         )
                         yield event
+                print("CHAT MESSAGE STREAM DELTA:", chat_message_stream_deltas)
                 chat_message = agglomerate_stream_deltas(chat_message_stream_deltas)
             else:
                 chat_message: ChatMessage = self.model.generate(
@@ -1235,16 +1236,15 @@ class ToolCallingAgent(MultiStepAgent):
                     tools_to_call_from=list(self.tools.values()),
                 )
 
-                model_output = chat_message.content
                 self.logger.log_markdown(
-                    content=model_output if model_output else str(chat_message.raw),
+                    content=chat_message.content if chat_message.content else str(chat_message.raw),
                     title="Output message of the LLM:",
                     level=LogLevel.DEBUG,
                 )
 
             # Record model output
             memory_step.model_output_message = chat_message
-            memory_step.model_output = model_output
+            memory_step.model_output = chat_message.content
             memory_step.token_usage = chat_message.token_usage
         except Exception as e:
             raise AgentGenerationError(f"Error while generating output:\n{e}", self.logger) from e

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -276,15 +276,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert (
-                not missing_keys
-            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            assert not missing_keys, (
+                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            )
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert (
-                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
-                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
+                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        )
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -338,9 +338,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(
-                agent.name and agent.description for agent in managed_agents
-            ), "All managed agents need both a name and a description!"
+            assert all(agent.name and agent.description for agent in managed_agents), (
+                "All managed agents need both a name and a description!"
+            )
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -276,15 +276,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            assert (
+                not missing_keys
+            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        assert (
+                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
+                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -338,9 +338,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            assert all(
+                agent.name and agent.description for agent in managed_agents
+            ), "All managed agents need both a name and a description!"
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -256,15 +256,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert (
-                not missing_keys
-            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            assert not missing_keys, (
+                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            )
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert (
-                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
-                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
+                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        )
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -318,9 +318,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(
-                agent.name and agent.description for agent in managed_agents
-            ), "All managed agents need both a name and a description!"
+            assert all(agent.name and agent.description for agent in managed_agents), (
+                "All managed agents need both a name and a description!"
+            )
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -656,10 +656,11 @@ You have been provided with these additional arguments, that you can access usin
             else:
                 plan_message = self.model.generate(input_messages, stop_sequences=["<end_plan>"])
                 plan_message_content = plan_message.content
-                input_tokens, output_tokens = (
-                    plan_message.token_usage.input_tokens,
-                    plan_message.token_usage.output_tokens,
-                )
+                if plan_message.token_usage is not None:
+                    input_tokens, output_tokens = (
+                        plan_message.token_usage.input_tokens,
+                        plan_message.token_usage.output_tokens,
+                    )
             plan = textwrap.dedent(
                 f"""I still need to solve the task I was given:\n```\n{self.task}\n```\n\nHere are the facts I know and my new/updated plan of action to solve the task:\n```\n{plan_message_content}\n```"""
             )
@@ -781,7 +782,7 @@ You have been provided with these additional arguments, that you can access usin
             chat_message: ChatMessage = self.model.generate(messages)
             return chat_message
         except Exception as e:
-            return f"Error in generating final LLM output:\n{e}"
+            return ChatMessage(role=MessageRole.ASSISTANT, content=f"Error in generating final LLM output:\n{e}")
 
     def visualize(self):
         """Creates a rich tree visualization of the agent's structure."""

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -572,7 +572,10 @@ You have been provided with these additional arguments, that you can access usin
                     content=[
                         {
                             "type": "text",
-                            "text": self.prompt_templates["planning"]["initial_plan"],
+                            "text": populate_template(
+                                self.prompt_templates["planning"]["initial_plan"],
+                                variables={"task": task, "tools": self.tools, "managed_agents": self.managed_agents},
+                            ),
                         }
                     ],
                 )

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1292,7 +1292,6 @@ class ToolCallingAgent(MultiStepAgent):
         assert chat_message.tool_calls is not None
         for tool_call in chat_message.tool_calls:
             yield tool_call
-        for tool_call in chat_message.tool_calls:
             tool_name = tool_call.function.name
             tool_arguments = tool_call.function.arguments
             model_outputs.append(str(f"Called Tool: '{tool_name}' with arguments: {tool_arguments}"))

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -209,7 +209,7 @@ class RunResult:
 StreamEvent: TypeAlias = Union[
     ChatMessageStreamDelta,
     ChatMessageToolCall,
-    FinalOutput,
+    ActionOutput,
     PlanningStep,
     ActionStep,
     FinalAnswerStep,
@@ -270,15 +270,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            assert (
+                not missing_keys
+            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        assert (
+                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
+                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -332,9 +332,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            assert all(
+                agent.name and agent.description for agent in managed_agents
+            ), "All managed agents need both a name and a description!"
             self.managed_agents = {agent.name: agent for agent in managed_agents}
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1227,7 +1227,6 @@ class ToolCallingAgent(MultiStepAgent):
                             Markdown(agglomerate_stream_deltas(chat_message_stream_deltas).render_as_markdown())
                         )
                         yield event
-                print("CHAT MESSAGE STREAM DELTA:", chat_message_stream_deltas)
                 chat_message = agglomerate_stream_deltas(chat_message_stream_deltas)
             else:
                 chat_message: ChatMessage = self.model.generate(

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -166,8 +166,7 @@ class TaskStep(MemoryStep):
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         content = [{"type": "text", "text": f"New task:\n{self.task}"}]
         if self.task_images:
-            for image in self.task_images:
-                content.append({"type": "image", "image": image})
+            content.extend([{"type": "image", "image": image} for image in self.task_images])
 
         return [ChatMessage(role=MessageRole.USER, content=content)]
 

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -2,7 +2,7 @@ from dataclasses import asdict, dataclass
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
-from smolagents.models import ChatMessage, Message, MessageRole
+from smolagents.models import ChatMessage, MessageRole
 from smolagents.monitoring import AgentLogger, LogLevel, Timing, TokenUsage
 from smolagents.utils import AgentError, make_json_serializable
 
@@ -39,7 +39,7 @@ class MemoryStep:
     def dict(self):
         return asdict(self)
 
-    def to_messages(self, summary_mode: bool = False) -> list[Message]:
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         raise NotImplementedError
 
 
@@ -47,7 +47,7 @@ class MemoryStep:
 class ActionStep(MemoryStep):
     step_number: int
     timing: Timing
-    model_input_messages: list[Message] | None = None
+    model_input_messages: list[ChatMessage] | None = None
     tool_calls: list[ToolCall] | None = None
     error: AgentError | None = None
     model_output_message: ChatMessage | None = None
@@ -77,16 +77,16 @@ class ActionStep(MemoryStep):
             "is_final_answer": self.is_final_answer,
         }
 
-    def to_messages(self, summary_mode: bool = False) -> list[Message]:
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         messages = []
         if self.model_output is not None and not summary_mode:
             messages.append(
-                Message(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.model_output.strip()}])
+                ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.model_output.strip()}])
             )
 
         if self.tool_calls is not None:
             messages.append(
-                Message(
+                ChatMessage(
                     role=MessageRole.TOOL_CALL,
                     content=[
                         {
@@ -99,7 +99,7 @@ class ActionStep(MemoryStep):
 
         if self.observations_images:
             messages.append(
-                Message(
+                ChatMessage(
                     role=MessageRole.USER,
                     content=[
                         {
@@ -113,7 +113,7 @@ class ActionStep(MemoryStep):
 
         if self.observations is not None:
             messages.append(
-                Message(
+                ChatMessage(
                     role=MessageRole.TOOL_RESPONSE,
                     content=[
                         {
@@ -132,7 +132,7 @@ class ActionStep(MemoryStep):
             message_content = f"Call id: {self.tool_calls[0].id}\n" if self.tool_calls else ""
             message_content += error_message
             messages.append(
-                Message(role=MessageRole.TOOL_RESPONSE, content=[{"type": "text", "text": message_content}])
+                ChatMessage(role=MessageRole.TOOL_RESPONSE, content=[{"type": "text", "text": message_content}])
             )
 
         return messages
@@ -140,18 +140,20 @@ class ActionStep(MemoryStep):
 
 @dataclass
 class PlanningStep(MemoryStep):
-    model_input_messages: list[Message]
+    model_input_messages: list[ChatMessage]
     model_output_message: ChatMessage
     plan: str
     timing: Timing
     token_usage: TokenUsage | None = None
 
-    def to_messages(self, summary_mode: bool = False) -> list[Message]:
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         if summary_mode:
             return []
         return [
-            Message(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.plan.strip()}]),
-            Message(role=MessageRole.USER, content=[{"type": "text", "text": "Now proceed and carry out this plan."}]),
+            ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.plan.strip()}]),
+            ChatMessage(
+                role=MessageRole.USER, content=[{"type": "text", "text": "Now proceed and carry out this plan."}]
+            ),
             # This second message creates a role change to prevent models models from simply continuing the plan message
         ]
 
@@ -161,23 +163,23 @@ class TaskStep(MemoryStep):
     task: str
     task_images: list["PIL.Image.Image"] | None = None
 
-    def to_messages(self, summary_mode: bool = False) -> list[Message]:
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         content = [{"type": "text", "text": f"New task:\n{self.task}"}]
         if self.task_images:
             for image in self.task_images:
                 content.append({"type": "image", "image": image})
 
-        return [Message(role=MessageRole.USER, content=content)]
+        return [ChatMessage(role=MessageRole.USER, content=content)]
 
 
 @dataclass
 class SystemPromptStep(MemoryStep):
     system_prompt: str
 
-    def to_messages(self, summary_mode: bool = False) -> list[Message]:
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         if summary_mode:
             return []
-        return [Message(role=MessageRole.SYSTEM, content=[{"type": "text", "text": self.system_prompt}])]
+        return [ChatMessage(role=MessageRole.SYSTEM, content=[{"type": "text", "text": self.system_prompt}])]
 
 
 @dataclass

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -1,8 +1,8 @@
 from dataclasses import asdict, dataclass
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
 
-from smolagents.models import ChatMessage, MessageRole
+from smolagents.models import ChatMessage, Message, MessageRole
 from smolagents.monitoring import AgentLogger, LogLevel, Timing, TokenUsage
 from smolagents.utils import AgentError, make_json_serializable
 
@@ -15,11 +15,6 @@ if TYPE_CHECKING:
 
 
 logger = getLogger(__name__)
-
-
-class Message(TypedDict):
-    role: MessageRole
-    content: str | list[dict[str, Any]]
 
 
 @dataclass

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -121,8 +121,8 @@ class ChatMessage:
     def dict(self):
         return get_dict_from_nested_dataclasses(self)
 
-    def render_as_markdown(self):
-        rendered = self.content
+    def render_as_markdown(self) -> str:
+        rendered = self.content or ""
         if self.tool_calls:
             rendered += "\n".join(
                 [

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1854,7 +1854,6 @@ __all__ = [
     "TransformersModel",
     "ApiModel",
     "InferenceClientModel",
-    "HfApiModel",
     "LiteLLMModel",
     "LiteLLMRouterModel",
     "OpenAIServerModel",

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -122,7 +122,7 @@ class ChatMessage:
         return get_dict_from_nested_dataclasses(self)
 
     def render_as_markdown(self) -> str:
-        rendered = self.content or ""
+        rendered = str(self.content) or ""
         if self.tool_calls:
             rendered += "\n".join(
                 [

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -914,7 +914,7 @@ class TransformersModel(Model):
             or 1024
         )
         prompt_tensor = (self.processor if hasattr(self, "processor") else self.tokenizer).apply_chat_template(
-            [message.dict() for message in messages],
+            messages,
             tools=tools,
             return_tensors="pt",
             add_generation_prompt=True,

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -666,9 +666,7 @@ class MLXModel(Model):
     >>> messages = [
     ...     {
     ...         "role": "user",
-    ...         "content": [
-    ...             {"type": "text", "text": "Explain quantum mechanics in simple terms."}
-    ...         ]
+    ...         "content": "Explain quantum mechanics in simple terms."
     ...     }
     ... ]
     >>> response = engine(messages, stop_sequences=["END"])

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -153,7 +153,6 @@ class ToolCallStreamDelta:
     function: ChatMessageToolCallDefinition | None = None
 
     def convert_to_tool_call(self) -> ChatMessageToolCall:
-        assert self.type is not None
         assert self.function is not None
         return ChatMessageToolCall(
             id=self.id or self.index,
@@ -203,8 +202,8 @@ def agglomerate_stream_deltas(
                 if tool_call_delta.index is not None:
                     if tool_call_delta.index not in accumulated_tool_calls:
                         accumulated_tool_calls[tool_call_delta.index] = ToolCallStreamDelta(
-                            id=None,
-                            type=None,
+                            id=tool_call_delta.id,
+                            type=tool_call_delta.type,
                             function=ChatMessageToolCallDefinition(name="", arguments=""),
                         )
                     # Update the tool call at the specific index

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -276,8 +276,8 @@ def get_clean_message_list(
     flatten_messages_as_text: bool = False,
 ) -> list[dict[str, Any]]:
     """
+    Creates a list of messages to give as input to the LLM. These messages are dictionaries and chat template compatible with transformers LLM chat template.
     Subsequent messages with the same role will be concatenated to a single message.
-    output_message_list is a list of messages that will be used to generate the final message that is chat template compatible with transformers LLM chat template.
 
     Args:
         message_list (`list[dict[str, str]]`): List of chat messages.
@@ -427,7 +427,7 @@ class Model:
         """
         # Clean and standardize the message list
         flatten_messages_as_text = kwargs.pop("flatten_messages_as_text", self.flatten_messages_as_text)
-        messages = get_clean_message_list(
+        messages_as_dicts = get_clean_message_list(
             messages,
             role_conversions=custom_role_conversions or tool_role_conversions,
             convert_images_to_image_urls=convert_images_to_image_urls,
@@ -436,7 +436,7 @@ class Model:
         # Use self.kwargs as the base configuration
         completion_kwargs = {
             **self.kwargs,
-            "messages": messages,
+            "messages": messages_as_dicts,
         }
 
         # Handle specific parameters
@@ -1616,9 +1616,7 @@ class OpenAIServerModel(ApiModel):
         )
 
 
-class OpenAIModel(OpenAIServerModel):
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls)
+OpenAIModel = OpenAIServerModel
 
 
 class AzureOpenAIServerModel(OpenAIServerModel):
@@ -1678,9 +1676,7 @@ class AzureOpenAIServerModel(OpenAIServerModel):
         return openai.AzureOpenAI(**self.client_kwargs)
 
 
-class AzureOpenAIModel(AzureOpenAIServerModel):
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls)
+AzureOpenAIModel = AzureOpenAIServerModel
 
 
 class AmazonBedrockServerModel(ApiModel):
@@ -1861,10 +1857,7 @@ class AmazonBedrockServerModel(ApiModel):
         )
 
 
-class AmazonBedrockModel(AmazonBedrockServerModel):
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls)
-
+AmazonBedrockModel = AmazonBedrockServerModel
 
 __all__ = [
     "MessageRole",

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -217,7 +217,16 @@ def agglomerate_stream_deltas(
         role=role,
         content=accumulated_content,
         tool_calls=[
-            tool_call_stream_delta.convert_to_tool_call() for tool_call_stream_delta in accumulated_tool_calls.values()
+            ChatMessageToolCall(
+                function=ChatMessageToolCallFunction(
+                    name=tool_call_stream_delta.function.name,
+                    arguments=tool_call_stream_delta.function.arguments,
+                ),
+                id=tool_call_stream_delta.id or "",
+                type="function",
+            )
+            for tool_call_stream_delta in accumulated_tool_calls.values()
+            if tool_call_stream_delta.function
         ],
         token_usage=TokenUsage(
             input_tokens=total_input_tokens,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -821,7 +821,11 @@ class TestMultiStepAgent:
             (
                 1,
                 [
-                    [ChatMessage(role=MessageRole.USER, content="INITIAL_PLAN_USER_PROMPT")],
+                    [
+                        ChatMessage(
+                            role=MessageRole.USER, content=[{"type": "text", "text": "INITIAL_PLAN_USER_PROMPT"}]
+                        ),
+                    ],
                 ],
             ),
             (
@@ -830,11 +834,11 @@ class TestMultiStepAgent:
                     [
                         ChatMessage(
                             role=MessageRole.SYSTEM,
-                            content="UPDATE_PLAN_SYSTEM_PROMPT",
+                            content=[{"type": "text", "text": "UPDATE_PLAN_SYSTEM_PROMPT"}],
                         ),
                         ChatMessage(
                             role=MessageRole.USER,
-                            content="UPDATE_PLAN_USER_PROMPT",
+                            content=[{"type": "text", "text": "UPDATE_PLAN_USER_PROMPT"}],
                         ),
                     ],
                 ],
@@ -876,7 +880,7 @@ class TestMultiStepAgent:
         }
         for expected_messages in expected_messages_list:
             for expected_message in expected_messages:
-                expected_message.content = expected_message_texts[expected_message.content]
+                expected_message.content[0]["text"] = expected_message_texts[expected_message.content[0]["text"]]
         assert isinstance(planning_step, PlanningStep)
         expected_model_input_messages = expected_messages_list[0]
         model_input_messages = planning_step.model_input_messages
@@ -886,7 +890,7 @@ class TestMultiStepAgent:
             assert isinstance(message, ChatMessage)
             assert message.role in MessageRole.__members__.values()
             assert message.role == expected_message.role
-            assert isinstance(message.content, str)
+            assert isinstance(message.content, list)
             for content, expected_content in zip(message.content, expected_message.content):
                 assert content == expected_content
         # Test calls to model
@@ -900,7 +904,7 @@ class TestMultiStepAgent:
                 assert isinstance(message, ChatMessage)
                 assert message.role in MessageRole.__members__.values()
                 assert message.role == expected_message.role
-                assert isinstance(message.content, str)
+                assert isinstance(message.content, list)
                 for content, expected_content in zip(message.content, expected_message.content):
                     assert content == expected_content
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -667,7 +667,7 @@ nested_answer()
             len(update_plan_step.model_input_messages) == 3
         )  # system message + memory messages (1 task message, the latest one is removed) + user message
         assert update_plan_step.model_input_messages[0].role == "system"
-        assert task in update_plan_step.model_input_messages[0].content
+        assert task in update_plan_step.model_input_messages[0].content[0]["text"]
         assert update_plan_step.model_input_messages[1].role == "user"
         assert "Previous user request" in update_plan_step.model_input_messages[1].content[0]["text"]
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -821,11 +821,7 @@ class TestMultiStepAgent:
             (
                 1,
                 [
-                    [
-                        ChatMessage(
-                            role=MessageRole.USER, content=[{"type": "text", "text": "INITIAL_PLAN_USER_PROMPT"}]
-                        )
-                    ],
+                    [ChatMessage(role=MessageRole.USER, content="INITIAL_PLAN_USER_PROMPT")],
                 ],
             ),
             (
@@ -834,11 +830,11 @@ class TestMultiStepAgent:
                     [
                         ChatMessage(
                             role=MessageRole.SYSTEM,
-                            content=[{"type": "text", "text": "UPDATE_PLAN_SYSTEM_PROMPT"}],
+                            content="UPDATE_PLAN_SYSTEM_PROMPT",
                         ),
                         ChatMessage(
                             role=MessageRole.USER,
-                            content=[{"type": "text", "text": "UPDATE_PLAN_USER_PROMPT"}],
+                            content="UPDATE_PLAN_USER_PROMPT",
                         ),
                     ],
                 ],
@@ -880,8 +876,7 @@ class TestMultiStepAgent:
         }
         for expected_messages in expected_messages_list:
             for expected_message in expected_messages:
-                for expected_content in expected_message["content"]:
-                    expected_content["text"] = expected_message_texts[expected_content["text"]]
+                expected_message.content = expected_message_texts[expected_message.content]
         assert isinstance(planning_step, PlanningStep)
         expected_model_input_messages = expected_messages_list[0]
         model_input_messages = planning_step.model_input_messages
@@ -891,8 +886,7 @@ class TestMultiStepAgent:
             assert isinstance(message, ChatMessage)
             assert message.role in MessageRole.__members__.values()
             assert message.role == expected_message.role
-            assert isinstance(message.content, list)
-            assert len(message.content) == 1
+            assert isinstance(message.content, str)
             for content, expected_content in zip(message.content, expected_message.content):
                 assert content == expected_content
         # Test calls to model
@@ -906,8 +900,7 @@ class TestMultiStepAgent:
                 assert isinstance(message, ChatMessage)
                 assert message.role in MessageRole.__members__.values()
                 assert message.role == expected_message.role
-                assert isinstance(message.content, list)
-                assert len(message.content) == 1
+                assert isinstance(message.content, str)
                 for content, expected_content in zip(message.content, expected_message.content):
                     assert content == expected_content
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1235,7 +1235,7 @@ class TestToolCallingAgent:
 
         model = OpenAIServerModel(model_id="fakemodel")
 
-        agent = ToolCallingAgent(model=model, tools=[], max_steps=1, stream_outputs=True)
+        agent = ToolCallingAgent(model=model, tools=[], max_steps=1, stream_outputs=True, verbosity_level=100)
         result = agent.run("Make 2 calls to final answer: return both 'output1' and 'output2'")
         assert len(agent.memory.steps[-1].model_output_message.tool_calls) == 2
         assert agent.memory.steps[-1].model_output_message.tool_calls[0].function.name == "final_answer"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -928,7 +928,10 @@ class TestMultiStepAgent:
                     [
                         ChatMessage(
                             role=MessageRole.SYSTEM,
-                            content=[{"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"}, {"type": "image"}],
+                            content=[
+                                {"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"},
+                                {"type": "image", "image": "image1.png"},
+                            ],
                         ),
                         ChatMessage(
                             role=MessageRole.USER,
@@ -978,7 +981,6 @@ class TestMultiStepAgent:
                 assert message.role in MessageRole.__members__.values()
                 assert message.role == expected_message.role
                 assert isinstance(message.content, list)
-                assert len(message.content) == len(expected_message.content)
                 for content, expected_content in zip(message.content, expected_message.content):
                     assert content == expected_content
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1121,7 +1121,7 @@ class TestToolCallingAgent:
                 ChatMessageToolCall(
                     id="call_0",
                     type="function",
-                    function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "test_value"}),
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "test_value"}),
                 )
             ],
         )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -53,7 +53,7 @@ from smolagents.memory import (
 from smolagents.models import (
     ChatMessage,
     ChatMessageToolCall,
-    ChatMessageToolCallDefinition,
+    ChatMessageToolCallFunction,
     InferenceClientModel,
     MessageRole,
     Model,
@@ -115,7 +115,7 @@ class FakeToolCallModel(Model):
                     ChatMessageToolCall(
                         id="call_0",
                         type="function",
-                        function=ChatMessageToolCallDefinition(
+                        function=ChatMessageToolCallFunction(
                             name="python_interpreter", arguments={"code": "2*3.6452"}
                         ),
                     )
@@ -129,7 +129,7 @@ class FakeToolCallModel(Model):
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="final_answer", arguments={"answer": "7.2904"}),
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "7.2904"}),
                     )
                 ],
             )
@@ -145,7 +145,7 @@ class FakeToolCallModelImage(Model):
                     ChatMessageToolCall(
                         id="call_0",
                         type="function",
-                        function=ChatMessageToolCallDefinition(
+                        function=ChatMessageToolCallFunction(
                             name="fake_image_generation_tool",
                             arguments={"prompt": "An image of a cat"},
                         ),
@@ -160,7 +160,7 @@ class FakeToolCallModelImage(Model):
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="final_answer", arguments="image.png"),
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments="image.png"),
                     )
                 ],
             )
@@ -176,7 +176,7 @@ class FakeToolCallModelVL(Model):
                     ChatMessageToolCall(
                         id="call_0",
                         type="function",
-                        function=ChatMessageToolCallDefinition(
+                        function=ChatMessageToolCallFunction(
                             name="fake_image_understanding_tool",
                             arguments={
                                 "prompt": "What is in this image?",
@@ -194,7 +194,7 @@ class FakeToolCallModelVL(Model):
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="final_answer", arguments="The image is a cat."),
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments="The image is a cat."),
                     )
                 ],
             )
@@ -1309,7 +1309,7 @@ class TestToolCallingAgent:
                 ChatMessageToolCall(
                     id="call_0",
                     type="function",
-                    function=ChatMessageToolCallDefinition(
+                    function=ChatMessageToolCallFunction(
                         name="final_answer", arguments={"answer1": "1", "answer2": "2"}
                     ),
                 )
@@ -1328,7 +1328,7 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "test_value"}),
+                        function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "test_value"}),
                     )
                 ],
                 "expected_model_output": "Called Tool: 'test_tool' with arguments: {'input': 'test_value'}",
@@ -1342,12 +1342,12 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "value1"}),
+                        function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value1"}),
                     ),
                     ChatMessageToolCall(
                         id="call_2",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "value2"}),
+                        function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
                     ),
                 ],
                 "expected_model_output": "Called Tool: 'test_tool' with arguments: {'input': 'value1'}\nCalled Tool: 'test_tool' with arguments: {'input': 'value2'}",
@@ -1361,7 +1361,7 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="nonexistent_tool", arguments={"input": "test"}),
+                        function=ChatMessageToolCallFunction(name="nonexistent_tool", arguments={"input": "test"}),
                     )
                 ],
                 "expected_error": AgentToolExecutionError,
@@ -1372,7 +1372,7 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "error"}),
+                        function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "error"}),
                     )
                 ],
                 "expected_error": AgentToolExecutionError,
@@ -1391,7 +1391,7 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(
+                        function=ChatMessageToolCallFunction(
                             name="final_answer", arguments={"answer": "This is the final answer"}
                         ),
                     )
@@ -1407,7 +1407,7 @@ class TestToolCallingAgent:
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="test_tool", arguments={"wrong_param": "value"}),
+                        function=ChatMessageToolCallFunction(name="test_tool", arguments={"wrong_param": "value"}),
                     )
                 ],
                 "expected_error": AgentToolCallError,
@@ -1799,7 +1799,7 @@ class TestMultiAgents:
                                 ChatMessageToolCall(
                                     id="call_0",
                                     type="function",
-                                    function=ChatMessageToolCallDefinition(
+                                    function=ChatMessageToolCallFunction(
                                         name="search_agent",
                                         arguments="Who is the current US president?",
                                     ),
@@ -1815,7 +1815,7 @@ class TestMultiAgents:
                                 ChatMessageToolCall(
                                     id="call_0",
                                     type="function",
-                                    function=ChatMessageToolCallDefinition(
+                                    function=ChatMessageToolCallFunction(
                                         name="final_answer", arguments="Final report."
                                     ),
                                 )
@@ -1862,7 +1862,7 @@ final_answer("Final report.")
                         ChatMessageToolCall(
                             id="call_0",
                             type="function",
-                            function=ChatMessageToolCallDefinition(
+                            function=ChatMessageToolCallFunction(
                                 name="final_answer",
                                 arguments="Report on the current US president",
                             ),

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -122,32 +122,21 @@ def test_action_step_to_messages():
     messages = action_step.to_messages()
     assert len(messages) == 4
     for message in messages:
-        assert isinstance(message, dict)
-        assert "role" in message
-        assert "content" in message
-        assert isinstance(message["role"], MessageRole)
-        assert isinstance(message["content"], list)
+        assert isinstance(message, ChatMessage)
     assistant_message = messages[0]
-    assert assistant_message["role"] == MessageRole.ASSISTANT
-    assert len(assistant_message["content"]) == 1
-    for content in assistant_message["content"]:
-        assert isinstance(content, dict)
-        assert "type" in content
-        assert "text" in content
+    assert assistant_message.role == MessageRole.ASSISTANT
+    assert len(assistant_message.content) == 1
+    assert assistant_message.content[0]["type"] == "text"
+    assert assistant_message.content[0]["text"] == "Hi"
     message = messages[1]
-    assert message["role"] == MessageRole.TOOL_CALL
+    assert message.role == MessageRole.TOOL_CALL
 
-    assert len(message["content"]) == 1
-    text_content = message["content"][0]
-    assert isinstance(text_content, dict)
-    assert "type" in text_content
-    assert "text" in text_content
+    assert len(message.content) == 1
+    assert message.content[0]["type"] == "text"
+    assert "Calling tools:" in message.content[0]["text"]
 
     image_message = messages[2]
-    image_content = image_message["content"][0]
-    assert isinstance(image_content, dict)
-    assert "type" in image_content
-    assert "image" in image_content
+    assert image_message.content[0]["type"] == "image"  # type: ignore
 
     observation_message = messages[3]
     assert observation_message.role == MessageRole.TOOL_RESPONSE
@@ -185,17 +174,15 @@ def test_planning_step_to_messages():
     messages = planning_step.to_messages(summary_mode=False)
     assert len(messages) == 2
     for message in messages:
-        assert isinstance(message, dict)
-        assert "role" in message
-        assert "content" in message
-        assert isinstance(message["content"], list)
-        assert len(message["content"]) == 1
-        for content in message["content"]:
+        assert isinstance(message, ChatMessage)
+        assert isinstance(message.content, list)
+        assert len(message.content) == 1
+        for content in message.content:
             assert isinstance(content, dict)
             assert "type" in content
             assert "text" in content
-    assert messages[0]["role"] == MessageRole.ASSISTANT
-    assert messages[1]["role"] == MessageRole.USER
+    assert messages[0].role == MessageRole.ASSISTANT
+    assert messages[1].role == MessageRole.USER
 
 
 def test_task_step_to_messages():
@@ -203,18 +190,15 @@ def test_task_step_to_messages():
     messages = task_step.to_messages(summary_mode=False)
     assert len(messages) == 1
     for message in messages:
-        assert isinstance(message, dict)
-        assert "role" in message
-        assert "content" in message
-        assert isinstance(message["role"], MessageRole)
-        assert message["role"] == MessageRole.USER
-        assert isinstance(message["content"], list)
-        assert len(message["content"]) == 2
-        text_content = message["content"][0]
+        assert isinstance(message, ChatMessage)
+        assert message.role == MessageRole.USER
+        assert isinstance(message.content, list)
+        assert len(message.content) == 2
+        text_content = message.content[0]
         assert isinstance(text_content, dict)
         assert "type" in text_content
         assert "text" in text_content
-        for image_content in message["content"][1:]:
+        for image_content in message.content[1:]:
             assert isinstance(image_content, dict)
             assert "type" in image_content
             assert "image" in image_content
@@ -225,14 +209,11 @@ def test_system_prompt_step_to_messages():
     messages = system_prompt_step.to_messages(summary_mode=False)
     assert len(messages) == 1
     for message in messages:
-        assert isinstance(message, dict)
-        assert "role" in message
-        assert "content" in message
-        assert isinstance(message["role"], MessageRole)
-        assert message["role"] == MessageRole.SYSTEM
-        assert isinstance(message["content"], list)
-        assert len(message["content"]) == 1
-        for content in message["content"]:
+        assert isinstance(message, ChatMessage)
+        assert message.role == MessageRole.SYSTEM
+        assert isinstance(message.content, list)
+        assert len(message.content) == 1
+        for content in message.content:
             assert isinstance(content, dict)
             assert "type" in content
             assert "text" in content

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -7,7 +7,6 @@ from smolagents.memory import (
     AgentMemory,
     ChatMessage,
     MemoryStep,
-    Message,
     MessageRole,
     PlanningStep,
     SystemPromptStep,
@@ -41,7 +40,7 @@ class TestMemoryStep:
 
 def test_action_step_dict():
     action_step = ActionStep(
-        model_input_messages=[Message(role=MessageRole.USER, content="Hello")],
+        model_input_messages=[ChatMessage(role=MessageRole.USER, content="Hello")],
         tool_calls=[
             ToolCall(id="id", name="get_weather", arguments={"location": "Paris"}),
         ],
@@ -58,7 +57,7 @@ def test_action_step_dict():
     action_step_dict = action_step.dict()
     # Check each key individually for better test failure messages
     assert "model_input_messages" in action_step_dict
-    assert action_step_dict["model_input_messages"] == [Message(role=MessageRole.USER, content="Hello")]
+    assert action_step_dict["model_input_messages"] == [ChatMessage(role=MessageRole.USER, content="Hello")]
 
     assert "tool_calls" in action_step_dict
     assert len(action_step_dict["tool_calls"]) == 1
@@ -106,7 +105,7 @@ def test_action_step_dict():
 
 def test_action_step_to_messages():
     action_step = ActionStep(
-        model_input_messages=[Message(role=MessageRole.USER, content="Hello")],
+        model_input_messages=[ChatMessage(role=MessageRole.USER, content="Hello")],
         tool_calls=[
             ToolCall(id="id", name="get_weather", arguments={"location": "Paris"}),
         ],
@@ -178,7 +177,7 @@ def test_action_step_to_messages_no_tool_calls_with_observations():
 
 def test_planning_step_to_messages():
     planning_step = PlanningStep(
-        model_input_messages=[Message(role=MessageRole.USER, content="Hello")],
+        model_input_messages=[ChatMessage(role=MessageRole.USER, content="Hello")],
         model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content="Plan"),
         plan="This is a plan.",
         timing=Timing(start_time=0.0, end_time=1.0),

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -150,8 +150,8 @@ def test_action_step_to_messages():
     assert "image" in image_content
 
     observation_message = messages[3]
-    assert observation_message["role"] == MessageRole.TOOL_RESPONSE
-    assert "Observation:\nThis is a nice observation" in observation_message["content"][0]["text"]
+    assert observation_message.role == MessageRole.TOOL_RESPONSE
+    assert "Observation:\nThis is a nice observation" in observation_message.content[0]["text"]
 
 
 def test_action_step_to_messages_no_tool_calls_with_observations():
@@ -171,8 +171,8 @@ def test_action_step_to_messages_no_tool_calls_with_observations():
     messages = action_step.to_messages()
     assert len(messages) == 1
     observation_message = messages[0]
-    assert observation_message["role"] == MessageRole.TOOL_RESPONSE
-    assert "Observation:\nThis is an observation." in observation_message["content"][0]["text"]
+    assert observation_message.role == MessageRole.TOOL_RESPONSE
+    assert "Observation:\nThis is an observation." in observation_message.content[0]["text"]
 
 
 def test_planning_step_to_messages():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -283,9 +283,9 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": "Test message"}]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert (
-            model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system"
-        ), "role conversion should be applied"
+        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
+            "role conversion should be applied"
+        )
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -223,9 +223,9 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": "Test message"}]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
-            "role conversion should be applied"
-        )
+        assert (
+            model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system"
+        ), "role conversion should be applied"
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -284,9 +284,9 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": "Test message"}]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert (
-            model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system"
-        ), "role conversion should be applied"
+        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
+            "role conversion should be applied"
+        )
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,6 @@ from smolagents.models import (
     AzureOpenAIServerModel,
     ChatMessage,
     ChatMessageToolCall,
-    HfApiModel,
     InferenceClientModel,
     LiteLLMModel,
     LiteLLMRouterModel,
@@ -284,9 +283,9 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": "Test message"}]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
-            "role conversion should be applied"
-        )
+        assert (
+            model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system"
+        ), "role conversion should be applied"
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")
@@ -330,21 +329,6 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
         for el in model.generate_stream(messages, stop_sequences=["great"]):
             assert el.content is not None
-
-
-class TestHfApiModel:
-    def test_deprecation_warning(self):
-        """Test that HfApiModel raises a deprecation warning when instantiated."""
-        # Should raise FutureWarning with specific message
-        with pytest.warns(
-            FutureWarning,
-            match="HfApiModel was renamed to InferenceClientModel in version 1.14.0 and will be removed in 1.17.0.",
-        ):
-            model = HfApiModel(model_id="test-model")
-        # Verify it returns an instance of InferenceClientModel
-        assert isinstance(model, InferenceClientModel)
-        # Verify the model_id was properly passed through
-        assert model.model_id == "test-model"
 
 
 class TestLiteLLMModel:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -555,9 +555,9 @@ def test_get_clean_message_list_basic():
     result = get_clean_message_list(messages)
     assert len(result) == 2
     assert result[0].role == "user"
-    assert result[0].content[0].text == "Hello!"
+    assert result[0].content[0]["text"] == "Hello!"
     assert result[1].role == "assistant"
-    assert result[1].content[0].text == "Hi there!"
+    assert result[1].content[0]["text"] == "Hi there!"
 
 
 def test_get_clean_message_list_role_conversions():
@@ -568,9 +568,9 @@ def test_get_clean_message_list_role_conversions():
     result = get_clean_message_list(messages, role_conversions={"tool-call": "assistant", "tool-response": "user"})
     assert len(result) == 2
     assert result[0].role == "assistant"
-    assert result[0].content[0].text == "Calling tool..."
+    assert result[0].content[0]["text"] == "Calling tool..."
     assert result[1].role == "user"
-    assert result[1].content[0].text == "Tool response"
+    assert result[1].content[0]["text"] == "Tool response"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -395,7 +395,7 @@ class TestLiteLLMRouterModel:
             {"model_name": "llama-3.3-70b", "litellm_params": {"model": "groq/llama-3.3-70b"}},
             {"model_name": "llama-3.3-70b", "litellm_params": {"model": "cerebras/llama-3.3-70b"}},
         ]
-        with patch("litellm.Router") as mock_router:
+        with patch("litellm.router.Router") as mock_router:
             router_model = LiteLLMRouterModel(
                 model_id="model-group-1", model_list=model_list, client_kwargs={"routing_strategy": "simple-shuffle"}
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -291,7 +291,7 @@ class TestInferenceClientModel:
         messages = [ChatMessage(role=MessageRole.USER, content="Test message")]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert model.client.chat_completion.call_args.kwargs["messages"][0].role == "system", (
+        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
             "role conversion should be applied"
         )
 
@@ -554,10 +554,10 @@ def test_get_clean_message_list_basic():
     ]
     result = get_clean_message_list(messages)
     assert len(result) == 2
-    assert result[0].role == "user"
-    assert result[0].content[0]["text"] == "Hello!"
-    assert result[1].role == "assistant"
-    assert result[1].content[0]["text"] == "Hi there!"
+    assert result[0]["role"] == "user"
+    assert result[0]["content"][0]["text"] == "Hello!"
+    assert result[1]["role"] == "assistant"
+    assert result[1]["content"][0]["text"] == "Hi there!"
 
 
 def test_get_clean_message_list_role_conversions():
@@ -567,10 +567,10 @@ def test_get_clean_message_list_role_conversions():
     ]
     result = get_clean_message_list(messages, role_conversions={"tool-call": "assistant", "tool-response": "user"})
     assert len(result) == 2
-    assert result[0].role == "assistant"
-    assert result[0].content[0]["text"] == "Calling tool..."
-    assert result[1].role == "user"
-    assert result[1].content[0]["text"] == "Tool response"
+    assert result[0]["role"] == "assistant"
+    assert result[0]["content"][0]["text"] == "Calling tool..."
+    assert result[1]["role"] == "user"
+    assert result[1]["content"][0]["text"] == "Tool response"
 
 
 @pytest.mark.parametrize(
@@ -578,7 +578,7 @@ def test_get_clean_message_list_role_conversions():
     [
         (
             False,
-            ChatMessage(
+            dict(
                 role=MessageRole.USER,
                 content=[
                     {"type": "image", "image": "encoded_image"},
@@ -588,7 +588,7 @@ def test_get_clean_message_list_role_conversions():
         ),
         (
             True,
-            ChatMessage(
+            dict(
                 role=MessageRole.USER,
                 content=[
                     {"type": "image_url", "image_url": {"url": "data:image/png;base64,encoded_image"}},
@@ -619,8 +619,8 @@ def test_get_clean_message_list_flatten_messages_as_text():
     ]
     result = get_clean_message_list(messages, flatten_messages_as_text=True)
     assert len(result) == 1
-    assert result[0].role == "user"
-    assert result[0].content == "Hello!\nHow are you?"
+    assert result[0]["role"] == "user"
+    assert result[0]["content"] == "Hello!\nHow are you?"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -291,9 +291,9 @@ class TestInferenceClientModel:
         messages = [ChatMessage(role=MessageRole.USER, content="Test message")]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert (
-            model.client.chat_completion.call_args.kwargs["messages"][0].role == "system"
-        ), "role conversion should be applied"
+        assert model.client.chat_completion.call_args.kwargs["messages"][0].role == "system", (
+            "role conversion should be applied"
+        )
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,7 +50,7 @@ class TestModel:
     def test_agglomerate_stream_deltas(self):
         from smolagents.models import (
             ChatMessageStreamDelta,
-            ChatMessageToolCallDefinition,
+            ChatMessageToolCallFunction,
             TokenUsage,
             ToolCallStreamDelta,
             agglomerate_stream_deltas,
@@ -63,7 +63,7 @@ class TestModel:
                     ToolCallStreamDelta(
                         index=0,
                         type="function",
-                        function=ChatMessageToolCallDefinition(arguments="", name="web_search", description=None),
+                        function=ChatMessageToolCallFunction(arguments="", name="web_search", description=None),
                     )
                 ],
                 token_usage=None,
@@ -74,7 +74,7 @@ class TestModel:
                     ToolCallStreamDelta(
                         index=0,
                         type="function",
-                        function=ChatMessageToolCallDefinition(arguments=' {"', name="web_search", description=None),
+                        function=ChatMessageToolCallFunction(arguments=' {"', name="web_search", description=None),
                     )
                 ],
                 token_usage=None,
@@ -85,7 +85,7 @@ class TestModel:
                     ToolCallStreamDelta(
                         index=0,
                         type="function",
-                        function=ChatMessageToolCallDefinition(
+                        function=ChatMessageToolCallFunction(
                             arguments='query": "current pope name and date of birth"}',
                             name="web_search",
                             description=None,
@@ -283,9 +283,9 @@ class TestInferenceClientModel:
         messages = [{"role": "user", "content": "Test message"}]
         _ = model(messages)
         # Verify that the role conversion was applied
-        assert model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system", (
-            "role conversion should be applied"
-        )
+        assert (
+            model.client.chat_completion.call_args.kwargs["messages"][0]["role"] == "system"
+        ), "role conversion should be applied"
 
     def test_init_model_with_tokens(self):
         model = InferenceClientModel(model_id="test-model", token="abc")

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -27,7 +27,7 @@ from smolagents import (
 from smolagents.models import (
     ChatMessage,
     ChatMessageToolCall,
-    ChatMessageToolCallDefinition,
+    ChatMessageToolCallFunction,
     Model,
     TokenUsage,
 )
@@ -46,7 +46,7 @@ class FakeLLMModel(Model):
                     ChatMessageToolCall(
                         id="fake_id",
                         type="function",
-                        function=ChatMessageToolCallDefinition(name="final_answer", arguments={"answer": "image"}),
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "image"}),
                     )
                 ],
                 token_usage=TokenUsage(input_tokens=10, output_tokens=20) if self.give_token_usage else None,


### PR DESCRIPTION
This PR change the logic of streaming messages:
- Previously, the logic was to accumulate streaming deltas in the Model classes, and yield objects that "contain all the generated text since start of streaming until now"
- This PR makes the ModelClass directly return atomic streaming deltas, to handle the aggregation only within the agent.
The reason for this is that front-ends like [copilotkit](https://docs.ag-ui.com/concepts/events#textmessagestart) generally expect individual streaming deltas.

Additionally, it removes the `HfApiModel` class, which was deprecated and due for deletion in 1.17, and fuses `Message` into `ChatMessage`