### PR TITLE
Fix: __new__ method only accepts class object, remove **args and **kw…

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -542,7 +542,7 @@ class SpeechToTextTool(PipelineTool):
 
         cls.pre_processor_class = WhisperProcessor
         cls.model_class = WhisperForConditionalGeneration
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls)
 
     def encode(self, audio):
         from .agent_types import AgentAudio

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -535,10 +535,7 @@ class SpeechToTextTool(PipelineTool):
     output_type = "string"
 
     def __new__(cls, *args, **kwargs):
-        from transformers.models.whisper import (
-            WhisperForConditionalGeneration,
-            WhisperProcessor,
-        )
+        from transformers.models.whisper import WhisperForConditionalGeneration, WhisperProcessor
 
         cls.pre_processor_class = WhisperProcessor
         cls.model_class = WhisperForConditionalGeneration

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -96,6 +96,14 @@ class TestSpeechToTextTool:
         assert tool.pre_processor_class == WhisperProcessor
         assert tool.model_class == WhisperForConditionalGeneration
 
+    def test_initialization(self):
+        from transformers.models.whisper import WhisperForConditionalGeneration, WhisperProcessor
+
+        tool = SpeechToTextTool(model="dummy_model_id")
+        assert tool is not None
+        assert tool.pre_processor_class == WhisperProcessor
+        assert tool.model_class == WhisperForConditionalGeneration
+
 
 @pytest.mark.parametrize(
     "language, content_type, extract_format, query",


### PR DESCRIPTION
This pull request includes a minor change to the `__new__` method in `src/smolagents/default_tools.py`. The change removes the `*args` and `**kwargs` parameters from the `super().__new__` call

Fixes #1461 