### PR TITLE
Fix DockerExecutor tests with final_answer by calling send_tools

### DIFF
--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -193,18 +193,21 @@ class TestDockerExecutorIntegration:
 
     def test_execute_output(self):
         """Test execution that returns a string"""
+        self.executor.send_tools({"final_answer": FinalAnswerTool()})
         code_action = 'final_answer("This is the final answer")'
         result, logs, final_answer = self.executor(code_action)
         assert result == "This is the final answer", "Result should be 'This is the final answer'"
 
     def test_execute_multiline_output(self):
         """Test execution that returns a string"""
+        self.executor.send_tools({"final_answer": FinalAnswerTool()})
         code_action = 'result = "This is the final answer"\nfinal_answer(result)'
         result, logs, final_answer = self.executor(code_action)
         assert result == "This is the final answer", "Result should be 'This is the final answer'"
 
     def test_execute_image_output(self):
         """Test execution that returns a base64 image"""
+        self.executor.send_tools({"final_answer": FinalAnswerTool()})
         code_action = dedent("""
             import base64
             from PIL import Image


### PR DESCRIPTION
Fix DockerExecutor tests with final_answer by calling send_tools.

Currently, they raise error:
> NameError: name 'final_answer' is not defined

I guess this bug was introduced when we required explicitly calling to `send_tools`.