### PR TITLE
fix(models): support dict-style messages in get_clean_message_list

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -288,15 +288,15 @@ def get_clean_message_list(
     output_message_list: list[dict[str, Any]] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
     for message in message_list:
-        role = message.role
+        role = message["role"]
         if role not in MessageRole.roles():
             raise ValueError(f"Incorrect role {role}, only {MessageRole.roles()} are supported for now.")
 
         if role in role_conversions:
-            message.role = role_conversions[role]  # type: ignore
+            message["role"] = role_conversions[role]  # type: ignore
         # encode images if needed
-        if isinstance(message.content, list):
-            for element in message.content:
+        if isinstance(message["content"], list):
+            for element in message["content"]:
                 assert isinstance(element, dict), "Error: this element should be a dict:" + str(element)
                 if element["type"] == "image":
                     assert not flatten_messages_as_text, f"Cannot use images with {flatten_messages_as_text=}"
@@ -310,12 +310,12 @@ def get_clean_message_list(
                     else:
                         element["image"] = encode_image_base64(element["image"])
 
-        if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+        if len(output_message_list) > 0 and message["role"] == output_message_list[-1]["role"]:
+            assert isinstance(message["content"], list), "Error: wrong content:" + str(message["content"])
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                output_message_list[-1]["content"] += "\n" + message["content"][0]["text"]
             else:
-                for el in message.content:
+                for el in message["content"]:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
                         output_message_list[-1]["content"][-1]["text"] += "\n" + el["text"]
@@ -323,12 +323,12 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = message["content"][0]["text"]
             else:
-                content = message.content
+                content = message["content"]
             output_message_list.append(
                 {
-                    "role": message.role,
+                    "role": message["role"],
                     "content": content,
                 }
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -728,6 +728,17 @@ def test_supports_stop_parameter(model_id, expected):
     assert supports_stop_parameter(model_id) == expected, f"Failed for model_id: {model_id}"
 
 
+def test_transformers_model_with_dict_message():
+    model = TransformersModel(model_id="HuggingFaceTB/SmolLM-135M-Instruct")
+    # Message passed as a dictionary, not a class object
+    message_dict = [{"role": "user", "content": [{"type": "text", "text": "Hello, how are you?"}]}]
+    # Run model
+    output = model(message_dict, stop_sequences=["END"])
+    print(output)
+    assert isinstance(output, ChatMessage), "Expected output to be a ChatMessage object"
+    assert output.content and isinstance(output.content, str), "Expected non-empty text in content"
+    assert len(output.content.strip()) > 0, "Output content is empty"
+
 class TestGetToolCallFromText:
     @pytest.fixture(autouse=True)
     def mock_uuid4(self):


### PR DESCRIPTION
### **Fix: Support Dict-Style Messages in `get_clean_message_list`**

### **Summary**
This pull request updates the `get_clean_message_list()` method in `models.py` to support **dictionary-style messages** in addition to structured Message objects. This improves developer experience and aligns `TransformersModel` with `InferenceClientModel`, which already supports dict input formats.

### **Problem**
Passing a dictionary-style message to TransformersModel raises an AttributeError, due to direct attribute access (message.role) instead of dictionary key access:

`AttributeError: 'dict' object has no attribute 'role'`

 ```
 File ".../smolagents/models.py", line 291, in get_clean_message_list
    role = message.role
           ^^^^^^^^^^^^
```

This breaks many natural use cases like:
`model([{"role": "user", "content": [{"type": "text", "text": "Hello"}]}])`

### **What Was Changed**
Replaced attribute-style access (message.role, message.content) with dictionary-style access (message['role'], message['content']) throughout the get_clean_message_list() function.

Ensured message merging, image processing, and content flattening still function correctly.

Prevented crashes for users providing standard dict inputs, improving ease of use and compatibility.



Also added a test case to validate this functionality.
Test passed locally with `pytest -k test_transformers_model_with_dict_message`

<img width="1468" height="160" alt="testcase-output" src="https://github.com/user-attachments/assets/bfc5de70-252e-4cd6-b841-9620006405b8" />



Happy to add documentation or additional test coverage if needed.


