### PR TITLE
Serpapi import error bug fix

### DIFF
--- a/examples/open_deep_research/scripts/text_web_browser.py
+++ b/examples/open_deep_research/scripts/text_web_browser.py
@@ -11,7 +11,7 @@ from urllib.parse import unquote, urljoin, urlparse
 
 import pathvalidate
 import requests
-from serpapi import GoogleSearch
+import serpapi
 
 from smolagents import Tool
 
@@ -213,7 +213,7 @@ class SimpleTextBrowser:
         if filter_year is not None:
             params["tbs"] = f"cdr:1,cd_min:01/01/{filter_year},cd_max:12/31/{filter_year}"
 
-        search = GoogleSearch(params)
+        search = serpapi.search(params)
         results = search.get_dict()
         self.page_title = f"{query} - Search"
         if "organic_results" not in results.keys():


### PR DESCRIPTION
It looks like serpapi changed their import structure, giving the error `ImportError: cannot import name 'GoogleSearch' from 'serpapi'`. This fixed the error on two computers, one mac and one linux, both using a freshly `pip install serpapi` at version 0.1.5.

This only impacts the deepresearch tutorial. 