### PR TITLE
Fix: step callbacks not being triggered for planning steps

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -509,6 +509,7 @@ You have been provided with these additional arguments, that you can access usin
                     start_time=planning_start_time,
                     end_time=planning_end_time,
                 )
+                self._finalize_step(planning_step)
 
             # Start action step!
             action_step_start_time = time.time()
@@ -559,7 +560,7 @@ You have been provided with these additional arguments, that you can access usin
             except Exception as e:
                 raise AgentError(f"Check {check_function.__name__} failed with error: {e}", self.logger)
 
-    def _finalize_step(self, memory_step: ActionStep):
+    def _finalize_step(self, memory_step: ActionStep | PlanningStep):
         memory_step.timing.end_time = time.time()
         for callback in self.step_callbacks:
             # For compatibility with old callbacks that don't take the agent as an argument


### PR DESCRIPTION
Fixes https://github.com/huggingface/smolagents/issues/1499 

Step callbacks were previously only executed for ActionStep objects but not for PlanningStep objects, creating inconsistent behavior where callbacks that should be invoked for every step were skipped during planning phases.

**Changes:**
- Modified `_finalize_step()` to accept both `ActionStep | PlanningStep` types
- Added `_finalize_step(planning_step)` call in planning step flow

**Backward Compatibility:**
- No breaking changes - existing callbacks continue to work unchanged
- Preserves same execution order of finalizing step & adding to memory as ActionStep flow

**Testing:**
- Lightweight test using existing `FakeCodeModelPlanning()` verifies both planning and action step callbacks
- All existing tests continue to pass