### PR TITLE
Feat: Add input validation for `max_steps` in agent initialization

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -290,7 +290,8 @@ class MultiStepAgent(ABC):
                         assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
                             f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
                         )
-
+        if not isinstance(max_steps, int) or max_steps <= 0:
+            raise ValueError("max_steps must be a positive integer.")
         self.max_steps = max_steps
         self.step_number = 0
         if grammar is not None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -485,6 +485,11 @@ class TestAgent:
         )
         assert "Remember this" in agent.task
 
+    @pytest.mark.parametrize("invalid_max_steps", [0, -1, 5.5, "ten"])
+    def test_invalid_max_steps_raises_error(self, invalid_max_steps):
+        with pytest.raises(ValueError, match="max_steps must be a positive integer."):
+            CodeAgent(tools=[], model=Model(), max_steps=invalid_max_steps)
+
     def test_reset_conversations(self):
         agent = CodeAgent(tools=[PythonInterpreterTool()], model=FakeCodeModel())
         output = agent.run("What is 2 multiplied by 3.6452?", reset=True)


### PR DESCRIPTION
**Problem:**
The `max_steps` parameter, intended to limit the ReAct loop, previously accepted invalid values (e.g., zero, negative numbers, non-integers) without raising an error. This could lead to unexpected agent behavior, infinite loops, or runtime crashes.

**Solution:**
This PR adds input validation for the `max_steps` parameter in `MultiStepAgent` to ensure it's a positive integer, preventing potential runtime errors from invalid inputs. It also includes a new unit test to verify the validation logic.

**Files Modified:**
- `src/smolagents/agents.py`
- `tests/test_agents.py`