### PR TITLE
Fix: SpeechToTextTool returns incoherent transcripts

### DIFF
--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -249,6 +249,33 @@ class AgentAudio(AgentType, str):
             sf.write(self._path, self._tensor, samplerate=self.samplerate)
             return self._path
 
+    def resample(self, target_samplerate: int):
+        """
+        Resamples the internal audio tensor to the given sample rate in-place.
+
+        Modifies:
+        - self._tensor
+        - self.samplerate
+
+        Returns:
+            torch.Tensor: The resampled audio tensor.
+        """
+        from scipy import signal
+        from torch import from_numpy
+
+        if self._tensor is None:
+            raise ValueError("No tensor found — call to_raw() first or initialize with a tensor.")
+
+        audio_np = self._tensor.numpy()
+        duration = audio_np.shape[-1] / self.samplerate
+        target_len = int(duration * target_samplerate)
+
+        resampled = signal.resample(audio_np, target_len)
+        self._tensor = from_numpy(resampled.astype("float32"))
+        self.samplerate = target_samplerate
+
+        return self._tensor
+
 
 _AGENT_TYPE_MAPPING = {"string": AgentText, "image": AgentImage, "audio": AgentAudio}
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -553,32 +553,22 @@ class SpeechToTextTool(PipelineTool):
         self.language = language
 
     def encode(self, audio):
-        from scipy import signal
-        from torch import Tensor, from_numpy
-
         from .agent_types import AgentAudio
-
-        def _resample(raw_audio_tensor: Tensor, original_samplerate: int, target_samplerate) -> Tensor:
-            raw_audio_np = raw_audio_tensor.numpy()
-
-            duration = raw_audio_np.shape[-1] / original_samplerate
-            target_len = int(duration * target_samplerate)
-
-            resampled_raw_audio_np = signal.resample(raw_audio_np, target_len)
-            resampled_raw_audio_tensor = from_numpy(resampled_raw_audio_np.astype("float32"))
-
-            return resampled_raw_audio_tensor
 
         whisper_samplerate = 16_000
 
         agent_audio = AgentAudio(audio)
-        audio = agent_audio.to_raw()
+        raw_audio_tensor = agent_audio.to_raw()
 
         if agent_audio.samplerate != whisper_samplerate:
-            audio = _resample(audio, original_samplerate=agent_audio.samplerate, target_samplerate=whisper_samplerate)
+            raw_audio_tensor = agent_audio.resample(target_samplerate=whisper_samplerate)
 
         return self.pre_processor(
-            audio, sampling_rate=whisper_samplerate, return_tensors="pt", return_attention_mask=True, truncation=False
+            raw_audio_tensor,
+            sampling_rate=whisper_samplerate,
+            return_tensors="pt",
+            return_attention_mask=True,
+            truncation=False,
         )
 
     def forward(self, inputs):


### PR DESCRIPTION
This PR improves `SpeechToTextTool` to ensure it works out of the box as expected, addressing issue #1478.

_At a high level_:
- Explicitly pass the correct whisper sampling_rate to the pre-processor and ensure the attention_mask is properly generated then passed through to the model’s forward method to avoid unreliable behavior during inference.
- Introduces explicit language control when instantiating the class (ex. `language='en'`) while preserving the option for auto-detection when desired (language is omitted or `None`).
- Ensures audio inputs are resampled to the expected model sampling rate to avoid silent transcription failures.
- Adds support for longer audio files to to get transcription completeness.

_Note_: This is my first contribution to an open-source project, I'm excited to be part of it and open to any feedback or suggestions. Thanks a lot!