### PR TITLE
Support managed agents in ToolCallingAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -323,6 +323,10 @@ class MultiStepAgent(ABC):
                 "All managed agents need both a name and a description!"
             )
             self.managed_agents = {agent.name: agent for agent in managed_agents}
+            # Ensure managed agents can be called as tools by the model: set their inputs and output_type
+            for agent in self.managed_agents.values():
+                agent.inputs = {"task": {"type": "string", "description": "Long detailed description of the task."}}
+                agent.output_type = "string"
 
     def _setup_tools(self, tools, add_base_tools):
         assert all(isinstance(tool, Tool) for tool in tools), "All elements must be instance of Tool (or a subclass)"
@@ -1221,7 +1225,7 @@ class ToolCallingAgent(MultiStepAgent):
                 output_stream = self.model.generate_stream(
                     input_messages,
                     stop_sequences=["Observation:", "Calling tools:"],
-                    tools_to_call_from=list(self.tools.values()),
+                    tools_to_call_from=list(self.tools.values()) + list(self.managed_agents.values()),
                 )
 
                 model_output = ""
@@ -1256,7 +1260,7 @@ class ToolCallingAgent(MultiStepAgent):
                 chat_message: ChatMessage = self.model.generate(
                     input_messages,
                     stop_sequences=["Observation:", "Calling tools:"],
-                    tools_to_call_from=list(self.tools.values()),
+                    tools_to_call_from=list(self.tools.values()) + list(self.managed_agents.values()),
                 )
 
                 model_output = chat_message.content

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -150,8 +150,12 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
-  def {{ agent.name }}("Your query goes here.") -> str:
-      """{{ agent.description }}"""
+  def {{ agent.name }}(task: str) -> str:
+      """{{ agent.description }}
+
+      Args:
+          task: Long detailed description of the task.
+      """
   {% endfor %}
   ```
   {%- endif %}

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -96,8 +96,12 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
-  def {{ agent.name }}("Your query goes here.") -> str:
-      """{{ agent.description }}"""
+  def {{ agent.name }}(task: str) -> str:
+      """{{ agent.description }}
+
+      Args:
+          task: Long detailed description of the task.
+      """
   {% endfor %}
   ```
   {%- endif %}

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -103,6 +103,8 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}
+      Takes inputs: {{agent.inputs}}
+      Returns an output of type: {{agent.output_type}}
   {%- endfor %}
   {%- endif %}
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1086,6 +1086,33 @@ class TestToolCallingAgent:
         assert agent.instructions == "Test instructions"
         assert "Test instructions" in agent.system_prompt
 
+    def test_toolcalling_agent_passes_both_tools_and_managed_agents(self, test_tool):
+        """Test that both tools and managed agents are passed to the model."""
+        managed_agent = MagicMock()
+        managed_agent.name = "managed_agent"
+        model = MagicMock()
+        model.generate.return_value = ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_0",
+                    type="function",
+                    function=ChatMessageToolCallDefinition(name="test_tool", arguments={"input": "test_value"}),
+                )
+            ],
+        )
+        agent = ToolCallingAgent(tools=[test_tool], managed_agents=[managed_agent], model=model)
+        # Run the agent one step to trigger the model call
+        next(agent.run("Test task", stream=True))
+        # Check that the model was called with both tools and managed agents:
+        # - Get all tool_to_call_from names passed to the model
+        tools_to_call_from_names = [tool.name for tool in model.generate.call_args.kwargs["tools_to_call_from"]]
+        # - Verify both regular tools and managed agents are included
+        assert "test_tool" in tools_to_call_from_names  # The regular tool
+        assert "managed_agent" in tools_to_call_from_names  # The managed agent
+        assert "final_answer" in tools_to_call_from_names  # The final_answer tool (added by default)
+
     @patch("huggingface_hub.InferenceClient")
     def test_toolcalling_agent_api(self, mock_inference_client):
         mock_client = mock_inference_client.return_value


### PR DESCRIPTION
Support managed agents in `ToolCallingAgent`.

Fix #1455.
Fix #1353.
Supersede and close #1418.