### PR TITLE
Replace deprecated ast.Num and ast.Str with ast.Constant in tool validation

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -197,7 +197,7 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
 
             # Check if the assignment is more complex than simple literals
             if not all(
-                isinstance(val, (ast.Str, ast.Num, ast.Constant, ast.Dict, ast.List, ast.Set))
+                isinstance(val, (ast.Constant, ast.Dict, ast.List, ast.Set))
                 for val in ast.walk(node.value)
             ):
                 for target in node.targets:
@@ -223,7 +223,7 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
                 if default is None:
                     if arg.arg != "self":
                         self.non_defaults.add(arg.arg)
-                elif not isinstance(default, (ast.Str, ast.Num, ast.Constant, ast.Dict, ast.List, ast.Set)):
+                elif not isinstance(default, (ast.Constant, ast.Dict, ast.List, ast.Set)):
                     self.non_literal_defaults.add(arg.arg)
 
     class_level_checker = ClassLevelChecker()

--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -196,10 +196,7 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
                     self.class_attributes.add(target.id)
 
             # Check if the assignment is more complex than simple literals
-            if not all(
-                isinstance(val, (ast.Constant, ast.Dict, ast.List, ast.Set))
-                for val in ast.walk(node.value)
-            ):
+            if not all(isinstance(val, (ast.Constant, ast.Dict, ast.List, ast.Set)) for val in ast.walk(node.value)):
                 for target in node.targets:
                     if isinstance(target, ast.Name):
                         self.complex_attributes.add(target.id)


### PR DESCRIPTION
I had the following warning :

DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead

ast.Str and ast.Num have been deprecated since Python 3.8 and will be removed in Python 3.14. Starting with Python 3.8, all literals (str, int, float, etc.) are represented by ast.Constant.