### PR TITLE
Support mlx-0.26.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
+  "mlx[cpu]",  # GH-1588
 ]
 dev = [
   "smolagents[quality,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ mcp = [
 ]
 mlx-lm = [
   "mlx-lm",
-  "mlx<0.26.5",  # Hotfix for GH-1587
 ]
 openai = [
   "openai>=1.58.1"


### PR DESCRIPTION
Support mlx-0.26.5.

See: https://github.com/ml-explore/mlx/issues/2390#issuecomment-3091445381
> We are changing the way we release to PyPi. Moving forward the linux cpu-only build you have to specify the [cpu] tag:
`pip install "mlx[cpu]"`
Relevant docs: https://ml-explore.github.io/mlx/build/html/install.html#cpu-only-linux

Fix #1588.