### PR TITLE
Bug Fix: Fix continue semantics of LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -985,12 +985,9 @@ def evaluate_for(
                 if line_result is not None:
                     result = line_result
             except BreakException:
-                break
+                return result
             except ContinueException:
-                continue
-        else:
-            continue
-        break
+                break
     return result
 
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -991,20 +991,6 @@ S4 = S1.intersection(S2)
         assert state["S3"] == {"a"}
         assert state["S4"] == {"b", "c"}
 
-    def test_break(self):
-        code = """
-i = 0
-
-while True:
-    i+= 1
-    if i==3:
-        break
-
-i"""
-        result, is_final_answer = evaluate_python_code(code, {"print": print, "round": round}, state={})
-        assert result == 3
-        assert not is_final_answer
-
     def test_return(self):
         # test early returns
         code = """

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -532,6 +532,10 @@ print(check_digits)
         result, _ = evaluate_python_code(code, {"range": range}, state={})
         assert result == 0
 
+        code = "cnt = 0\nfor i in range(3):\n    if i == 1:\n        continue\n    cnt += 1\ncnt"
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == 2
+
     def test_call_int(self):
         code = "import math\nstr(math.ceil(149))"
         result, _ = evaluate_python_code(code, {"str": lambda x: str(x)}, state={})

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -526,6 +526,10 @@ print(check_digits)
         result, _ = evaluate_python_code(code, {"range": range}, state={})
         assert result == 9
 
+        code = "cnt = 0\nfor i in range(10):\n    continue\n    cnt += 1\ncnt"
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == 0
+
     def test_call_int(self):
         code = "import math\nstr(math.ceil(149))"
         result, _ = evaluate_python_code(code, {"str": lambda x: str(x)}, state={})

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -517,15 +517,17 @@ print(check_digits)
         result, _ = evaluate_python_code(code, {}, state={})
         assert result == {10, 19, 20}
 
-    def test_break_continue(self):
+    def test_break(self):
         code = "for i in range(10):\n    if i == 5:\n        break\ni"
         result, _ = evaluate_python_code(code, {"range": range}, state={})
         assert result == 5
 
-        code = "for i in range(10):\n    if i == 5:\n        continue\ni"
+    def test_pass(self):
+        code = "for i in range(10):\n    if i == 5:\n        pass\ni"
         result, _ = evaluate_python_code(code, {"range": range}, state={})
         assert result == 9
 
+    def test_continue(self):
         code = "cnt = 0\nfor i in range(10):\n    continue\n    cnt += 1\ncnt"
         result, _ = evaluate_python_code(code, {"range": range}, state={})
         assert result == 0


### PR DESCRIPTION
## Bug: `continue` treated as `pass` within for loops with LocalPythonExecutor

### Fix
The proposed fix is to make continue statements break from the current execution of the loop body and continue to the next loop iteration.

### Problem Description
The local python interpreter incorrectly handles continue statements within `for` loops. A `continue` statement is treated as a `pass` statement which silently breaks normal Python semantics.

### Minimal Bug Reproduction:
```python
from smolagents.local_python_executor import LocalPythonExecutor, BASE_PYTHON_TOOLS

# this program should not print anything
program = """for i in range(5):
  continue
  print(i)"""

executor = LocalPythonExecutor(additional_authorized_imports=[])
executor.send_tools(BASE_PYTHON_TOOLS)

print(executor(program).logs)
```
Output:
```
0
1
2
3
4

```

The output from the above code is incorrect based on the semantics of a Python `continue` statement which should skip to the next loop iteration rather than execute the rest of the loop body.