### PR TITLE
change default MCPClient transport to streamable-http

### DIFF
--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -48,7 +48,7 @@ class MCPClient:
               - "transport": Transport protocol to use, one of:
                 - "streamable-http": (recommended) Streamable HTTP transport.
                 - "sse": Legacy HTTP+SSE transport (deprecated).
-              If "transport" is omitted, the legacy "sse" transport is assumed (a deprecation warning will be issued).
+              If "transport" is omitted, it defaults to "streamable-http". A warning is issued to encourage explicit declaration.
 
             <Deprecated version="1.17.0">
             The HTTP+SSE transport is deprecated and future behavior will default to the Streamable HTTP transport.
@@ -93,12 +93,11 @@ class MCPClient:
             transport = server_parameters.get("transport")
             if transport is None:
                 warnings.warn(
-                    "Passing a dict as server_parameters without specifying the 'transport' key is deprecated. "
-                    "For now, it defaults to the legacy 'sse' (HTTP+SSE) transport, but this default will change "
-                    "to 'streamable-http' in version 1.20. Please add the 'transport' key explicitly. ",
+                    "Passing a dict as server_parameters without specifying the 'transport' key now defaults to 'streamable-http'. "
+                    "To silence this warning, explicitly pass transport='streamable-http'.",
                     FutureWarning,
                 )
-                transport = "sse"
+                transport = "streamable-http"
                 server_parameters["transport"] = transport
             if transport not in {"sse", "streamable-http"}:
                 raise ValueError(

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -58,3 +58,22 @@ def test_multiple_servers(echo_server_script: str):
         assert tools[1].name == "echo_tool"
         assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
         assert tools[1].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
+
+
+def test_default_transport_is_streamable_http(monkeypatch):
+    """Test that MCPClient defaults to 'streamable-http' transport when not specified."""
+    captured_parameters = {}
+
+    # Patch MCPAdapt to capture the server_parameters passed to it
+    def mock_init(self, server_parameters, *args, **kwargs):
+        nonlocal captured_parameters
+        captured_parameters = server_parameters
+        self.__enter__ = lambda: []  # mock tools
+        self.__exit__ = lambda *args: None
+
+    monkeypatch.setattr("smolagents.mcp_client.MCPAdapt.__init__", mock_init)
+
+    with pytest.warns(FutureWarning, match="now defaults to 'streamable-http'"):
+        MCPClient({"url": "http://dummy-url.com"})
+
+    assert captured_parameters["transport"] == "streamable-http"


### PR DESCRIPTION
### Summary

This PR updates the default behavior of `MCPClient` to use the `streamable-http` transport instead of the deprecated `sse` protocol when no `transport` is explicitly provided in `server_parameters`.

### Changes

- Default transport is now `"streamable-http"` if not specified.
- Updated warning message accordingly.
- Reflects change introduced in version 1.20.0 of `mcp`.

### Why?

As of v1.20.0, the `"sse"` transport is deprecated. This change aligns the default behavior with the new recommended standard and avoids future breakage.