### PR TITLE
ToolCallingAgent: remove unncessary addition to model_output

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1392,13 +1392,9 @@ class ToolCallingAgent(MultiStepAgent):
                     yield tool_output
 
         memory_step.tool_calls = [parallel_calls[k] for k in sorted(parallel_calls.keys())]
-        memory_step.model_output = memory_step.model_output or ""
         memory_step.observations = memory_step.observations or ""
         for tool_output in [outputs[k] for k in sorted(outputs.keys())]:
-            message = f"Tool call {tool_output.id}: calling '{tool_output.tool_call.name}' with arguments: {tool_output.tool_call.arguments}\n"
-            memory_step.model_output += message
             memory_step.observations += tool_output.observation + "\n"
-        memory_step.model_output = memory_step.model_output.rstrip("\n")
         memory_step.observations = (
             memory_step.observations.rstrip("\n") if memory_step.observations else memory_step.observations
         )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1718,7 +1718,6 @@ class TestToolCallingAgent:
                         function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "test_value"}),
                     )
                 ],
-                "expected_model_output": "Tool call call_1: calling 'test_tool' with arguments: {'input': 'test_value'}",
                 "expected_observations": "Processed: test_value",
                 "expected_final_outputs": ["Processed: test_value"],
                 "expected_error": None,
@@ -1737,7 +1736,6 @@ class TestToolCallingAgent:
                         function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
                     ),
                 ],
-                "expected_model_output": "Tool call call_1: calling 'test_tool' with arguments: {'input': 'value1'}\nTool call call_2: calling 'test_tool' with arguments: {'input': 'value2'}",
                 "expected_observations": "Processed: value1\nProcessed: value2",
                 "expected_final_outputs": ["Processed: value1", "Processed: value2"],
                 "expected_error": None,
@@ -1767,7 +1765,6 @@ class TestToolCallingAgent:
             # Case 4: Empty tool calls list
             {
                 "tool_calls": [],
-                "expected_model_output": "",
                 "expected_observations": "",
                 "expected_final_outputs": [],
                 "expected_error": None,
@@ -1783,7 +1780,6 @@ class TestToolCallingAgent:
                         ),
                     )
                 ],
-                "expected_model_output": "Tool call call_1: calling 'final_answer' with arguments: {'answer': 'This is the final answer'}",
                 "expected_observations": "This is the final answer",
                 "expected_final_outputs": ["This is the final answer"],
                 "expected_error": None,
@@ -1807,7 +1803,7 @@ class TestToolCallingAgent:
         # Create chat message with the specified tool calls for process_tool_calls
         chat_message = ChatMessage(role=MessageRole.ASSISTANT, content="", tool_calls=test_case["tool_calls"])
         # Create a memory step for process_tool_calls
-        memory_step = ActionStep(step_number=10, timing="mock_timing")
+        memory_step = ActionStep(step_number=10, timing="mock_timing", model_output="")
 
         # Process tool calls
         if test_case["expected_error"]:
@@ -1815,7 +1811,7 @@ class TestToolCallingAgent:
                 list(agent.process_tool_calls(chat_message, memory_step))
         else:
             final_outputs = list(agent.process_tool_calls(chat_message, memory_step))
-            assert memory_step.model_output == test_case["expected_model_output"]
+            assert memory_step.model_output == ""
             assert memory_step.observations == test_case["expected_observations"]
             assert [
                 final_output.output for final_output in final_outputs if isinstance(final_output, ToolOutput)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -116,7 +116,7 @@ class FakeToolCallModel(Model):
         if len(messages) < 3:
             return ChatMessage(
                 role=MessageRole.ASSISTANT,
-                content="",
+                content="I will call the python interpreter.",
                 tool_calls=[
                     ChatMessageToolCall(
                         id="call_0",
@@ -130,7 +130,7 @@ class FakeToolCallModel(Model):
         else:
             return ChatMessage(
                 role=MessageRole.ASSISTANT,
-                content="",
+                content="I will return the final answer.",
                 tool_calls=[
                     ChatMessageToolCall(
                         id="call_1",
@@ -421,10 +421,7 @@ class TestAgent:
         assert "7.2904" in output
         assert agent.memory.steps[0].task == "What is 2 multiplied by 3.6452?"
         assert "7.2904" in agent.memory.steps[1].observations
-        assert (
-            agent.memory.steps[2].model_output
-            == "Tool call call_1: calling 'final_answer' with arguments: {'answer': '7.2904'}"
-        )
+        assert agent.memory.steps[2].model_output == "I will return the final answer."
 
     def test_toolcalling_agent_handles_image_tool_outputs(self, shared_datadir):
         import PIL.Image
@@ -615,7 +612,6 @@ class TestAgent:
         agent.replay()
 
         str_output = agent_logger.console.export_text()
-        assert "Tool call" in str_output
         assert "arguments" in str_output
 
     def test_code_nontrivial_final_answer_works(self):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -42,7 +42,7 @@ class FakeLLMModel(Model):
         if tools_to_call_from is not None:
             return ChatMessage(
                 role=MessageRole.ASSISTANT,
-                content="",
+                content="I will call the final_answer tool.",
                 tool_calls=[
                     ChatMessageToolCall(
                         id="fake_id",


### PR DESCRIPTION
Currently in `ToolCallingAgent`, `memory_step.model_output` is augmented by appending a formatted string representing every tool call.
- I think it is not necessary. It was originally intended to better visualize tool calls in Gradio interfaces. But these interfaces now visualize the content of `step.tool_calls` directly
- it has the unintended effect of showing LLMs a wrong history of past messages. The artifact that it created for me is that the model would see tool call descriptions in history, thus it would start to write itself `Tool call {id}: calling {name} with {arguments}` instead of using JSON action format.

Thus we can remove it!