### PR TITLE
Fix missing mentions of additional_args in manager agent prompts

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.mdx
+++ b/docs/source/en/tutorials/building_good_agents.mdx
@@ -329,8 +329,8 @@ Above example were using notional tools that might not exist for you. On top of 
 
 {%- if managed_agents and managed_agents.values() | list %}
 You can also give tasks to team members.
-Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-Given that this team member is a real human, you should be very verbose in your task.
+Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+You can also include any relevant variables or context using the 'additional_args' argument.
 Here is a list of the team members that you can call:
 {%- for agent in managed_agents.values() %}
 - {{ agent.name }}: {{ agent.description }}
@@ -368,8 +368,8 @@ So while you can overwrite this system prompt template by passing your custom pr
   ```
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-  Given that this team member is a real human, you should be very verbose in your task.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}

--- a/docs/source/hi/tutorials/building_good_agents.mdx
+++ b/docs/source/hi/tutorials/building_good_agents.mdx
@@ -335,8 +335,8 @@ Above example were using notional tools that might not exist for you. On top of 
 
 {%- if managed_agents and managed_agents.values() | list %}
 You can also give tasks to team members.
-Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-Given that this team member is a real human, you should be very verbose in your task.
+Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+You can also include any relevant variables or context using the 'additional_args' argument.
 Here is a list of the team members that you can call:
 {%- for agent in managed_agents.values() %}
 - {{ agent.name }}: {{ agent.description }}
@@ -373,8 +373,8 @@ Now Begin! If you solve the task correctly, you will receive a reward of $1,000,
   ```
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-  Given that this team member is a real human, you should be very verbose in your task.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}

--- a/docs/source/zh/tutorials/building_good_agents.mdx
+++ b/docs/source/zh/tutorials/building_good_agents.mdx
@@ -333,8 +333,8 @@ Above example were using notional tools that might not exist for you. On top of 
 
 {%- if managed_agents and managed_agents.values() | list %}
 You can also give tasks to team members.
-Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-Given that this team member is a real human, you should be very verbose in your task.
+Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+You can also include any relevant variables or context using the 'additional_args' argument.
 Here is a list of the team members that you can call:
 {%- for agent in managed_agents.values() %}
 - {{ agent.name }}: {{ agent.description }}
@@ -371,8 +371,8 @@ Now Begin! If you solve the task correctly, you will receive a reward of $1,000,
   ```
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
-  Given that this team member is a real human, you should be very verbose in your task.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -326,7 +326,13 @@ class MultiStepAgent(ABC):
             self.managed_agents = {agent.name: agent for agent in managed_agents}
             # Ensure managed agents can be called as tools by the model: set their inputs and output_type
             for agent in self.managed_agents.values():
-                agent.inputs = {"task": {"type": "string", "description": "Long detailed description of the task."}}
+                agent.inputs = {
+                    "task": {"type": "string", "description": "Long detailed description of the task."},
+                    "additional_args": {
+                        "type": "object",
+                        "description": "Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.",
+                    },
+                }
                 agent.output_type = "string"
 
     def _setup_tools(self, tools, add_base_tools):

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -145,7 +145,7 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task'.
+  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
   Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
   Here is a list of the team members that you can call:
   ```python

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -150,11 +150,12 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
-  def {{ agent.name }}(task: str) -> str:
+  def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
       """{{ agent.description }}
 
       Args:
           task: Long detailed description of the task.
+          additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
       """
   {% endfor %}
   ```
@@ -224,8 +225,13 @@ planning:
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}("Your query goes here.") -> str:
-        """{{ agent.description }}"""
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
     {% endfor %}
     ```
     {%- endif %}
@@ -286,8 +292,13 @@ planning:
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}("Your query goes here.") -> str:
-        """{{ agent.description }}"""
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
     {% endfor %}
     ```
     {%- endif %}

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -145,8 +145,8 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-  Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
@@ -219,8 +219,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
@@ -281,8 +281,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -281,7 +281,7 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-        Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
+    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
     Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
     Here is a list of the team members that you can call:
     ```python

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -91,8 +91,8 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-  Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
@@ -164,8 +164,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
@@ -226,8 +226,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -96,11 +96,12 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   ```python
   {%- for agent in managed_agents.values() %}
-  def {{ agent.name }}(task: str) -> str:
+  def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
       """{{ agent.description }}
 
       Args:
           task: Long detailed description of the task.
+          additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
       """
   {% endfor %}
   ```
@@ -169,8 +170,13 @@ planning:
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}("Your query goes here.") -> str:
-        """{{ agent.description }}"""
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
     {% endfor %}
     ```
     {%- endif %}
@@ -231,8 +237,13 @@ planning:
     Here is a list of the team members that you can call:
     ```python
     {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}("Your query goes here.") -> str:
-        """{{ agent.description }}"""
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
     {% endfor %}
     ```
     {%- endif %}

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -91,7 +91,7 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task'.
+  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
   Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
   Here is a list of the team members that you can call:
   ```python
@@ -164,7 +164,7 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task'.
+    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
     Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
     Here is a list of the team members that you can call:
     ```python
@@ -226,7 +226,7 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task'.
+    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
     Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
     Here is a list of the team members that you can call:
     ```python

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -98,8 +98,8 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-  Given that this team member is a real human, you should be very verbose in your task.
+  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+  You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}
@@ -155,8 +155,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}
@@ -208,8 +208,8 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
-    Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -103,8 +103,8 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}
-      Takes inputs: {{agent.inputs}}
-      Returns an output of type: {{agent.output_type}}
+    Takes inputs: {{agent.inputs}}
+    Returns an output of type: {{agent.output_type}}
   {%- endfor %}
   {%- endif %}
 
@@ -160,6 +160,9 @@ planning:
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}
+    - {{ agent.name }}: {{ agent.description }}
+      Takes inputs: {{agent.inputs}}
+      Returns an output of type: {{agent.output_type}}
     {%- endfor %}
     {%- endif %}
 
@@ -213,6 +216,8 @@ planning:
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}
+      Takes inputs: {{agent.inputs}}
+      Returns an output of type: {{agent.output_type}}
     {%- endfor %}
     {%- endif %}
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -103,8 +103,8 @@ system_prompt: |-
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
   - {{ agent.name }}: {{ agent.description }}
-    Takes inputs: {{agent.inputs}}
-    Returns an output of type: {{agent.output_type}}
+    - Takes inputs: {{agent.inputs}}
+    - Returns an output of type: {{agent.output_type}}
   {%- endfor %}
   {%- endif %}
 
@@ -161,8 +161,8 @@ planning:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}
     - {{ agent.name }}: {{ agent.description }}
-      Takes inputs: {{agent.inputs}}
-      Returns an output of type: {{agent.output_type}}
+      - Takes inputs: {{agent.inputs}}
+      - Returns an output of type: {{agent.output_type}}
     {%- endfor %}
     {%- endif %}
 
@@ -216,8 +216,8 @@ planning:
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
     - {{ agent.name }}: {{ agent.description }}
-      Takes inputs: {{agent.inputs}}
-      Returns an output of type: {{agent.output_type}}
+      - Takes inputs: {{agent.inputs}}
+      - Returns an output of type: {{agent.output_type}}
     {%- endfor %}
     {%- endif %}
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -98,7 +98,7 @@ system_prompt: |-
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
-  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
+  Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
   Given that this team member is a real human, you should be very verbose in your task.
   Here is a list of the team members that you can call:
   {%- for agent in managed_agents.values() %}
@@ -155,7 +155,7 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
+    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
     Given that this team member is a real human, you should be very verbose in your task.
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}
@@ -208,7 +208,7 @@ planning:
 
     {%- if managed_agents and managed_agents.values() | list %}
     You can also give tasks to team members.
-    Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task'.
+    Calling a team member works similarly to calling a tool: provide the task as the 'task' argument. You can also include any relevant variables or context using the 'additional_args' argument.
     Given that this team member is a real human, you should be very verbose in your task, it should be a long string providing informations as detailed as necessary.
     Here is a list of the team members that you can call:
     {%- for agent in managed_agents.values() %}


### PR DESCRIPTION
Fix missing mentions of `additional_args` in manager agent prompts.

Follow-up to:
- #1441
- #1456