### PR TITLE
Make validate_tool_arguments raise exception instead of returning error string

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1430,9 +1430,10 @@ class ToolCallingAgent(MultiStepAgent):
         arguments = self._substitute_state_variables(arguments)
         is_managed_agent = tool_name in self.managed_agents
 
-        error_msg = validate_tool_arguments(tool, arguments)
-        if error_msg:
-            raise AgentToolCallError(error_msg, self.logger)
+        try:
+            validate_tool_arguments(tool, arguments)
+        except (ValueError, TypeError) as e:
+            raise AgentToolCallError(str(e), self.logger) from e
 
         try:
             # Call tool with appropriate arguments

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1434,6 +1434,9 @@ class ToolCallingAgent(MultiStepAgent):
             validate_tool_arguments(tool, arguments)
         except (ValueError, TypeError) as e:
             raise AgentToolCallError(str(e), self.logger) from e
+        except Exception as e:
+            error_msg = f"Error executing tool '{tool_name}' with arguments {str(arguments)}: {type(e).__name__}: {e}"
+            raise AgentToolExecutionError(error_msg, self.logger) from e
 
         try:
             # Call tool with appropriate arguments

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -1261,7 +1261,30 @@ def get_tools_definition_code(tools: dict[str, Tool]) -> str:
     return tool_definition_code
 
 
-def validate_tool_arguments(tool: Tool, arguments: Any) -> str | None:
+def validate_tool_arguments(tool: Tool, arguments: Any) -> None:
+    """Validate tool arguments against tool's input schema.
+
+    Checks that all provided arguments match the tool's expected input types and that
+    all required arguments are present. Supports both dictionary arguments and single
+    value arguments for tools with one input parameter.
+
+    Args:
+        tool (`Tool`): Tool whose input schema will be used for validation.
+        arguments (`Any`): Arguments to validate. Can be a dictionary mapping
+            argument names to values, or a single value for tools with one input.
+
+
+    Raises:
+        ValueError: If an argument is not in the tool's input schema, if a required
+            argument is missing, or if the argument value doesn't match the expected type.
+        TypeError: If an argument has an incorrect type that cannot be converted
+            (e.g., string instead of number, excluding integer to number conversion).
+
+    Note:
+        - Supports type coercion from integer to number
+        - Handles nullable parameters when explicitly marked in the schema
+        - Accepts "any" type as a wildcard that matches all types
+    """
     if isinstance(arguments, dict):
         for key, value in arguments.items():
             if key not in tool.inputs:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -1265,7 +1265,7 @@ def validate_tool_arguments(tool: Tool, arguments: Any) -> str | None:
     if isinstance(arguments, dict):
         for key, value in arguments.items():
             if key not in tool.inputs:
-                return f"Argument {key} is not in the tool's input schema."
+                raise ValueError(f"Argument {key} is not in the tool's input schema")
 
             actual_type = _get_json_schema_type(type(value))["type"]
             expected_type = tool.inputs[key]["type"]
@@ -1279,18 +1279,17 @@ def validate_tool_arguments(tool: Tool, arguments: Any) -> str | None:
             ):
                 if actual_type == "integer" and expected_type == "number":
                     continue
-                return f"Argument {key} has type '{actual_type}' but should be '{tool.inputs[key]['type']}'."
+                raise TypeError(f"Argument {key} has type '{actual_type}' but should be '{tool.inputs[key]['type']}'")
 
         for key, schema in tool.inputs.items():
             key_is_nullable = schema.get("nullable", False)
             if key not in arguments and not key_is_nullable:
-                return f"Argument {key} is required."
+                raise ValueError(f"Argument {key} is required")
         return None
     else:
         expected_type = list(tool.inputs.values())[0]["type"]
         if _get_json_schema_type(type(arguments))["type"] != expected_type and not expected_type == "any":
-            return f"Argument has type '{type(arguments).__name__}' but should be '{expected_type}'."
-        return None
+            raise TypeError(f"Argument has type '{type(arguments).__name__}' but should be '{expected_type}'")
 
 
 __all__ = [

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -820,11 +820,13 @@ def test_validate_tool_arguments(tool_input_type, expected_input, expects_error)
         """
         return argument_a
 
-    error = validate_tool_arguments(test_tool, {"argument_a": expected_input})
     if expects_error:
-        assert error is not None
+        with pytest.raises((ValueError, TypeError)):
+            validate_tool_arguments(test_tool, {"argument_a": expected_input})
+
     else:
-        assert error is None
+        # Should not raise any exception
+        validate_tool_arguments(test_tool, {"argument_a": expected_input})
 
 
 @pytest.mark.parametrize(
@@ -834,9 +836,9 @@ def test_validate_tool_arguments(tool_input_type, expected_input, expects_error)
         # - Valid input
         ("required_unsupported_none", str, ..., "text", None),
         # - None not allowed
-        ("required_unsupported_none", str, ..., None, "Argument param has type 'null' but should be 'string'."),
+        ("required_unsupported_none", str, ..., None, "Argument param has type 'null' but should be 'string'"),
         # - Missing required parameter is not allowed
-        ("required_unsupported_none", str, ..., ..., "Argument param is required."),
+        ("required_unsupported_none", str, ..., ..., "Argument param is required"),
         #
         # Required parameters but supports None
         # - Valid input
@@ -845,13 +847,13 @@ def test_validate_tool_arguments(tool_input_type, expected_input, expects_error)
         ("required_supported_none", str | None, ..., None, None),
         # - Missing required parameter is not allowed
         # TODO: Fix this test case: property is marked as nullable because it can be None, but it can't be missing because it is required
-        # ("required_supported_none", str | None, ..., ..., "Argument param is required."),
+        # ("required_supported_none", str | None, ..., ..., "Argument param is required"),
         pytest.param(
             "required_supported_none",
             str | None,
             ...,
             ...,
-            "Argument param is required.",
+            "Argument param is required",
             marks=pytest.mark.skip(reason="TODO: Fix this test case"),
         ),
         #
@@ -860,13 +862,13 @@ def test_validate_tool_arguments(tool_input_type, expected_input, expects_error)
         ("optional_unsupported_none", str, "default", "text", None),
         # - None not allowed
         # TODO: Fix this test case: property is marked as nullable because it has a default value, but it can't be None
-        # ("optional_unsupported_none", str, "default", None, "Argument param has type 'null' but should be 'string'."),
+        # ("optional_unsupported_none", str, "default", None, "Argument param has type 'null' but should be 'string'"),
         pytest.param(
             "optional_unsupported_none",
             str,
             "default",
             None,
-            "Argument param has type 'null' but should be 'string'.",
+            "Argument param has type 'null' but should be 'string'",
             marks=pytest.mark.skip(reason="TODO: Fix this test case"),
         ),
         # - Missing optional parameter is allowed
@@ -916,9 +918,10 @@ def test_validate_tool_arguments_nullable(scenario, type_hint, default, input_va
 
     # Test with the input dictionary
     input_dict = {"param": input_value} if input_value is not ... else {}
-    error = validate_tool_arguments(test_tool, input_dict)
 
     if expected_error_message:
-        assert error == expected_error_message, f"Expected error for {scenario}"
+        with pytest.raises((ValueError, TypeError), match=expected_error_message):
+            validate_tool_arguments(test_tool, input_dict)
     else:
-        assert error is None, f"Unexpected error for {scenario}"
+        # Should not raise any exception
+        validate_tool_arguments(test_tool, input_dict)


### PR DESCRIPTION
Make `validate_tool_arguments` raise exception instead of returning error string, improving code design and following Python conventions.

### Changes Made

- **Updated `validate_tool_arguments`**: Now raises `ValueError` and `TypeError` directly instead of returning error message strings
- **Removed periods from error messages**: Following Python best practices for exception messages
- **Updated docstring**: Added comprehensive `Raises` section documenting all possible exceptions
- **Updated tests**: Modified `test_validate_tool_arguments` and `test_validate_tool_arguments_nullable` to use `pytest.raises()` for exception testing
- **Simplified caller code**: The caller in `execute_tool_call` now has cleaner exception handling with proper exception chaining using `from e`

### Benefits

1. **Removes tight coupling**: The validation function is no longer tightly coupled to its caller that needs to convert returned error strings into exceptions
2. **Pythonic approach**: Uses standard Python exceptions (`ValueError`/`TypeError`) following established conventions
3. **Better error handling**: Proper exception chaining preserves the original context with `from e`
4. **Cleaner separation of concerns**: Validation logic is separated from error handling context
5. **Consistent with Python stdlib**: Follows the same pattern used throughout the Python standard library

### Exception Types
- `ValueError`: For invalid argument values (missing required args, args not in schema, etc.)
- `TypeError`: For type mismatches that cannot be converted

The caller catches these exceptions and reraises them as `AgentToolCallError` with proper context, maintaining the existing error handling flow while improving the internal design.