### PR TITLE
CI hotfix: Pin transformers < 4.54.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ toolkit = [
 ]
 transformers = [
   "accelerate",
-  "transformers>=4.0.0",
+  "transformers>=4.0.0,<4.54.0",  # Hotfix for GH-1619
   "smolagents[torch]",
 ]
 vision = [


### PR DESCRIPTION
CI hotfix: Pin transformers < 4.54.0.

Fix #1619.