### PR TITLE
Allow markdown formatting for code blocks

### DIFF
--- a/examples/rag_using_chromadb.py
+++ b/examples/rag_using_chromadb.py
@@ -121,6 +121,7 @@ agent = CodeAgent(
     model=model,
     max_steps=4,
     verbosity_level=2,
+    stream_outputs=True,
 )
 
 agent_output = agent.run("How can I push a model to the Hub?")

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -584,7 +584,7 @@ You have been provided with these additional arguments, that you can access usin
                             "type": "text",
                             "text": populate_template(
                                 self.prompt_templates["planning"]["initial_plan"],
-                                variables={"task": task},
+                                variables={"task": task, "tools": self.tools, "managed_agents": self.managed_agents},
                             ),
                         }
                     ],
@@ -641,6 +641,8 @@ You have been provided with these additional arguments, that you can access usin
                             self.prompt_templates["planning"]["update_plan_post_messages"],
                             variables={
                                 "task": task,
+                                "tools": self.tools,
+                                "managed_agents": self.managed_agents,
                                 "remaining_steps": (self.max_steps - step),
                             },
                         ),

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -1,10 +1,10 @@
 system_prompt: |-
   You are an expert assistant who can solve any task using code blobs. You will be given a task to solve as best you can.
   To do so, you have been given access to a list of tools: these tools are basically Python functions which you can call with code.
-  To solve the task, you must plan forward to proceed in a series of steps, in a cycle of 'Thought:', '<code>', and 'Observation:' sequences.
+  To solve the task, you must plan forward to proceed in a series of steps, in a cycle of Thought, Code, and Observation sequences.
 
   At each step, in the 'Thought:' sequence, you should first explain your reasoning towards solving the task and the tools that you want to use.
-  Then in the '<code>' sequence, you should write the code in simple Python. The code sequence must end with '</code>' sequence.
+  Then in the Code sequence you should write the code in simple Python. The code sequence must be opened with '{{code_block_opening_tag}}', and closed with '{{code_block_closing_tag}}'.
   During each intermediate step, you can use 'print()' to save whatever important information you will then need.
   These print outputs will then appear in the 'Observation:' field, which will be available as input for the next step.
   In the end you have to return a final answer using the `final_answer` tool.
@@ -14,26 +14,26 @@ system_prompt: |-
   Task: "Generate an image of the oldest person in this document."
 
   Thought: I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.
-  <code>
+  {{code_block_opening_tag}}
   answer = document_qa(document=document, question="Who is the oldest person mentioned?")
   print(answer)
-  </code>
+  {{code_block_closing_tag}}
   Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
 
   Thought: I will now generate an image showcasing the oldest person.
-  <code>
+  {{code_block_opening_tag}}
   image = image_generator("A portrait of John Doe, a 55-year-old man living in Canada.")
   final_answer(image)
-  </code>
+  {{code_block_closing_tag}}
 
   ---
   Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
   Thought: I will use python code to compute the result of the operation and then return the final answer using the `final_answer` tool
-  <code>
+  {{code_block_opening_tag}}
   result = 5 + 3 + 1294.678
   final_answer(result)
-  </code>
+  {{code_block_closing_tag}}
 
   ---
   Task:
@@ -42,12 +42,12 @@ system_prompt: |-
   {'question': 'Quel est l'animal sur l'image?', 'image': 'path/to/image.jpg'}"
 
   Thought: I will use the following tools: `translator` to translate the question into English and then `image_qa` to answer the question on the input image.
-  <code>
+  {{code_block_opening_tag}}
   translated_question = translator(question=question, src_lang="French", tgt_lang="English")
   print(f"The translated question is {translated_question}.")
   answer = image_qa(image=image, question=translated_question)
   final_answer(f"The answer is {answer}")
-  </code>
+  {{code_block_closing_tag}}
 
   ---
   Task:
@@ -55,18 +55,18 @@ system_prompt: |-
   What does he say was the consequence of Einstein learning too much math on his creativity, in one word?
 
   Thought: I need to find and read the 1979 interview of Stanislaus Ulam with Martin Sherwin.
-  <code>
+  {{code_block_opening_tag}}
   pages = web_search(query="1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein")
   print(pages)
-  </code>
+  {{code_block_closing_tag}}
   Observation:
   No result found for query "1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein".
 
   Thought: The query was maybe too restrictive and did not find any results. Let's try again with a broader query.
-  <code>
+  {{code_block_opening_tag}}
   pages = web_search(query="1979 interview Stanislaus Ulam")
   print(pages)
-  </code>
+  {{code_block_closing_tag}}
   Observation:
   Found 6 pages:
   [Stanislaus Ulam 1979 interview](https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/)
@@ -76,12 +76,12 @@ system_prompt: |-
   (truncated)
 
   Thought: I will read the first 2 pages to know more.
-  <code>
+  {{code_block_opening_tag}}
   for url in ["https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/", "https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/"]:
       whole_page = visit_webpage(url)
       print(whole_page)
       print("\n" + "="*80 + "\n")  # Print separator between pages
-  </code>
+  {{code_block_closing_tag}}
   Observation:
   Manhattan Project Locations:
   Los Alamos, NM
@@ -89,48 +89,48 @@ system_prompt: |-
   (truncated)
 
   Thought: I now have the final answer: from the webpages visited, Stanislaus Ulam says of Einstein: "He learned too much mathematics and sort of diminished, it seems to me personally, it seems to me his purely physics creativity." Let's answer in one word.
-  <code>
+  {{code_block_opening_tag}}
   final_answer("diminished")
-  </code>
+  {{code_block_closing_tag}}
 
   ---
   Task: "Which city has the highest population: Guangzhou or Shanghai?"
 
   Thought: I need to get the populations for both cities and compare them: I will use the tool `web_search` to get the population of both cities.
-  <code>
+  {{code_block_opening_tag}}
   for city in ["Guangzhou", "Shanghai"]:
       print(f"Population {city}:", web_search(f"{city} population")
-  </code>
+  {{code_block_closing_tag}}
   Observation:
   Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
   Population Shanghai: '26 million (2019)'
 
   Thought: Now I know that Shanghai has the highest population.
-  <code>
+  {{code_block_opening_tag}}
   final_answer("Shanghai")
-  </code>
+  {{code_block_closing_tag}}
 
   ---
   Task: "What is the current age of the pope, raised to the power 0.36?"
 
   Thought: I will use the tool `wikipedia_search` to get the age of the pope, and confirm that with a web search.
-  <code>
+  {{code_block_opening_tag}}
   pope_age_wiki = wikipedia_search(query="current pope age")
   print("Pope age as per wikipedia:", pope_age_wiki)
   pope_age_search = web_search(query="current pope age")
   print("Pope age as per google search:", pope_age_search)
-  </code>
+  {{code_block_closing_tag}}
   Observation:
   Pope age: "The pope Francis is currently 88 years old."
 
   Thought: I know that the pope is 88 years old. Let's compute the result using python code.
-  <code>
+  {{code_block_opening_tag}}
   pope_current_age = 88 ** 0.36
   final_answer(pope_current_age)
-  </code>
+  {{code_block_closing_tag}}
 
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
-  ```python
+  {{code_block_opening_tag}}
   {%- for tool in tools.values() %}
   def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
       """{{ tool.description }}
@@ -141,14 +141,14 @@ system_prompt: |-
       {%- endfor %}
       """
   {% endfor %}
-  ```
+  {{code_block_closing_tag}}
 
   {%- if managed_agents and managed_agents.values() | list %}
   You can also give tasks to team members.
   Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
   You can also include any relevant variables or context using the 'additional_args' argument.
   Here is a list of the team members that you can call:
-  ```python
+  {{code_block_opening_tag}}
   {%- for agent in managed_agents.values() %}
   def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
       """{{ agent.description }}
@@ -158,11 +158,11 @@ system_prompt: |-
           additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
       """
   {% endfor %}
-  ```
+  {{code_block_closing_tag}}
   {%- endif %}
 
   Here are the rules you should always follow to solve your task:
-  1. Always provide a 'Thought:' sequence, and a '<code>' sequence ending with '</code>', else you will fail.
+  1. Always provide a 'Thought:' sequence, and a '{{code_block_opening_tag}}' sequence ending with '{{code_block_closing_tag}}', else you will fail.
   2. Use only variables that you have defined!
   3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
   4. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to wikipedia_search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
@@ -204,36 +204,9 @@ planning:
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
-    You can leverage these tools, behaving like regular python functions:
-    ```python
-    {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}
-        """
-    {% endfor %}
-    ```
-
+    Remember that you can leverage the tools listed above.
     {%- if managed_agents and managed_agents.values() | list %}
-    You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
-    You can also include any relevant variables or context using the 'additional_args' argument.
-    Here is a list of the team members that you can call:
-    ```python
-    {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
-        """{{ agent.description }}
-
-        Args:
-            task: Long detailed description of the task.
-            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
-        """
-    {% endfor %}
-    ```
+    You can also give tasks to the team members described above.
     {%- endif %}
 
     ---
@@ -272,35 +245,9 @@ planning:
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
-    You can leverage these tools, behaving like regular python functions:
-    ```python
-    {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}"""
-    {% endfor %}
-    ```
-
+    Remember that you can leverage the tools listed above.
     {%- if managed_agents and managed_agents.values() | list %}
-    You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
-    You can also include any relevant variables or context using the 'additional_args' argument.
-    Here is a list of the team members that you can call:
-    ```python
-    {%- for agent in managed_agents.values() %}
-    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
-        """{{ agent.description }}
-
-        Args:
-            task: Long detailed description of the task.
-            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
-        """
-    {% endfor %}
-    ```
+    You can also give tasks to the team members described above.
     {%- endif %}
 
     Now write your updated facts survey below, then your new plan.

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -204,9 +204,36 @@ planning:
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
-    Remember that you can leverage the tools listed above.
+    You can leverage these tools, behaving like regular python functions:
+    ```python
+    {%- for tool in tools.values() %}
+    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
+        """{{ tool.description }}
+
+        Args:
+        {%- for arg_name, arg_info in tool.inputs.items() %}
+            {{ arg_name }}: {{ arg_info.description }}
+        {%- endfor %}
+        """
+    {% endfor %}
+    ```
+
     {%- if managed_agents and managed_agents.values() | list %}
-    You can also give tasks to the team members described above.
+    You can also give tasks to team members.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
+    Here is a list of the team members that you can call:
+    ```python
+    {%- for agent in managed_agents.values() %}
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
+    {% endfor %}
+    ```
     {%- endif %}
 
     ---
@@ -245,9 +272,35 @@ planning:
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
-    Remember that you can leverage the tools listed above.
+    You can leverage these tools, behaving like regular python functions:
+    ```python
+    {%- for tool in tools.values() %}
+    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
+        """{{ tool.description }}
+
+        Args:
+        {%- for arg_name, arg_info in tool.inputs.items() %}
+            {{ arg_name }}: {{ arg_info.description }}
+        {%- endfor %}"""
+    {% endfor %}
+    ```
+
     {%- if managed_agents and managed_agents.values() | list %}
-    You can also give tasks to the team members described above.
+    You can also give tasks to team members.
+    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
+    You can also include any relevant variables or context using the 'additional_args' argument.
+    Here is a list of the team members that you can call:
+    ```python
+    {%- for agent in managed_agents.values() %}
+    def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+        """{{ agent.description }}
+
+        Args:
+            task: Long detailed description of the task.
+            additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+        """
+    {% endfor %}
+    ```
     {%- endif %}
 
     Now write your updated facts survey below, then your new plan.

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -154,8 +154,8 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
     try:
         first_accolade_index = json_blob.find("{")
         last_accolade_index = [a.start() for a in list(re.finditer("}", json_blob))][-1]
-        json_data = json_blob[first_accolade_index : last_accolade_index + 1]
-        json_data = json.loads(json_data, strict=False)
+        json_str = json_blob[first_accolade_index : last_accolade_index + 1]
+        json_data = json.loads(json_str, strict=False)
         return json_data, json_blob[:first_accolade_index]
     except IndexError:
         raise ValueError("The model output does not contain any JSON blob.")
@@ -172,16 +172,16 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
         )
 
 
-def extract_code_from_text(text: str) -> str | None:
+def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str | None:
     """Extract code from the LLM's output."""
-    pattern = r"<code>(.*?)</code>"
-    matches = re.findall(pattern, text, re.DOTALL)
+    initial_pattern = rf"{code_block_tags[0]}(.*?){code_block_tags[1]}"
+    matches = re.findall(initial_pattern, text, re.DOTALL)
     if matches:
         return "\n\n".join(match.strip() for match in matches)
     return None
 
 
-def parse_code_blobs(text: str) -> str:
+def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     """Extract code blocs from the LLM's output.
 
     If a valid code block is passed, it returns it directly.
@@ -195,7 +195,9 @@ def parse_code_blobs(text: str) -> str:
     Raises:
         ValueError: If no valid code block is found in the text.
     """
-    matches = extract_code_from_text(text)
+    matches = extract_code_from_text(text, code_block_tags)
+    if not matches:  # Fallback to markdown pattern
+        matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))
     if matches:
         return matches
     # Maybe the LLM outputted a code blob directly
@@ -209,27 +211,27 @@ def parse_code_blobs(text: str) -> str:
         raise ValueError(
             dedent(
                 f"""
-                Your code snippet is invalid, because the regex pattern <code>(.*?)</code> was not found in it.
+                Your code snippet is invalid, because the regex pattern {code_block_tags[0]}(.*?){code_block_tags[1]} was not found in it.
                 Here is your code snippet:
                 {text}
                 It seems like you're trying to return the final answer, you can do it as follows:
-                <code>
+                {code_block_tags[0]}
                 final_answer("YOUR FINAL ANSWER HERE")
-                </code>
+                {code_block_tags[1]}
                 """
             ).strip()
         )
     raise ValueError(
         dedent(
             f"""
-            Your code snippet is invalid, because the regex pattern <code>(.*?)</code> was not found in it.
+            Your code snippet is invalid, because the regex pattern {code_block_tags[0]}(.*?){code_block_tags[1]} was not found in it.
             Here is your code snippet:
             {text}
             Make sure to include code with the correct pattern, for instance:
             Thoughts: Your thoughts
-            <code>
+            {code_block_tags[0]}
             # Your python code here
-            </code>
+            {code_block_tags[1]}
             """
         ).strip()
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,29 +95,44 @@ class SimpleTool(Tool):
 class AgentTextTests(unittest.TestCase):
     def test_parse_code_blobs(self):
         with pytest.raises(ValueError):
-            parse_code_blobs("Wrong blob!")
+            parse_code_blobs("Wrong blob!", ("<code>", "</code>"))
 
         # Parsing mardkwon with code blobs should work
-        output = parse_code_blobs("""
+        output = parse_code_blobs(
+            """
 Here is how to solve the problem:
 <code>
 import numpy as np
 </code>
-""")
+""",
+            ("<code>", "</code>"),
+        )
         assert output == "import numpy as np"
 
-        # Parsing code blobs should work
+        # Parsing pure python code blobs should work
         code_blob = "import numpy as np"
-        output = parse_code_blobs(code_blob)
+        output = parse_code_blobs(code_blob, ("```python", "```"))
         assert output == code_blob
 
         # Allow whitespaces after header
-        output = parse_code_blobs("<code>    \ncode_a\n</code>")
+        output = parse_code_blobs("<code>    \ncode_a\n</code>", ("<code>", "</code>"))
         assert output == "code_a"
+
+        # Parsing markdown with code blobs should work
+        output = parse_code_blobs(
+            """
+Here is how to solve the problem:
+```python
+import numpy as np
+```
+""",
+            ("<code>", "</code>"),
+        )
+        assert output == "import numpy as np"
 
     def test_multiple_code_blobs(self):
         test_input = "<code>\nFoo\n</code>\n\n<code>\ncode_a\n</code>\n\n<code>\ncode_b\n</code>"
-        result = parse_code_blobs(test_input)
+        result = parse_code_blobs(test_input, ("<code>", "</code>"))
         assert result == "Foo\n\ncode_a\n\ncode_b"
 
 


### PR DESCRIPTION
This follows up on https://github.com/huggingface/smolagents/pull/1442 and https://github.com/huggingface/smolagents/pull/1491:
- We changed code block fencing blocks from markdown to XML to align with general usage of XML tags in chat templates
- This degrades performance for Gemma-3-12B-IT, and maybe other models, we hypothese that this is due to presence of markdown-formatted blocks in training corpora.
- This PR introduces the possibility to customize code block tags
- It also adds a check for the presence of markdown blocks as a fallback in any case.
- It also adapts the system prompt to whichever code block format is used. In particular, in the system prompts, it wraps the tool descriptions within these code tags, so as to further nudge the model towards using the proper tags.