### PR TITLE
Add Tool to_code_prompt and to_tool_calling_prompt

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -322,9 +322,7 @@ final_answer(pope_current_age)
 
 Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools:
 {%- for tool in tools.values() %}
-- {{ tool.name }}: {{ tool.description }}
-    Takes inputs: {{tool.inputs}}
-    Returns an output of type: {{tool.output_type}}
+- {{ tool.to_tool_calling_prompt() }}
 {%- endfor %}
 
 {%- if managed_agents and managed_agents.values() | list %}
@@ -359,9 +357,7 @@ So while you can overwrite this system prompt template by passing your custom pr
 - To insert tool descriptions:
   ```
   {%- for tool in tools.values() %}
-  - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
-      Returns an output of type: {{tool.output_type}}
+  - {{ tool.to_tool_calling_prompt() }}
   {%- endfor %}
   ```
 - To insert the descriptions for managed agents if there are any:

--- a/docs/source/hi/tutorials/building_good_agents.md
+++ b/docs/source/hi/tutorials/building_good_agents.md
@@ -328,9 +328,7 @@ final_answer(pope_current_age)
 
 Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools:
 {%- for tool in tools.values() %}
-- {{ tool.name }}: {{ tool.description }}
-    Takes inputs: {{tool.inputs}}
-    Returns an output of type: {{tool.output_type}}
+- {{ tool.to_tool_calling_prompt() }}
 {%- endfor %}
 
 {%- if managed_agents and managed_agents.values() | list %}
@@ -364,9 +362,7 @@ Now Begin! If you solve the task correctly, you will receive a reward of $1,000,
 - टूल विवरण डालने के लिए।
   ```
   {%- for tool in tools.values() %}
-  - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
-      Returns an output of type: {{tool.output_type}}
+  - {{ tool.to_tool_calling_prompt() }}
   {%- endfor %}
   ```
 - यदि कोई मैनेज्ड एजेंट्स हैं तो उनके लिए विवरण डालने के लिए।

--- a/docs/source/zh/tutorials/building_good_agents.md
+++ b/docs/source/zh/tutorials/building_good_agents.md
@@ -326,9 +326,7 @@ final_answer(pope_current_age)
 
 Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools:
 {%- for tool in tools.values() %}
-- {{ tool.name }}: {{ tool.description }}
-    Takes inputs: {{tool.inputs}}
-    Returns an output of type: {{tool.output_type}}
+- {{ tool.to_tool_calling_prompt() }}
 {%- endfor %}
 
 {%- if managed_agents and managed_agents.values() | list %}
@@ -362,9 +360,7 @@ Now Begin! If you solve the task correctly, you will receive a reward of $1,000,
 - 用于插入工具描述。
   ```
   {%- for tool in tools.values() %}
-  - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
-      Returns an output of type: {{tool.output_type}}
+  - {{ tool.to_tool_calling_prompt() }}
   {%- endfor %}
   ```
 - 用于插入 managed agent 的描述（如果有）。

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -78,7 +78,7 @@ from .monitoring import (
     Monitor,
 )
 from .remote_executors import DockerExecutor, E2BExecutor, WasmExecutor
-from .tools import Tool, validate_tool_arguments
+from .tools import BaseTool, Tool, validate_tool_arguments
 from .utils import (
     AGENT_GRADIO_APP_TEMPLATE,
     AgentError,
@@ -359,7 +359,9 @@ class MultiStepAgent(ABC):
                 agent.output_type = "string"
 
     def _setup_tools(self, tools, add_base_tools):
-        assert all(isinstance(tool, Tool) for tool in tools), "All elements must be instance of Tool (or a subclass)"
+        assert all(isinstance(tool, BaseTool) for tool in tools), (
+            "All elements must be instance of BaseTool (or a subclass)"
+        )
         self.tools = {tool.name: tool for tool in tools}
         if add_base_tools:
             self.tools.update(

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -132,14 +132,7 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   {{code_block_opening_tag}}
   {%- for tool in tools.values() %}
-  def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-      """{{ tool.description }}
-
-      Args:
-      {%- for arg_name, arg_info in tool.inputs.items() %}
-          {{ arg_name }}: {{ arg_info.description }}
-      {%- endfor %}
-      """
+  {{ tool.to_code_prompt() }}
   {% endfor %}
   {{code_block_closing_tag}}
 
@@ -207,14 +200,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}
-        """
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 
@@ -275,13 +261,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}"""
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -78,14 +78,7 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   ```python
   {%- for tool in tools.values() %}
-  def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-      """{{ tool.description }}
-
-      Args:
-      {%- for arg_name, arg_info in tool.inputs.items() %}
-          {{ arg_name }}: {{ arg_info.description }}
-      {%- endfor %}
-      """
+  {{ tool.to_code_prompt() }}
   {% endfor %}
   ```
 
@@ -152,14 +145,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}
-        """
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 
@@ -220,13 +206,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}"""
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -91,9 +91,7 @@ system_prompt: |-
 
   Above example were using notional tools that might not exist for you. You only have access to these tools:
   {%- for tool in tools.values() %}
-  - {{ tool.name }}: {{ tool.description }}
-      Takes inputs: {{tool.inputs}}
-      Returns an output of type: {{tool.output_type}}
+  - {{ tool.to_tool_calling_prompt() }}
   {%- endfor %}
 
   {%- if managed_agents and managed_agents.values() | list %}
@@ -147,9 +145,7 @@ planning:
 
     You can leverage these tools:
     {%- for tool in tools.values() %}
-    - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
-        Returns an output of type: {{tool.output_type}}
+    - {{ tool.to_tool_calling_prompt() }}
     {%- endfor %}
 
     {%- if managed_agents and managed_agents.values() | list %}
@@ -203,9 +199,7 @@ planning:
 
     You can leverage these tools:
     {%- for tool in tools.values() %}
-    - {{ tool.name }}: {{ tool.description }}
-        Takes inputs: {{tool.inputs}}
-        Returns an output of type: {{tool.output_type}}
+    - {{ tool.to_tool_calling_prompt() }}
     {%- endfor %}
 
     {%- if managed_agents and managed_agents.values() | list %}

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -246,8 +246,8 @@ class Tool(BaseTool):
         self.is_initialized = True
 
     def to_code_prompt(self) -> str:
-        args_types = ", ".join(f"{arg_name}: {arg_schema['type']}" for arg_name, arg_schema in self.inputs.items())
-        tool_signature = f"({args_types}) -> {self.output_type}"
+        args_signature = ", ".join(f"{arg_name}: {arg_schema['type']}" for arg_name, arg_schema in self.inputs.items())
+        tool_signature = f"({args_signature}) -> {self.output_type}"
         tool_doc = self.description
         if self.inputs:
             args_descriptions = "\n".join(
@@ -255,7 +255,7 @@ class Tool(BaseTool):
             )
             args_doc = f"Args:\n{textwrap.indent(args_descriptions, '    ')}"
             tool_doc += f"\n\n{args_doc}"
-        tool_doc = '"""' + tool_doc + '\n"""'
+        tool_doc = f'"""{tool_doc}\n"""'
         return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"
 
     def to_tool_calling_prompt(self) -> str:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -255,7 +255,7 @@ class Tool(BaseTool):
             )
             args_doc = f"Args:\n{textwrap.indent(args_descriptions, '    ')}"
             tool_doc += f"\n\n{args_doc}"
-        tool_doc = '"""\n' + tool_doc + '\n"""'
+        tool_doc = '"""' + tool_doc + '\n"""'
         return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"
 
     def to_tool_calling_prompt(self) -> str:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -26,6 +26,7 @@ import tempfile
 import textwrap
 import types
 import warnings
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
@@ -94,7 +95,15 @@ AUTHORIZED_TYPES = [
 CONVERSION_DICT = {"str": "string", "int": "integer", "float": "number"}
 
 
-class Tool:
+class BaseTool(ABC):
+    name: str
+
+    @abstractmethod
+    def __call__(self, *args, **kwargs) -> Any:
+        pass
+
+
+class Tool(BaseTool):
     """
     A base class for the functions used by the agent. Subclass this and implement the `forward` method as well as the
     following class attributes:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -245,6 +245,22 @@ class Tool(BaseTool):
         """
         self.is_initialized = True
 
+    def to_code_prompt(self) -> str:
+        args_types = ", ".join(f"{arg_name}: {arg_schema['type']}" for arg_name, arg_schema in self.inputs.items())
+        tool_signature = f"({args_types}) -> {self.output_type}"
+        tool_doc = self.description
+        if self.inputs:
+            args_descriptions = "\n".join(
+                f"{arg_name}: {arg_schema['description']}" for arg_name, arg_schema in self.inputs.items()
+            )
+            args_doc = f"Args:\n{textwrap.indent(args_descriptions, '    ')}"
+            tool_doc += f"\n\n{args_doc}"
+        tool_doc = '"""\n' + tool_doc + '\n"""'
+        return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"
+
+    def to_tool_calling_prompt(self) -> str:
+        return f"{self.name}: {self.description}\n    Takes inputs: {self.inputs}\n    Returns an output of type: {self.output_type}"
+
     def to_dict(self) -> dict:
         """Returns a dictionary representing the tool"""
         class_name = self.__class__.__name__

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -320,6 +320,7 @@ def instance_to_source(instance, base_cls=None):
         name: value
         for name, value in cls.__dict__.items()
         if not name.startswith("__")
+        and not name == "_abc_impl"
         and not callable(value)
         and not (base_cls and hasattr(base_cls, name) and getattr(base_cls, name) == value)
     }

--- a/tests/fixtures/tools.py
+++ b/tests/fixtures/tools.py
@@ -20,6 +20,65 @@ def test_tool():
 
 
 @pytest.fixture
+def no_input_tool():
+    class NoInputTool(Tool):
+        name = "no_input_tool"
+        description = "Tool with no inputs"
+        inputs = {}
+        output_type = "string"
+
+        def forward(self):
+            return "test"
+
+    return NoInputTool()
+
+
+@pytest.fixture
+def single_input_tool():
+    class SingleInputTool(Tool):
+        name = "single_input_tool"
+        description = "Tool with one input"
+        inputs = {"text": {"type": "string", "description": "Input text"}}
+        output_type = "string"
+
+        def forward(self, text):
+            return "test"
+
+    return SingleInputTool()
+
+
+@pytest.fixture
+def multi_input_tool():
+    class MultiInputTool(Tool):
+        name = "multi_input_tool"
+        description = "Tool with multiple inputs"
+        inputs = {
+            "text": {"type": "string", "description": "Text input"},
+            "count": {"type": "integer", "description": "Number count"},
+        }
+        output_type = "object"
+
+        def forward(self, text, count):
+            return "test"
+
+    return MultiInputTool()
+
+
+@pytest.fixture
+def multiline_description_tool():
+    class MultilineDescriptionTool(Tool):
+        name = "multiline_description_tool"
+        description = "This is a tool with\nmultiple lines\nin the description"
+        inputs = {"input": {"type": "string", "description": "Some input"}}
+        output_type = "string"
+
+        def forward(self, input):
+            return "test"
+
+    return MultilineDescriptionTool()
+
+
+@pytest.fixture
 def example_tool():
     @tool
     def valid_tool_function(input: str) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -125,18 +125,18 @@ class TestTool:
     @pytest.mark.parametrize(
         "tool_fixture, expected_output",
         [
-            ("no_input_tool", 'def no_input_tool() -> string:\n    """\n    Tool with no inputs\n    """'),
+            ("no_input_tool", 'def no_input_tool() -> string:\n    """Tool with no inputs\n    """'),
             (
                 "single_input_tool",
-                'def single_input_tool(text: string) -> string:\n    """\n    Tool with one input\n\n    Args:\n        text: Input text\n    """',
+                'def single_input_tool(text: string) -> string:\n    """Tool with one input\n\n    Args:\n        text: Input text\n    """',
             ),
             (
                 "multi_input_tool",
-                'def multi_input_tool(text: string, count: integer) -> object:\n    """\n    Tool with multiple inputs\n\n    Args:\n        text: Text input\n        count: Number count\n    """',
+                'def multi_input_tool(text: string, count: integer) -> object:\n    """Tool with multiple inputs\n\n    Args:\n        text: Text input\n        count: Number count\n    """',
             ),
             (
                 "multiline_description_tool",
-                'def multiline_description_tool(input: string) -> string:\n    """\n    This is a tool with\n    multiple lines\n    in the description\n\n    Args:\n        input: Some input\n    """',
+                'def multiline_description_tool(input: string) -> string:\n    """This is a tool with\n    multiple lines\n    in the description\n\n    Args:\n        input: Some input\n    """',
             ),
         ],
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -122,6 +122,57 @@ class TestTool:
             tool = create_tool()
             assert isinstance(tool, Tool)
 
+    @pytest.mark.parametrize(
+        "tool_fixture, expected_output",
+        [
+            ("no_input_tool", 'def no_input_tool() -> string:\n    """\n    Tool with no inputs\n    """'),
+            (
+                "single_input_tool",
+                'def single_input_tool(text: string) -> string:\n    """\n    Tool with one input\n\n    Args:\n        text: Input text\n    """',
+            ),
+            (
+                "multi_input_tool",
+                'def multi_input_tool(text: string, count: integer) -> object:\n    """\n    Tool with multiple inputs\n\n    Args:\n        text: Text input\n        count: Number count\n    """',
+            ),
+            (
+                "multiline_description_tool",
+                'def multiline_description_tool(input: string) -> string:\n    """\n    This is a tool with\n    multiple lines\n    in the description\n\n    Args:\n        input: Some input\n    """',
+            ),
+        ],
+    )
+    def test_tool_to_code_prompt_output_format(self, tool_fixture, expected_output, request):
+        """Test that to_code_prompt generates properly formatted and indented output."""
+        tool = request.getfixturevalue(tool_fixture)
+        code_prompt = tool.to_code_prompt()
+        assert code_prompt == expected_output
+
+    @pytest.mark.parametrize(
+        "tool_fixture, expected_output",
+        [
+            (
+                "no_input_tool",
+                "no_input_tool: Tool with no inputs\n    Takes inputs: {}\n    Returns an output of type: string",
+            ),
+            (
+                "single_input_tool",
+                "single_input_tool: Tool with one input\n    Takes inputs: {'text': {'type': 'string', 'description': 'Input text'}}\n    Returns an output of type: string",
+            ),
+            (
+                "multi_input_tool",
+                "multi_input_tool: Tool with multiple inputs\n    Takes inputs: {'text': {'type': 'string', 'description': 'Text input'}, 'count': {'type': 'integer', 'description': 'Number count'}}\n    Returns an output of type: object",
+            ),
+            (
+                "multiline_description_tool",
+                "multiline_description_tool: This is a tool with\nmultiple lines\nin the description\n    Takes inputs: {'input': {'type': 'string', 'description': 'Some input'}}\n    Returns an output of type: string",
+            ),
+        ],
+    )
+    def test_tool_to_tool_calling_prompt_output_format(self, tool_fixture, expected_output, request):
+        """Test that to_tool_calling_prompt generates properly formatted output."""
+        tool = request.getfixturevalue(tool_fixture)
+        tool_calling_prompt = tool.to_tool_calling_prompt()
+        assert tool_calling_prompt == expected_output
+
     def test_tool_init_with_decorator(self):
         @tool
         def coolfunc(a: str, b: int) -> float:


### PR DESCRIPTION
Add `to_code_prompt` and `to_tool_calling_prompt` methods to Tool class.

This PR represents the first step in a broader refactoring of the tools system.

## Changes

### New Methods
This PR introduces two new methods to the `Tool` class to improve and generalize template rendering:
- `to_code_prompt()`: Generate properly formatted Python function definitions with docstrings for code agent prompts
- `to_tool_calling_prompt()`: Generate tool descriptions for tool-calling agent prompts

### Template Integration
- Update Jinja templates and replace hardcoded YAML generation with method calls

### Testing
- Added comprehensive pytest test suite covering:
  - Tools with no inputs
  - Tools with single/multiple inputs
  - Multi-line descriptions