### PR TITLE
Reset agent memory on GradioUI clear button

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -502,6 +502,7 @@ class GradioUI:
                 [text_input, submit_btn],
             )
 
+            chatbot.clear(self.agent.memory.reset)
         return demo
 
 


### PR DESCRIPTION
 Reset agent memory when the clear button is clicked in the Gradio chatbot interface.

Close #1609.