### PR TITLE
fix(docs): Correct broken link in documentation homepage

### DIFF
--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -22,7 +22,7 @@ Key features of `smolagents` include:
 
 👁️ **Modality-agnostic**: Beyond text, agents can handle vision, video, and audio inputs, broadening the range of possible applications. Check out [this tutorial](examples/web_browser) for vision.
 
-🛠️ **Tool-agnostic**: You can use tools from any [MCP server](reference/tools#smolagents.ToolCollection.from_mcp), from [LangChain]reference/tools#smolagents.Tool.from_langchain), you can even use a [Hub Space](reference/tools#smolagents.Tool.from_space) as a tool.
+🛠️ **Tool-agnostic**: You can use tools from any [MCP server](reference/tools#smolagents.ToolCollection.from_mcp), from [LangChain](reference/tools#smolagents.Tool.from_langchain), you can even use a [Hub Space](reference/tools#smolagents.Tool.from_space) as a tool.
 
 💻 **CLI Tools**: Comes with command-line utilities (smolagent, webagent) for quickly running agents without writing boilerplate code.
 


### PR DESCRIPTION
Link breaks because of the missing opening parenthesis.

Before:
<img width="786" alt="Screenshot 2025-06-22 at 3 52 55 PM" src="https://github.com/user-attachments/assets/9e183a48-bbf2-43ad-a728-0ec7a3666ea2" />
