### PR TITLE
Pin smolagents version in generated requirements.txt

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -31,6 +31,7 @@ from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+import importlib.metadata
 
 from huggingface_hub import (
     CommitOperationAdd,
@@ -296,8 +297,16 @@ class Tool:
             validate_tool_attributes(self.__class__)
 
             tool_code = "from typing import Any, Optional\n" + instance_to_source(self, base_cls=Tool)
-
-        requirements = {el for el in get_imports(tool_code) if el not in sys.stdlib_module_names} | {"smolagents"}
+            
+        # Dynamically fetch the current smolagents version to ensure environment reproducibility.
+        try:
+            smolagents_version = importlib.metadata.version("smolagents")
+            smolagents_dependency = f"smolagents=={smolagents_version}"
+        except importlib.metadata.PackageNotFoundError:
+            # Fallback if smolagents is used locally without being installed
+            smolagents_dependency = "smolagents"
+        
+        requirements = {el for el in get_imports(tool_code) if el not in sys.stdlib_module_names} | {smolagents_dependency}
 
         return {"name": self.name, "code": tool_code, "requirements": sorted(requirements)}
 


### PR DESCRIPTION
I discovered some problems when I wanted to use push_to_hub function, and one of them is because : Traceback (most recent call last): File "/usr/local/lib/python3.10/site-packages/smolagents/agents.py", line 108, in populate_template return compiled_template.render(variables) File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 1295, in render self.environment.handle_exception() File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 942, in handle_exception raise rewrite_traceback_stack(source=source) File "<template>", line 6, in top-level template code jinja2.exceptions.UndefinedError: 'code_block_opening_tag' is undefined During handling of the above exception, another exception occurred

The issue is solved by the 1.20.0 version but the HuggingFace Space use the cached requirements.txt when it builds the container, so it use a previous version, the 1.19.0 ...



This commit resolves an issue where `agent.push_to_hub()` would generate a `requirements.txt` file without a specific version for `smolagents`.

**Problem:**
- The previous implementation hardcoded `"smolagents"` into the requirements list.
- On CI/CD platforms like Hugging Face Spaces, this could lead to build environments reusing an old cached layer with an outdated version of `smolagents`, even if a newer version was available on PyPI.
- This caused reproducibility issues and prevented users from getting critical bug fixes available in newer versions.

**Solution:**
- The `Tool.to_dict()` method in `smolagents/tools.py` has been updated to dynamically fetch the currently installed version of the `smolagents` library using `importlib.metadata`.
- It now generates a pinned version requirement (e.g., `smolagents==1.20.0`) in the `requirements.txt` file.
- This change ensures that any Space built using `push_to_hub` will have a reproducible environment that matches the user's local version, forcing the build cache to be invalidated when the version changes.