### PR TITLE
Fix: Prevent empty additional_args from being added to agent prompt

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -435,7 +435,7 @@ class MultiStepAgent(ABC):
         max_steps = max_steps or self.max_steps
         self.task = task
         self.interrupt_switch = False
-        if additional_args is not None:
+        if additional_args:
             self.state.update(additional_args)
             self.task += f"""
 You have been provided with these additional arguments, that you can access using the keys as variables in your python code:


### PR DESCRIPTION
## Description
Fixes empty `additional_args` dictionaries being added to agent prompts unnecessarily. The current implementation checks if `additional_args` is not `None`, but doesn't verify if the dictionary actually contains any items.

### Problem
1. Empty dictionaries were being added to prompts, unnecessarily increasing token usage
2. `ToolCallingAgent` was receiving Python arguments instructions despite not being able to execute Python code

Example prompt when using a nested multi agent strcuture like `CodeAgent` -> `ToolCallingAgent` (Managed Agent)
<pre><code>You're a helpful agent named 'web_agent'.
You have been submitted this task by your manager.
---
Task:
Find at least 3 notable Batman filming locations around the world. For each location, provide the city and country.
---
You're helping your manager solve a wider task: so make sure to not provide a one-line answer, but give as much information as possible to give them a clear understanding of the answer.

Your final_answer WILL HAVE to contain these parts:
### 1. Task outcome (short version):
### 2. Task outcome (extremely detailed version):
### 3. Additional context (if relevant):

Put all these in your final_answer tool, everything that you do not pass as an argument to final_answer will be lost.
And even if your task resolution is not successful, please return as much context as possible, so that your manager can act upon this feedback.
<strong>You have been provided with these additional arguments, that you can access using the keys as variables in your python code:
{}.</strong>
</code></pre>

### Solution
Changed the condition from `if additional_args is not None` to `if additional_args` to only add the additional arguments message when the dictionary is both not None and not empty.

<br><br/>
*Edit: Quality / format checks and tests run suscessfully.*