### PR TITLE
Enable image output for Tool.from_space

### DIFF
--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -18,6 +18,7 @@ import pathlib
 import tempfile
 import uuid
 from io import BytesIO
+from typing import Any
 
 import PIL.Image
 import requests
@@ -259,7 +260,7 @@ def handle_agent_input_types(*args, **kwargs):
     return args, kwargs
 
 
-def handle_agent_output_types(output, output_type=None):
+def handle_agent_output_types(output: Any, output_type: str) -> Any:
     if output_type in _AGENT_TYPE_MAPPING:
         # If the class has defined outputs, we can map directly according to the class definition
         decoded_outputs = _AGENT_TYPE_MAPPING[output_type](output)

--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -260,7 +260,7 @@ def handle_agent_input_types(*args, **kwargs):
     return args, kwargs
 
 
-def handle_agent_output_types(output: Any, output_type: str) -> Any:
+def handle_agent_output_types(output: Any, output_type: str | None = None) -> Any:
     if output_type in _AGENT_TYPE_MAPPING:
         # If the class has defined outputs, we can map directly according to the class definition
         decoded_outputs = _AGENT_TYPE_MAPPING[output_type](output)

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -282,15 +282,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert (
-                not missing_keys
-            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            assert not missing_keys, (
+                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+            )
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert (
-                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
-                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
+                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                        )
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -343,9 +343,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(
-                agent.name and agent.description for agent in managed_agents
-            ), "All managed agents need both a name and a description!"
+            assert all(agent.name and agent.description for agent in managed_agents), (
+                "All managed agents need both a name and a description!"
+            )
             self.managed_agents = {agent.name: agent for agent in managed_agents}
             # Ensure managed agents can be called as tools by the model: set their inputs and output_type
             for agent in self.managed_agents.values():

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -282,15 +282,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            assert (
+                not missing_keys
+            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        assert (
+                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
+                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -343,9 +343,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            assert all(
+                agent.name and agent.description for agent in managed_agents
+            ), "All managed agents need both a name and a description!"
             self.managed_agents = {agent.name: agent for agent in managed_agents}
             # Ensure managed agents can be called as tools by the model: set their inputs and output_type
             for agent in self.managed_agents.values():

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -152,9 +152,9 @@ class Tool:
         # Validate inputs
         for input_name, input_content in self.inputs.items():
             assert isinstance(input_content, dict), f"Input '{input_name}' should be a dictionary."
-            assert (
-                "type" in input_content and "description" in input_content
-            ), f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
+            assert "type" in input_content and "description" in input_content, (
+                f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
+            )
             # Get input_types as a list, whether from a string or list
             if isinstance(input_content["type"], str):
                 input_types = [input_content["type"]]
@@ -194,17 +194,17 @@ class Tool:
                 "properties"
             ]  # This function will not raise an error on missing docstrings, contrary to get_json_schema
             for key, value in self.inputs.items():
-                assert (
-                    key in json_schema
-                ), f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
+                assert key in json_schema, (
+                    f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
+                )
                 if "nullable" in value:
-                    assert (
-                        "nullable" in json_schema[key]
-                    ), f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
+                    assert "nullable" in json_schema[key], (
+                        f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
+                    )
                 if key in json_schema and "nullable" in json_schema[key]:
-                    assert (
-                        "nullable" in value
-                    ), f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
+                    assert "nullable" in value, (
+                        f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
+                    )
 
     def forward(self, *args, **kwargs):
         return NotImplementedError("Write this method in your subclass of `Tool`.")

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -582,7 +582,9 @@ class Tool:
                 self.name = name
                 self.description = description
                 self.client = Client(space_id, hf_token=token)
-                space_description = self.client.view_api(return_format="dict", print_info=False)["named_endpoints"]
+                space_api = self.client.view_api(return_format="dict", print_info=False)
+                assert isinstance(space_api, dict)
+                space_description = space_api["named_endpoints"]
 
                 # If api_name is not defined, take the first of the available APIs for this space
                 if api_name is None:
@@ -613,7 +615,6 @@ class Tool:
                     self.output_type = "audio"
                 else:
                     self.output_type = "any"
-                print(self.inputs, self.output_type)
                 self.is_initialized = True
 
             def sanitize_argument_for_prediction(self, arg):
@@ -649,7 +650,6 @@ class Tool:
                     ]  # Sometime the space also returns the generation seed, in which case the result is at index 0
                 IMAGE_EXTENTIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
                 AUDIO_EXTENTIONS = [".mp3", ".wav", ".ogg", ".m4a", ".flac"]
-                print("OUTPUT", output)
                 if isinstance(output, str) and any([output.endswith(ext) for ext in IMAGE_EXTENTIONS]):
                     output = AgentImage(output)
                 elif isinstance(output, str) and any([output.endswith(ext) for ext in AUDIO_EXTENTIONS]):
@@ -868,7 +868,7 @@ class ToolCollection:
         _collection = get_collection(collection_slug, token=token)
         _hub_repo_ids = {item.item_id for item in _collection.items if item.item_type == "space"}
 
-        tools = {Tool.from_hub(repo_id, token, trust_remote_code) for repo_id in _hub_repo_ids}
+        tools = [Tool.from_hub(repo_id, token, trust_remote_code) for repo_id in _hub_repo_ids]
 
         return cls(tools)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -734,9 +734,9 @@ nested_answer()
         input_messages = first_planning_step.model_input_messages
 
         # Check message structure and content
-        assert (
-            len(input_messages) == 4
-        ), "First planning step should have 4 messages: system-plan-pre-update + memory + task + user-plan-post-update"
+        assert len(input_messages) == 4, (
+            "First planning step should have 4 messages: system-plan-pre-update + memory + task + user-plan-post-update"
+        )
 
         # Verify system message contains current task
         system_message = input_messages[0]
@@ -745,9 +745,9 @@ nested_answer()
 
         # Verify memory message contains previous task
         memory_message = input_messages[1]
-        assert (
-            previous_task in memory_message.content[0]["text"]
-        ), f"Memory message should contain previous task: '{previous_task}'"
+        assert previous_task in memory_message.content[0]["text"], (
+            f"Memory message should contain previous task: '{previous_task}'"
+        )
 
         # Verify task message contains current task
         task_message = input_messages[2]


### PR DESCRIPTION
`gradio_client.Client.predict()` returns path to generated images/audio files instead of the real image/audio object: this PR fixes it. It also adds testing to make sure that agents do return image objects when they call `final_answer` on an image.