### PR TITLE
Bug Fix: KeyError when agent reaches max steps with image input

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -823,7 +823,10 @@ You have been provided with these additional arguments, that you can access usin
             chat_message: ChatMessage = self.model.generate(messages)
             return chat_message
         except Exception as e:
-            return ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": f"Error in generating final LLM output: {e}"}])
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=[{"type": "text", "text": f"Error in generating final LLM output: {e}"}],
+            )
 
     def visualize(self):
         """Creates a rich tree visualization of the agent's structure."""

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -823,7 +823,7 @@ You have been provided with these additional arguments, that you can access usin
             chat_message: ChatMessage = self.model.generate(messages)
             return chat_message
         except Exception as e:
-            return ChatMessage(role=MessageRole.ASSISTANT, content=f"Error in generating final LLM output:\n{e}")
+            return ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": f"Error in generating final LLM output: {e}"}])
 
     def visualize(self):
         """Creates a rich tree visualization of the agent's structure."""


### PR DESCRIPTION
### Problem
When an agent reaches max steps with image input, a KeyError occurs because the error handling in `provide_final_answer` returns a plain string instead of the expected list
format. This causes `models.py` to fail when trying to `pop("image")` from the message content.

### Solution
Changed the error message format in `agents.py:826` from a plain string to a properly structured list with type annotation, matching the expected ChatMessage content format.

### Testing
- All existing tests pass
- Code quality checks pass (`make quality`)
- Code formatting applied (`make style`)
- Fix verified with custom test case

### Related Issue
Fixes #1524
