### PR TITLE
WIP: Fence code with ```python instead of <code>

### DIFF
--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -1,10 +1,10 @@
 system_prompt: |-
   You are an expert assistant who can solve any task using code blobs. You will be given a task to solve as best you can.
   To do so, you have been given access to a list of tools: these tools are basically Python functions which you can call with code.
-  To solve the task, you must plan forward to proceed in a series of steps, in a cycle of 'Thought:', '<code>', and 'Observation:' sequences.
+  To solve the task, you must plan forward to proceed in a series of steps, in a cycle of 'Thought:', '```python', and 'Observation:' sequences.
 
   At each step, in the 'Thought:' sequence, you should first explain your reasoning towards solving the task and the tools that you want to use.
-  Then in the '<code>' sequence, you should write the code in simple Python. The code sequence must end with '</code>' sequence.
+  Then in the '```python' sequence, you should write the code in simple Python. The code sequence must end with '```' sequence.
   During each intermediate step, you can use 'print()' to save whatever important information you will then need.
   These print outputs will then appear in the 'Observation:' field, which will be available as input for the next step.
   In the end you have to return a final answer using the `final_answer` tool.
@@ -14,26 +14,26 @@ system_prompt: |-
   Task: "Generate an image of the oldest person in this document."
 
   Thought: I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.
-  <code>
+  ```python
   answer = document_qa(document=document, question="Who is the oldest person mentioned?")
   print(answer)
-  </code>
+  ```
   Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
 
   Thought: I will now generate an image showcasing the oldest person.
-  <code>
+  ```python
   image = image_generator("A portrait of John Doe, a 55-year-old man living in Canada.")
   final_answer(image)
-  </code>
+  ```
 
   ---
   Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
   Thought: I will use python code to compute the result of the operation and then return the final answer using the `final_answer` tool
-  <code>
+  ```python
   result = 5 + 3 + 1294.678
   final_answer(result)
-  </code>
+  ```
 
   ---
   Task:
@@ -42,12 +42,12 @@ system_prompt: |-
   {'question': 'Quel est l'animal sur l'image?', 'image': 'path/to/image.jpg'}"
 
   Thought: I will use the following tools: `translator` to translate the question into English and then `image_qa` to answer the question on the input image.
-  <code>
+  ```python
   translated_question = translator(question=question, src_lang="French", tgt_lang="English")
   print(f"The translated question is {translated_question}.")
   answer = image_qa(image=image, question=translated_question)
   final_answer(f"The answer is {answer}")
-  </code>
+  ```
 
   ---
   Task:
@@ -55,18 +55,18 @@ system_prompt: |-
   What does he say was the consequence of Einstein learning too much math on his creativity, in one word?
 
   Thought: I need to find and read the 1979 interview of Stanislaus Ulam with Martin Sherwin.
-  <code>
+  ```python
   pages = web_search(query="1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein")
   print(pages)
-  </code>
+  ```
   Observation:
   No result found for query "1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein".
 
   Thought: The query was maybe too restrictive and did not find any results. Let's try again with a broader query.
-  <code>
+  ```python
   pages = web_search(query="1979 interview Stanislaus Ulam")
   print(pages)
-  </code>
+  ```
   Observation:
   Found 6 pages:
   [Stanislaus Ulam 1979 interview](https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/)
@@ -76,12 +76,12 @@ system_prompt: |-
   (truncated)
 
   Thought: I will read the first 2 pages to know more.
-  <code>
+  ```python
   for url in ["https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/", "https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/"]:
       whole_page = visit_webpage(url)
       print(whole_page)
       print("\n" + "="*80 + "\n")  # Print separator between pages
-  </code>
+  ```
   Observation:
   Manhattan Project Locations:
   Los Alamos, NM
@@ -89,45 +89,45 @@ system_prompt: |-
   (truncated)
 
   Thought: I now have the final answer: from the webpages visited, Stanislaus Ulam says of Einstein: "He learned too much mathematics and sort of diminished, it seems to me personally, it seems to me his purely physics creativity." Let's answer in one word.
-  <code>
+  ```python
   final_answer("diminished")
-  </code>
+  ```
 
   ---
   Task: "Which city has the highest population: Guangzhou or Shanghai?"
 
   Thought: I need to get the populations for both cities and compare them: I will use the tool `web_search` to get the population of both cities.
-  <code>
+  ```python
   for city in ["Guangzhou", "Shanghai"]:
       print(f"Population {city}:", web_search(f"{city} population")
-  </code>
+  ```
   Observation:
   Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
   Population Shanghai: '26 million (2019)'
 
   Thought: Now I know that Shanghai has the highest population.
-  <code>
+  ```python
   final_answer("Shanghai")
-  </code>
+  ```
 
   ---
   Task: "What is the current age of the pope, raised to the power 0.36?"
 
   Thought: I will use the tool `wikipedia_search` to get the age of the pope, and confirm that with a web search.
-  <code>
+  ```python
   pope_age_wiki = wikipedia_search(query="current pope age")
   print("Pope age as per wikipedia:", pope_age_wiki)
   pope_age_search = web_search(query="current pope age")
   print("Pope age as per google search:", pope_age_search)
-  </code>
+  ```
   Observation:
   Pope age: "The pope Francis is currently 88 years old."
 
   Thought: I know that the pope is 88 years old. Let's compute the result using python code.
-  <code>
+  ```python
   pope_current_age = 88 ** 0.36
   final_answer(pope_current_age)
-  </code>
+  ```
 
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   ```python
@@ -162,7 +162,7 @@ system_prompt: |-
   {%- endif %}
 
   Here are the rules you should always follow to solve your task:
-  1. Always provide a 'Thought:' sequence, and a '<code>' sequence ending with '</code>', else you will fail.
+  1. Always provide a 'Thought:' sequence, and a '```python' sequence ending with '```', else you will fail.
   2. Use only variables that you have defined!
   3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
   4. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to wikipedia_search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -68,7 +68,9 @@ def escape_code_brackets(text: str) -> str:
     def replace_bracketed_content(match):
         content = match.group(1)
         cleaned = re.sub(
-            r"bold|red|green|blue|yellow|magenta|cyan|white|black|italic|dim|\s|#[0-9a-fA-F]{6}", "", content
+            r"bold|red|green|blue|yellow|magenta|cyan|white|black|italic|dim|\s|#[0-9a-fA-F]{6}",
+            "",
+            content,
         )
         return f"\\[{content}\\]" if cleaned.strip() else f"[{content}]"
 
@@ -173,8 +175,9 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
 
 
 def extract_code_from_text(text: str) -> str | None:
-    """Extract code from the LLM's output."""
-    pattern = r"<code>(.*?)</code>"
+    """Extract code from markdown code blocks in the LLM's output."""
+    # Pattern to match markdown code blocks with optional language specifier
+    pattern = r"```(?:python|py)?\n(.*?)\n```"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         return "\n\n".join(match.strip() for match in matches)
@@ -182,7 +185,7 @@ def extract_code_from_text(text: str) -> str | None:
 
 
 def parse_code_blobs(text: str) -> str:
-    """Extract code blocs from the LLM's output.
+    """Extract code blocks from the LLM's output.
 
     If a valid code block is passed, it returns it directly.
 
@@ -209,27 +212,27 @@ def parse_code_blobs(text: str) -> str:
         raise ValueError(
             dedent(
                 f"""
-                Your code snippet is invalid, because the regex pattern <code>(.*?)</code> was not found in it.
+                Your code snippet is invalid, because no markdown code block was found in it.
                 Here is your code snippet:
                 {text}
                 It seems like you're trying to return the final answer, you can do it as follows:
-                <code>
+                ```python
                 final_answer("YOUR FINAL ANSWER HERE")
-                </code>
+                ```
                 """
             ).strip()
         )
     raise ValueError(
         dedent(
             f"""
-            Your code snippet is invalid, because the regex pattern <code>(.*?)</code> was not found in it.
+            Your code snippet is invalid, because no markdown code block was found in it.
             Here is your code snippet:
             {text}
-            Make sure to include code with the correct pattern, for instance:
+            Make sure to include code with the correct markdown format, for instance:
             Thoughts: Your thoughts
-            <code>
+            ```python
             # Your python code here
-            </code>
+            ```
             """
         ).strip()
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,26 +97,53 @@ class AgentTextTests(unittest.TestCase):
         with pytest.raises(ValueError):
             parse_code_blobs("Wrong blob!")
 
-        # Parsing mardkwon with code blobs should work
-        output = parse_code_blobs("""
+        # Parsing markdown with code blocks should work
+        output = parse_code_blobs(
+            """
 Here is how to solve the problem:
-<code>
+```python
 import numpy as np
-</code>
-""")
+```
+"""
+        )
         assert output == "import numpy as np"
 
-        # Parsing code blobs should work
+        # Parsing code blocks with just ``` should work
+        output = parse_code_blobs(
+            """
+Here is how to solve the problem:
+```
+import numpy as np
+```
+"""
+        )
+        assert output == "import numpy as np"
+
+        # Parsing direct code blobs should work
         code_blob = "import numpy as np"
         output = parse_code_blobs(code_blob)
         assert output == code_blob
 
         # Allow whitespaces after header
-        output = parse_code_blobs("<code>    \ncode_a\n</code>")
+        output = parse_code_blobs("```python\ncode_a\n```")
+        assert output == "code_a"
+
+        # Test with 'py' language specifier
+        output = parse_code_blobs("```py\ncode_a\n```")
         assert output == "code_a"
 
     def test_multiple_code_blobs(self):
-        test_input = "<code>\nFoo\n</code>\n\n<code>\ncode_a\n</code>\n\n<code>\ncode_b\n</code>"
+        test_input = """```python
+Foo
+```
+
+```python
+code_a
+```
+
+```
+code_b
+```"""
         result = parse_code_blobs(test_input)
         assert result == "Foo\n\ncode_a\n\ncode_b"
 


### PR DESCRIPTION
This modifies the CodeAgent to expect and handle code wrapped by 

````
```python
code here
```
````

instead of 

````
<code>
code here
</code>
````

At least with gemma/gemini this substantially improves success of CodeAgent. For example of my evaluation suite it goes from 33% success to 100% success with gemma-3-12b-it. That is somewhat intuitive to me as I feel like writing code this way is fairly common and thus fits the pretraining corpus. However, there might have been intentional reasons for the `<code>` selection I am unaware of. Perhaps it gets emitted too frequently when thinkings?

**This is a work in process** I'm sure this implementation currently breaks the gradio demo and might affect other things. 

If there is interest in it, I would be happy to add a selector flag to the CodeAgent to allow toggling this behavior although it will likely require tracking two prompts.