### PR TITLE
DOC: correct image link for docs (secure_code_execution.md)

### DIFF
--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -116,7 +116,7 @@ For high-security applications or when using less trusted models, you should con
 When working with AI agents that execute code, security is paramount. There are two main approaches to sandboxing code execution in smolagents, each with different security properties and capabilities:
 
 
-![Sandbox approaches comparison](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/remote_execution.png)
+![Sandbox approaches comparison](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/sandboxed_execution.png)
 
 1. **Running individual code snippets in a sandbox**: This approach (left side of diagram) only executes the agent-generated Python code snippets in a sandbox while keeping the rest of the agentic system in your local environment. It's simpler to set up using `executor_type="e2b"` or `executor_type="docker"`, but it doesn't support multi-agents and still requires passing state data between your environment and the sandbox.
 


### PR DESCRIPTION
Hello,
Thank you for the Smolagents project!
I've fixed a typo in the [docs](https://github.com/huggingface/smolagents/blob/a36df09427adf748c75863543809778664c78503/docs/source/en/tutorials/secure_code_execution.md) where there was an **image link error**.
I believe it should be `remote_execution.png` → `sandboxed_execution.png` to match the actual file path. I referenced the [file directories](https://huggingface.co/datasets/huggingface/documentation-images/blob/main/smolagents/sandboxed_execution.png) and confirmed this should work correctly.
Thank you! 😊
@albertvillanova 


`as-is`
<img width="1576" height="1183" alt="image" src="https://github.com/user-attachments/assets/c2e62c75-63e8-4b72-ad07-7243ce498d8d" />


`to-be`
<img width="1355" height="1254" alt="image" src="https://github.com/user-attachments/assets/b144b1c1-978c-435a-b166-35b1497fa041" />
