### PR TITLE
Split Built-in Tools from Tools in Reference docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -46,5 +46,9 @@
     title: Agent-related objects
   - local: reference/models
     title: Model-related objects
-  - local: reference/tools
-    title: Tool-related objects
+  - title: Tools
+    sections:
+    - title: Tool-related objects
+      local: reference/tools
+    - title: Built-in Tools
+      local: reference/default_tools

--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -1,0 +1,64 @@
+# Built-in Tools
+
+Ready-to-use tool implementations provided by the `smolagents` library.
+These built-in tools are concrete implementations of the `Tool` base class, each designed for specific tasks such as web searching, Python code execution, webpage retrieval, and user interaction.
+You can use these tools directly in your agents without having to implement the underlying functionality yourself.
+Each tool handles a particular capability and follows a consistent interface, making it easy to compose them into powerful agent workflows.
+
+The built-in tools can be categorized by their primary functions:
+- **Information Retrieval**: Search and retrieve information from the web and specific knowledge sources.
+  - [`ApiWebSearchTool`](#apiwebsearchtool)
+  - [`DuckDuckGoSearchTool`](#duckduckgosearchtool)
+  - [`GoogleSearchTool`](#googlesearchtool)
+  - [`WebSearchTool`](#websearchtool)
+  - [`WikipediaSearchTool`](#wikipediasearchtool)
+- **Web Interaction**: Fetch and process content from specific web pages.
+  - [`VisitWebpageTool`](#visitwebpagetool)
+- **Code Execution**: Dynamic execution of Python code for computational tasks.
+  - [`PythonInterpreterTool`](#pythoninterpretertool)
+- **User Interaction**: Enable Human-in-the-Loop collaboration between agents and users.
+  - [`UserInputTool`](#userinputtool): Collect input from users.
+- **Speech Processing**: Convert audio to textual data.
+  - [`SpeechToTextTool`](#speechtotexttool)
+- **Workflow Control**: Manage and direct the flow of agent operations.
+  - [`FinalAnswerTool`](#finalanswertool): Conclude agent workflow with final response.
+
+## ApiWebSearchTool
+
+[[autodoc]] smolagents.default_tools.ApiWebSearchTool
+
+## DuckDuckGoSearchTool
+
+[[autodoc]] smolagents.default_tools.DuckDuckGoSearchTool
+
+## FinalAnswerTool
+
+[[autodoc]] smolagents.default_tools.FinalAnswerTool
+
+## GoogleSearchTool
+
+[[autodoc]] smolagents.default_tools.GoogleSearchTool
+
+## PythonInterpreterTool
+
+[[autodoc]] smolagents.default_tools.PythonInterpreterTool
+
+## SpeechToTextTool
+
+[[autodoc]] smolagents.default_tools.SpeechToTextTool
+
+## UserInputTool
+
+[[autodoc]] smolagents.default_tools.UserInputTool
+
+## VisitWebpageTool
+
+[[autodoc]] smolagents.default_tools.VisitWebpageTool
+
+## WebSearchTool
+
+[[autodoc]] smolagents.default_tools.WebSearchTool
+
+## WikipediaSearchTool
+
+[[autodoc]] smolagents.default_tools.WikipediaSearchTool

--- a/docs/source/en/reference/tools.md
+++ b/docs/source/en/reference/tools.md
@@ -10,7 +10,7 @@ can vary as the APIs or underlying models are prone to change.
 To learn more about agents and tools make sure to read the [introductory guide](../index). This page
 contains the API docs for the underlying classes.
 
-## Tools
+## Tool Base Classes
 
 ### load_tool
 
@@ -27,40 +27,6 @@ contains the API docs for the underlying classes.
 ### launch_gradio_demo
 
 [[autodoc]] launch_gradio_demo
-
-## Default tools
-
-### PythonInterpreterTool
-
-[[autodoc]] PythonInterpreterTool
-
-### FinalAnswerTool
-
-[[autodoc]] FinalAnswerTool
-
-### UserInputTool
-
-[[autodoc]] UserInputTool
-
-### WebSearchTool
-
-[[autodoc]] WebSearchTool
-
-### DuckDuckGoSearchTool
-
-[[autodoc]] DuckDuckGoSearchTool
-
-### GoogleSearchTool
-
-[[autodoc]] GoogleSearchTool
-
-### VisitWebpageTool
-
-[[autodoc]] VisitWebpageTool
-
-### SpeechToTextTool
-
-[[autodoc]] SpeechToTextTool
 
 ## ToolCollection
 


### PR DESCRIPTION
Split Built-in Tools from Tools in Reference docs, with a dedicated doc page.

Additionally, add missing `WikipediaSearchTool` to Reference docs.