### PR TITLE
Do not send variables if there is not any RemotePythonExecutor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -86,6 +86,8 @@ class RemotePythonExecutor(PythonExecutor):
         """
         Send variables to the kernel namespace using pickle.
         """
+        if not variables:
+            return
         pickled_vars = base64.b64encode(pickle.dumps(variables)).decode()
         code = f"""
 import pickle, base64

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -24,6 +24,12 @@ class TestRemotePythonExecutor:
         # No new packages should be installed
         assert "!pip install" not in executor.run_code_raise_errors.call_args.args[0]
 
+    def test_send_variables_with_empty_dict_is_noop(self):
+        executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())
+        executor.run_code_raise_errors = MagicMock()
+        executor.send_variables({})
+        assert executor.run_code_raise_errors.call_count == 0
+
     @require_run_all
     def test_send_tools_with_default_wikipedia_search_tool(self):
         tool = WikipediaSearchTool()


### PR DESCRIPTION
In `RemotePythonExecutor`, I think we do not need to run any code if there are no variables passed to `send_variables`.