### PR TITLE
Update deprecated duckduckgo-search to ddgs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ telemetry = [
   "openinference-instrumentation-smolagents>=0.1.4"
 ]
 toolkit = [
-  "duckduckgo-search>=6.3.7",  # DuckDuckGoSearchTool
+  "ddgs>=9.0.2",  # DuckDuckGoSearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 transformers = [

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -127,16 +127,16 @@ class DuckDuckGoSearchTool(Tool):
         self._min_interval = 1.0 / rate_limit if rate_limit else 0.0
         self._last_request_time = 0.0
         try:
-            from duckduckgo_search import DDGS
+            from ddgs import DDGS
         except ImportError as e:
             raise ImportError(
-                "You must install package `duckduckgo_search` to run this tool: for instance run `pip install duckduckgo-search`."
+                "You must install package `ddgs` to run this tool: for instance run `pip install ddgs`."
             ) from e
         self.ddgs = DDGS(**kwargs)
 
     def forward(self, query: str) -> str:
         self._enforce_rate_limit()
-        results = self.ddgs.text(query, max_results=self.max_results)
+        results = self.ddgs.text(query, num_results=self.max_results, backend='duckduckgo')
         if len(results) == 0:
             raise Exception("No results found! Try a less restrictive/shorter query.")
         postprocessed_results = [f"[{result['title']}]({result['href']})\n{result['body']}" for result in results]


### PR DESCRIPTION
I've updated deprecated package duckduckgo-search to ddgs. Ddgs now supports searching via different engines, so I've set backend='duckduckgo'.