### PR TITLE
Temporarily skip wrongly implemented tests

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1574,6 +1574,10 @@ class TestToolCallingAgent:
         assert "Error while parsing" in capture.get()
         assert len(agent.memory.steps) == 4
 
+    @pytest.mark.skip(
+        reason="Test is not properly implemented (GH-1255) because fake_tools should have the same name. "
+        "Additionally, it uses CodeAgent instead of ToolCallingAgent (GH-1409)"
+    )
     def test_change_tools_after_init(self):
         from smolagents import tool
 
@@ -1908,6 +1912,9 @@ print("Ok, calculation done!")""")
         assert messages
         assert all(m.content.endswith("</code>") for m in messages)
 
+    @pytest.mark.skip(
+        reason="Test is not properly implemented (GH-1255) because fake_tools should have the same name. "
+    )
     def test_change_tools_after_init(self):
         from smolagents import tool
 


### PR DESCRIPTION
Temporarily skip wrongly implemented tests.

These tests do not verify the intended behaviors and are therefore misleading, even though they may pass or fail inconsistently. Until we have time to properly rewrite them, they are being explicitly skipped to prevent confusion and inaccurate CI results.