### PR TITLE
Improve performance of CI quality checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           pip install --upgrade uv
 
-      - name: Install dependencies
-        run: uv pip install "smolagents[quality] @ ."
+      - name: Install only quality dependencies
+        run: uv pip install ruff
 
       # Equivalent of "make quality" but step by step
-      - run: ruff check examples src tests  # linter
-      - run: ruff format --check examples src tests  # formatter
+      - run: uv run ruff check examples src tests  # linter
+      - run: uv run ruff format --check examples src tests  # formatter

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,5 +27,5 @@ jobs:
         run: uv pip install ruff
 
       # Equivalent of "make quality" but step by step
-      - run: run ruff check examples src tests  # linter
-      - run: run ruff format --check examples src tests  # formatter
+      - run: ruff check examples src tests  # linter
+      - run: ruff format --check examples src tests  # formatter

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,5 +27,7 @@ jobs:
         run: uv pip install ruff
 
       # Equivalent of "make quality" but step by step
-      - run: ruff check examples src tests  # linter
-      - run: ruff format --check examples src tests  # formatter
+      - name: Run Ruff linter
+        run: ruff check examples src tests
+      - name: Run Ruff formatter
+        run: ruff format --check examples src tests

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,10 +18,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Setup venv
-      - name: Setup uv
-        run: |
-          pip install --upgrade uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Install only quality dependencies
         run: uv pip install ruff

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
 
       - name: Install only quality dependencies
         run: uv pip install ruff

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,5 +27,5 @@ jobs:
         run: uv pip install ruff
 
       # Equivalent of "make quality" but step by step
-      - run: uv run ruff check examples src tests  # linter
-      - run: uv run ruff format --check examples src tests  # formatter
+      - run: run ruff check examples src tests  # linter
+      - run: run ruff format --check examples src tests  # formatter


### PR DESCRIPTION
Improve performance of CI quality checks, by installing only the quality dependency (`ruff`) and not installing `smolagents`.