### PR TITLE
refactor(PythonExecutor): inherit from ABC and declare abstract methods

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,16 +1611,13 @@ class CodeOutput:
 
 class PythonExecutor(ABC):
     @abstractmethod
-    def send_tools(self, tools: dict[str, Tool]) -> None:
-        pass
+    def send_tools(self, tools: dict[str, Tool]) -> None: ...
 
     @abstractmethod
-    def send_variables(self, variables: dict[str, Any]) -> None:
-        pass
+    def send_variables(self, variables: dict[str, Any]) -> None: ...
 
     @abstractmethod
-    def __call__(self, code_action: str) -> CodeOutput:
-        pass
+    def __call__(self, code_action: str) -> CodeOutput: ...
 
 
 class LocalPythonExecutor(PythonExecutor):

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import math
 import re
+from abc import ABC
 from collections.abc import Callable, Generator, Mapping
 from dataclasses import dataclass
 from functools import wraps
@@ -1608,8 +1609,15 @@ class CodeOutput:
     is_final_answer: bool
 
 
-class PythonExecutor:
-    pass
+class PythonExecutor(ABC):
+    def send_tools(self, tools: dict[str, Tool]):
+        raise NotImplementedError("should be implemented in subclass")
+
+    def send_variables(self, variables: dict):
+        raise NotImplementedError("should be implemented in subclass")
+
+    def __call__(self, code_action: str) -> CodeOutput:
+        raise NotImplementedError("should be implemented in subclass")
 
 
 class LocalPythonExecutor(PythonExecutor):

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -21,7 +21,7 @@ import inspect
 import logging
 import math
 import re
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Mapping
 from dataclasses import dataclass
 from functools import wraps
@@ -1610,14 +1610,17 @@ class CodeOutput:
 
 
 class PythonExecutor(ABC):
-    def send_tools(self, tools: dict[str, Tool]):
-        raise NotImplementedError("should be implemented in subclass")
+    @abstractmethod
+    def send_tools(self, tools: dict[str, Tool]) -> None:
+        pass
 
-    def send_variables(self, variables: dict):
-        raise NotImplementedError("should be implemented in subclass")
+    @abstractmethod
+    def send_variables(self, variables: dict[str, Any]) -> None:
+        pass
 
+    @abstractmethod
     def __call__(self, code_action: str) -> CodeOutput:
-        raise NotImplementedError("should be implemented in subclass")
+        pass
 
 
 class LocalPythonExecutor(PythonExecutor):
@@ -1687,7 +1690,7 @@ class LocalPythonExecutor(PythonExecutor):
         logs = str(self.state["_print_outputs"])
         return CodeOutput(output=output, logs=logs, is_final_answer=is_final_answer)
 
-    def send_variables(self, variables: dict):
+    def send_variables(self, variables: dict[str, Any]):
         self.state.update(variables)
 
     def send_tools(self, tools: dict[str, Tool]):

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -82,7 +82,7 @@ class RemotePythonExecutor(PythonExecutor):
             code_output = self.run_code_raise_errors(code)
             self.logger.log(code_output.logs)
 
-    def send_variables(self, variables: dict):
+    def send_variables(self, variables: dict[str, Any]):
         """
         Send variables to the kernel namespace using pickle.
         """


### PR DESCRIPTION
This PR enriches the details of the `PythonExecutor` class:
1. Added method declaration.
2. Declares its inherited abstract base class.

Hope this small change will allow others to get more LSP hints when using this class:)