### PR TITLE
Enable return_full_result directly in run method

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -402,7 +402,7 @@ class MultiStepAgent(ABC):
         additional_args: dict | None = None,
         max_steps: int | None = None,
         return_full_result: bool | None = None,
-    ):
+    ) -> Any | RunResult:
         """
         Run the agent for the given task.
 

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -249,6 +249,7 @@ class MultiStepAgent(ABC):
             Each function should:
             - Take the final answer and the agent's memory as arguments.
             - Return a boolean indicating whether the final answer is valid.
+        return_full_result (`bool`, default `False`): Whether to return the full [`RunResult`] object or just the final answer output from the agent run.
     """
 
     def __init__(

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -400,7 +400,7 @@ class MultiStepAgent(ABC):
         images: list["PIL.Image.Image"] | None = None,
         additional_args: dict | None = None,
         max_steps: int | None = None,
-        return_full_result: bool = False,
+        return_full_result: bool | None = None,
     ):
         """
         Run the agent for the given task.
@@ -459,7 +459,7 @@ You have been provided with these additional arguments, that you can access dire
         assert isinstance(steps[-1], FinalAnswerStep)
         output = steps[-1].output
 
-        if self.return_full_result or return_full_result:
+        if return_full_result or (return_full_result is None and self.return_full_result):
             total_input_tokens = 0
             total_output_tokens = 0
             correct_token_usage = True

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -400,6 +400,7 @@ class MultiStepAgent(ABC):
         images: list["PIL.Image.Image"] | None = None,
         additional_args: dict | None = None,
         max_steps: int | None = None,
+        return_full_result: bool = False,
     ):
         """
         Run the agent for the given task.
@@ -413,6 +414,7 @@ class MultiStepAgent(ABC):
             images (`list[PIL.Image.Image]`, *optional*): Image(s) objects.
             additional_args (`dict`, *optional*): Any other variables that you want to pass to the agent run, for instance images or dataframes. Give them clear names!
             max_steps (`int`, *optional*): Maximum number of steps the agent can take to solve the task. if not provided, will use the agent's default value.
+            return_full_result (`bool`, defaults to `False`): Whether to return the full result of the agent run.
 
         Example:
         ```py
@@ -457,7 +459,7 @@ You have been provided with these additional arguments, that you can access dire
         assert isinstance(steps[-1], FinalAnswerStep)
         output = steps[-1].output
 
-        if self.return_full_result:
+        if self.return_full_result or return_full_result:
             total_input_tokens = 0
             total_output_tokens = 0
             correct_token_usage = True

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -414,7 +414,8 @@ class MultiStepAgent(ABC):
             images (`list[PIL.Image.Image]`, *optional*): Image(s) objects.
             additional_args (`dict`, *optional*): Any other variables that you want to pass to the agent run, for instance images or dataframes. Give them clear names!
             max_steps (`int`, *optional*): Maximum number of steps the agent can take to solve the task. if not provided, will use the agent's default value.
-            return_full_result (`bool`, defaults to `False`): Whether to return the full result of the agent run.
+            return_full_result (`bool`, *optional*): Whether to return the full [`RunResult`] object or just the final answer output.
+                If `None` (default), the agent's `self.return_full_result` setting is used.
 
         Example:
         ```py

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -460,7 +460,8 @@ You have been provided with these additional arguments, that you can access dire
         assert isinstance(steps[-1], FinalAnswerStep)
         output = steps[-1].output
 
-        if return_full_result or (return_full_result is None and self.return_full_result):
+        return_full_result = return_full_result if return_full_result is not None else self.return_full_result
+        if return_full_result:
             total_input_tokens = 0
             total_output_tokens = 0
             correct_token_usage = True

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -47,7 +47,9 @@ class FakeLLMModel(Model):
                     ChatMessageToolCall(
                         id="fake_id",
                         type="function",
-                        function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "image"}),
+                        function=ChatMessageToolCallFunction(
+                            name="final_answer", arguments={"answer": "This is the final answer."}
+                        ),
                     )
                 ],
                 token_usage=TokenUsage(input_tokens=10, output_tokens=20) if self.give_token_usage else None,
@@ -140,9 +142,23 @@ class MonitoringTester(unittest.TestCase):
         self.assertIn("This is the final answer.", final_message.content)
 
     def test_streaming_agent_image_output(self):
+        class FakeLLMModelImage(Model):
+            def generate(self, prompt, **kwargs):
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="I will call the final_answer tool.",
+                    tool_calls=[
+                        ChatMessageToolCall(
+                            id="fake_id",
+                            type="function",
+                            function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "image"}),
+                        )
+                    ],
+                )
+
         agent = ToolCallingAgent(
             tools=[],
-            model=FakeLLMModel(),
+            model=FakeLLMModelImage(),
             max_steps=1,
             verbosity_level=100,
         )
@@ -181,38 +197,24 @@ class MonitoringTester(unittest.TestCase):
         self.assertEqual(final_message.role, "assistant")
         self.assertIn("Malformed call", final_message.content)
 
-    def test_run_result_no_token_usage(self):
-        agent = CodeAgent(
-            tools=[],
-            model=FakeLLMModel(give_token_usage=False),
-            max_steps=1,
-            return_full_result=True,
-        )
 
-        result = agent.run("Fake task")
+@pytest.mark.parametrize("agent_class", [CodeAgent, ToolCallingAgent])
+def test_run_result_no_token_usage(agent_class):
+    agent = agent_class(
+        tools=[],
+        model=FakeLLMModel(give_token_usage=False),
+        max_steps=1,
+        return_full_result=True,
+    )
 
-        self.assertIsInstance(result, RunResult)
-        self.assertEqual(result.output, "This is the final answer.")
-        self.assertEqual(result.state, "success")
-        self.assertIsNone(result.token_usage)
-        self.assertIsInstance(result.messages, list)
-        self.assertGreater(result.timing.duration, 0)
+    result = agent.run("Fake task")
 
-        agent = ToolCallingAgent(
-            tools=[],
-            model=FakeLLMModel(give_token_usage=False),
-            max_steps=1,
-            return_full_result=True,
-        )
-
-        result = agent.run("Fake task")
-
-        self.assertIsInstance(result, RunResult)
-        self.assertEqual(result.output, "image")
-        self.assertEqual(result.state, "success")
-        self.assertIsNone(result.token_usage)
-        self.assertIsInstance(result.messages, list)
-        self.assertGreater(result.timing.duration, 0)
+    assert isinstance(result, RunResult)
+    assert result.output == "This is the final answer."
+    assert result.state == "success"
+    assert result.token_usage is None
+    assert isinstance(result.messages, list)
+    assert result.timing.duration > 0
 
 
 @pytest.mark.parametrize(
@@ -235,7 +237,7 @@ def test_run_return_full_result(init_return_full_result, run_return_full_result,
 
     if expect_runresult:
         assert isinstance(result, RunResult)
-        assert result.output == "image"
+        assert result.output == "This is the final answer."
         assert result.state == "success"
         assert result.token_usage == TokenUsage(input_tokens=10, output_tokens=20)
         assert isinstance(result.messages, list)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -218,6 +218,29 @@ class MonitoringTester(unittest.TestCase):
         assert agent.monitor.total_input_token_count == 10
         assert agent.monitor.total_output_token_count == 20
 
+        # Test argument precedence: return_full_result=False should override the agent's return_full_result
+        agent = ToolCallingAgent(
+            tools=[],
+            model=FakeLLMModel(),
+            max_steps=1,
+            return_full_result=True,
+        )
+
+        result = agent.run("Fake task", return_full_result=False)
+
+        self.assertIsInstance(result, str)
+
+        agent = ToolCallingAgent(
+            tools=[],
+            model=FakeLLMModel(),
+            max_steps=1,
+            return_full_result=False,
+        )
+
+        result = agent.run("Fake task", return_full_result=True)
+
+        self.assertIsInstance(result, RunResult)
+
     def test_run_result_no_token_usage(self):
         agent = CodeAgent(
             tools=[],

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -65,29 +65,6 @@ final_answer('This is the final answer.')
 
 
 class MonitoringTester(unittest.TestCase):
-    def test_code_agent_metrics(self):
-        agent = CodeAgent(
-            tools=[],
-            model=FakeLLMModel(),
-            max_steps=1,
-        )
-        agent.run("Fake task")
-
-        self.assertEqual(agent.monitor.total_input_token_count, 10)
-        self.assertEqual(agent.monitor.total_output_token_count, 20)
-
-    def test_toolcalling_agent_metrics(self):
-        agent = ToolCallingAgent(
-            tools=[],
-            model=FakeLLMModel(),
-            max_steps=1,
-        )
-
-        agent.run("Fake task")
-
-        self.assertEqual(agent.monitor.total_input_token_count, 10)
-        self.assertEqual(agent.monitor.total_output_token_count, 20)
-
     def test_code_agent_metrics_max_steps(self):
         class FakeLLMModelMalformedAnswer(Model):
             def generate(self, prompt, **kwargs):
@@ -244,3 +221,16 @@ def test_run_return_full_result(init_return_full_result, run_return_full_result,
         assert result.timing.duration > 0
     else:
         assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("agent_class", [CodeAgent, ToolCallingAgent])
+def test_code_agent_metrics(agent_class):
+    agent = agent_class(
+        tools=[],
+        model=FakeLLMModel(),
+        max_steps=1,
+    )
+    agent.run("Fake task")
+
+    assert agent.monitor.total_input_token_count == 10
+    assert agent.monitor.total_output_token_count == 20


### PR DESCRIPTION
I find myself often mistakenly passing argument `return_full_result` in the `run()` method instead of agent initialization: 
and indeed the choice to return full results can be run-specific rather than agent-specific. Thus I think it would be best to integrate this arg in the run() method as well.