### PR TITLE
Fix and improve MCP server security warnings in docs

### DIFF
--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -279,8 +279,12 @@ Leverage tools from the hundreds of MCP servers available on [glama.ai](https://
 The MCP servers tools can be loaded with [`ToolCollection.from_mcp`].
 
 > [!WARNING]
-> **Security Warning:** The same security warnings mentioned earlier for `MCPClient` apply when using `ToolCollection.from_mcp()`.
-
+> **Security Warning:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
+>
+> Using MCP servers comes with security risks:
+> - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
+> - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
+> - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
 
 For stdio-based MCP servers, pass the server parameters as an instance of `mcp.StdioServerParameters`:
 ```py

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -168,8 +168,10 @@ with MCPClient([server_params1, server_params2]) as tools:
 ```
 
 > [!WARNING]
-> **Security Warning:** Using MCP servers comes with security risks:
-> - **Trust is essential:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments. Malicious servers can execute harmful code on your machine.
+> **Security Warning:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
+>
+> Using MCP servers comes with security risks:
+> - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
 > - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
 

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -172,7 +172,7 @@ with MCPClient([server_params1, server_params2]) as tools:
 > Using MCP servers comes with security risks:
 > - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
-> - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
+> - **Streamable HTTP-based MCP servers:** While remote MCP servers will not execute code on your machine, still proceed with caution.
 
 ### Import a Space as a tool
 
@@ -282,7 +282,7 @@ The MCP servers tools can be loaded with [`ToolCollection.from_mcp`].
 > Using MCP servers comes with security risks:
 > - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
-> - **Streamable HTTP-based MCP servers** while the remote MCP servers will not be able to execute code on your machine, still proceed with caution.
+> - **Streamable HTTP-based MCP servers:** While remote MCP servers will not execute code on your machine, still proceed with caution.
 
 For stdio-based MCP servers, pass the server parameters as an instance of `mcp.StdioServerParameters`:
 ```py

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -169,7 +169,6 @@ with MCPClient([server_params1, server_params2]) as tools:
 
 > [!WARNING]
 > **Security Warning:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
->
 > Using MCP servers comes with security risks:
 > - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
@@ -280,7 +279,6 @@ The MCP servers tools can be loaded with [`ToolCollection.from_mcp`].
 
 > [!WARNING]
 > **Security Warning:** Always verify the source and integrity of any MCP server before connecting to it, especially for production environments.
->
 > Using MCP servers comes with security risks:
 > - **Trust is essential:** Only use MCP servers from trusted sources. Malicious servers can execute harmful code on your machine.
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -277,7 +277,7 @@ Leverage tools from the hundreds of MCP servers available on [glama.ai](https://
 The MCP servers tools can be loaded with [`ToolCollection.from_mcp`].
 
 > [!WARNING]
-> **Security Warning:** The same security warnings mentioned for `MCPClient` apply when using `MCPClient` directly.
+> **Security Warning:** The same security warnings mentioned earlier for `MCPClient` apply when using `ToolCollection.from_mcp()`.
 
 
 For stdio-based MCP servers, pass the server parameters as an instance of `mcp.StdioServerParameters`:


### PR DESCRIPTION
Fix and improve MCP server security warnings in docs:
- First, fix the repeated mention to `MCPClient` in the same sentence
  > The same security warnings mentioned for `MCPClient` apply when using `MCPClient`
- Restructure warnings using the inverted pyramid approach (most critical information first: call to action)
- Make all warnings self-contained rather than referencing previous warning
  - Ensure readers who skip to this section get complete information
  - Remove the need to search for previous context

These changes follow documentation best practices by ensuring critical security information is immediately visible and complete regardless of how users navigate the documentation.