### PR TITLE
Improve agent image handling

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -462,10 +462,11 @@ You have been provided with these additional arguments, that you can access dire
         if stream:
             # The steps are returned as they are executed through a generator to iterate on.
             return self._run_stream(task=self.task, max_steps=max_steps, images=images)
-        run_start_time = time.time()
-        # Outputs are returned only at the end. We only look at the last step.
 
+        run_start_time = time.time()
         steps = list(self._run_stream(task=self.task, max_steps=max_steps, images=images))
+
+        # Outputs are returned only at the end. We only look at the last step.
         assert isinstance(steps[-1], FinalAnswerStep)
         output = steps[-1].output
 
@@ -570,7 +571,7 @@ You have been provided with these additional arguments, that you can access dire
                 self.step_number += 1
 
         if not returned_final_answer and self.step_number == max_steps + 1:
-            final_answer = self._handle_max_steps_reached(task, images)
+            final_answer = self._handle_max_steps_reached(task)
             yield action_step
         yield FinalAnswerStep(handle_agent_output_types(final_answer))
 
@@ -585,9 +586,9 @@ You have been provided with these additional arguments, that you can access dire
         memory_step.timing.end_time = time.time()
         self.step_callbacks.callback(memory_step, agent=self)
 
-    def _handle_max_steps_reached(self, task: str, images: list["PIL.Image.Image"]) -> Any:
+    def _handle_max_steps_reached(self, task: str) -> Any:
         action_step_start_time = time.time()
-        final_answer = self.provide_final_answer(task, images)
+        final_answer = self.provide_final_answer(task)
         final_memory_step = ActionStep(
             step_number=self.step_number,
             error=AgentMaxStepsError("Reached max steps.", self.logger),
@@ -782,7 +783,7 @@ You have been provided with these additional arguments, that you can access dire
             )
         return rationale.strip(), action.strip()
 
-    def provide_final_answer(self, task: str, images: list["PIL.Image.Image"] | None = None) -> ChatMessage:
+    def provide_final_answer(self, task: str) -> ChatMessage:
         """
         Provide the final answer to the task, based on the logs of the agent's interactions.
 
@@ -804,8 +805,6 @@ You have been provided with these additional arguments, that you can access dire
                 ],
             )
         ]
-        if images:
-            messages[0].content += [{"type": "image", "image": image} for image in images]
         messages += self.write_memory_to_messages()[1:]
         messages.append(
             ChatMessage(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1177,44 +1177,38 @@ class TestMultiStepAgent:
                     assert content == expected_content
 
     @pytest.mark.parametrize(
-        "images, expected_messages_list",
+        "expected_messages_list",
         [
-            (
-                None,
+            [
                 [
-                    [
-                        ChatMessage(
-                            role=MessageRole.SYSTEM,
-                            content=[{"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"}],
-                        ),
-                        ChatMessage(
-                            role=MessageRole.USER,
-                            content=[{"type": "text", "text": "FINAL_ANSWER_USER_PROMPT"}],
-                        ),
-                    ]
-                ],
-            ),
-            (
-                ["image1.png"],
+                    ChatMessage(
+                        role=MessageRole.SYSTEM,
+                        content=[{"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"}],
+                    ),
+                    ChatMessage(
+                        role=MessageRole.USER,
+                        content=[{"type": "text", "text": "FINAL_ANSWER_USER_PROMPT"}],
+                    ),
+                ]
+            ],
+            [
                 [
-                    [
-                        ChatMessage(
-                            role=MessageRole.SYSTEM,
-                            content=[
-                                {"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"},
-                                {"type": "image", "image": "image1.png"},
-                            ],
-                        ),
-                        ChatMessage(
-                            role=MessageRole.USER,
-                            content=[{"type": "text", "text": "FINAL_ANSWER_USER_PROMPT"}],
-                        ),
-                    ]
-                ],
-            ),
+                    ChatMessage(
+                        role=MessageRole.SYSTEM,
+                        content=[
+                            {"type": "text", "text": "FINAL_ANSWER_SYSTEM_PROMPT"},
+                            {"type": "image", "image": "image1.png"},
+                        ],
+                    ),
+                    ChatMessage(
+                        role=MessageRole.USER,
+                        content=[{"type": "text", "text": "FINAL_ANSWER_USER_PROMPT"}],
+                    ),
+                ]
+            ],
         ],
     )
-    def test_provide_final_answer(self, images, expected_messages_list):
+    def test_provide_final_answer(self, expected_messages_list):
         fake_model = MagicMock()
         fake_model.generate.return_value = ChatMessage(
             role=MessageRole.ASSISTANT,
@@ -1228,7 +1222,7 @@ class TestMultiStepAgent:
             model=fake_model,
         )
         task = "Test task"
-        final_answer = agent.provide_final_answer(task, images=images).content
+        final_answer = agent.provide_final_answer(task).content
         expected_message_texts = {
             "FINAL_ANSWER_SYSTEM_PROMPT": agent.prompt_templates["final_answer"]["pre_messages"],
             "FINAL_ANSWER_USER_PROMPT": populate_template(


### PR DESCRIPTION
**Context**
I use `smolagents` to create a multimodel agent running an on-device VLM via `llama-server` and found inference to be quite slow. Looking at the logs, I realized that the image inputs are being processed in every VLM call (or agent step), which takes up a lot of processing time (2 seconds for each image). Ideally, the images should be processed once as the latent representations are already saved in the KV cache.

**Changes proposed**
We should not include images into ActionSteps in `agent.run` as they are already included in the TaskStep and saved to `agent.memory`. In other words, we only initialize images once in `agent.memory`. This allows the underlying VLM to process the images only once during the initial prefill and reduce latency for subsequent steps by exploiting the KV cache.

The same idea applies for `provide_final_answer`: the TaskStep is already stored in `agent.memory` which includes the original images passed into `agent.run`. There shouldn't be a need to include images in the final answer system prompt since they will be retrieved from `agent.memory`.

Next, I added support for sharing images between agents and only passing image(s) to the model only if it supports it. I contemplated creating another PR and decided not to as it builds on top of the previous change. The motivation is from my use case of running a task from a controller agent that is not multimodal, but can delegate tasks to its managed agents which can handle images.