### PR TITLE
fix(Tool.forward): raise the NotImplementedError instead of return

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -216,7 +216,7 @@ class Tool(BaseTool):
                     )
 
     def forward(self, *args, **kwargs):
-        return NotImplementedError("Write this method in your subclass of `Tool`.")
+        raise NotImplementedError("Write this method in your subclass of `Tool`.")
 
     def __call__(self, *args, sanitize_inputs_outputs: bool = False, **kwargs):
         if not self.is_initialized:


### PR DESCRIPTION
Hello! Although returning an Exception is grammatically possible, based on the context, it should be raising this Exception. I guess there might have been an accidental mistake here, so I corrected it.