### PR TITLE
Serialize MultiStepAgents with managed agents in a dict.

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -977,8 +977,7 @@ You have been provided with these additional arguments, that you can access usin
                 "data": self.model.to_dict(),
             },
             "managed_agents": {
-                managed_agent.name: managed_agent.to_dict()
-                for managed_agent in self.managed_agents.values()
+                managed_agent.name: managed_agent.to_dict() for managed_agent in self.managed_agents.values()
             },
             "prompt_templates": self.prompt_templates,
             "max_steps": self.max_steps,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -976,7 +976,10 @@ You have been provided with these additional arguments, that you can access usin
                 "class": self.model.__class__.__name__,
                 "data": self.model.to_dict(),
             },
-            "managed_agents": [managed_agent.to_dict() for managed_agent in self.managed_agents.values()],
+            "managed_agents": {
+                managed_agent.name: managed_agent.to_dict()
+                for managed_agent in self.managed_agents.values()
+            },
             "prompt_templates": self.prompt_templates,
             "max_steps": self.max_steps,
             "verbosity_level": int(self.logger.level),
@@ -1009,14 +1012,16 @@ You have been provided with these additional arguments, that you can access usin
             tools.append(Tool.from_code(tool_info["code"]))
         # Load managed agents
         managed_agents = []
-        for managed_agent_name, managed_agent_class_name in agent_dict["managed_agents"].items():
+        for managed_agent_name, managed_agent_data in agent_dict["managed_agents"].items():
+            managed_agent_class_name = managed_agent_data.pop("class")
             managed_agent_class = getattr(importlib.import_module("smolagents.agents"), managed_agent_class_name)
-            managed_agents.append(managed_agent_class.from_dict(agent_dict["managed_agents"][managed_agent_name]))
+            managed_agents.append(managed_agent_class.from_dict(managed_agent_data))
         # Extract base agent parameters
         agent_args = {
             "model": model,
             "tools": tools,
             "prompt_templates": agent_dict.get("prompt_templates"),
+            "managed_agents": managed_agents,
             "max_steps": agent_dict.get("max_steps"),
             "verbosity_level": agent_dict.get("verbosity_level"),
             "grammar": agent_dict.get("grammar"),


### PR DESCRIPTION
Fixes #1576 

The `MultiStepAgent.to_dict()` method returns `managed_agents` as a dict instead of a list.

The `MultiStepAgent.from_dict()` class method parses the managed_agents dict and turns it back into a list of `MultiStepAgent` instances to be passed as arguments to instantiate the class.