### PR TITLE
Fix docstring of WikipediaSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -469,7 +469,7 @@ class VisitWebpageTool(Tool):
 
 class WikipediaSearchTool(Tool):
     """
-    Search Wikipedia and return summary or full text of the requested article, along with the page URL.
+    Search Wikipedia and return the summary or full text of the requested article, along with the page URL.
 
     Attributes:
         user_agent (`str`): Custom user-agent string to identify the project. This is required as per Wikipedia API policies.


### PR DESCRIPTION
Fix docstring of `WikipediaSearchTool`.

Changes:
- Fix Examples section, currently malformed (see below)
- Fix data types and descriptions.

Currently, the Examples section of the docstring is malformed:

![Screenshot from 2025-07-04 15-40-45](https://github.com/user-attachments/assets/9ead0c3d-6dc4-4000-9ae8-4af94a8a6ff2)

This PR requires merging first:
- #1520 
  - This PR adds missing `WikipediaSearchTool` to Reference docs.