### PR TITLE
Fix Access of `content` Field in `ChatMessage` Object

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -860,7 +860,7 @@ You have been provided with these additional arguments, that you can access usin
         if self.provide_run_summary:
             answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
             for message in self.write_memory_to_messages(summary_mode=True):
-                content = message["content"]
+                content = message.content
                 answer += "\n" + truncate_content(str(content)) + "\n---"
             answer += "\n</summary_of_work>"
         return answer


### PR DESCRIPTION
This PR contains a one-line fix for #1532.