### PR TITLE
Add support for a customizable agent state in prompts

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -965,7 +965,6 @@ You have been provided with these additional arguments, that you can access usin
             "verbosity_level": int(self.logger.level),
             "grammar": self.grammar,
             "planning_interval": self.planning_interval,
-            "state": self.state,
             "name": self.name,
             "description": self.description,
             "requirements": sorted(requirements),

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -225,6 +225,8 @@ class MultiStepAgent(ABC):
         state (`dict[str, Any]`, *optional*): Dictionary of variables that can be used in prompt templates
             or called in a python executed environment.
             They can be accessed using the keys as variables, the value is a value of any type.
+            Remember that state variables can only be set through the instance, never saved nor loaded,
+            as they may not be serializable.
         name (`str`, *optional*): Necessary for a managed agent only - the name by which this agent can be called.
         description (`str`, *optional*): Necessary for a managed agent only - the description of this agent.
         provide_run_summary (`bool`, *optional*): Whether to provide a run summary when called as a managed agent.

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1005,7 +1005,6 @@ You have been provided with these additional arguments, that you can access usin
             "verbosity_level": agent_dict.get("verbosity_level"),
             "grammar": agent_dict.get("grammar"),
             "planning_interval": agent_dict.get("planning_interval"),
-            "state": agent_dict.get("state"),
             "name": agent_dict.get("name"),
             "description": agent_dict.get("description"),
         }


### PR DESCRIPTION
Proposal for #1450 .

- Introduced a `state` dictionary in the agent class to allow dynamic variables to be used in prompt templates and execution environments.
- Updated relevant methods to incorporate `state` into prompt building, serialization, and deserialization.