### PR TITLE
Fix boto3.converse call to make AmazonBedrockServerModel work with ToolCallingAgent

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1850,7 +1850,20 @@ class AmazonBedrockServerModel(ApiModel):
         )
         self._apply_rate_limit()
         # self.client is created in ApiModel class
-        response = self.client.converse(**completion_kwargs)
+        converse_api_args = [
+            "modelId",
+            "messages",
+            "system",
+            "inferenceConfig",
+            "toolConfig",
+            "guardrailConfig",
+            "additionalModelRequestFields",
+            "promptVariables",
+            "additionalModelResponseFieldPaths",
+            "requestMetadata",
+            "performanceConfig",
+        ]
+        response = self.client.converse(**{k: v for k, v in completion_kwargs.items() if k in converse_api_args})
 
         # Get last message content block in case thinking mode is enabled: discard thinking
         last_message_content_block = response["output"]["message"]["content"][-1]


### PR DESCRIPTION
Resolves https://github.com/huggingface/smolagents/issues/1432

This pull request fixes an issue where the `AmazonBedrockServerModel` fails when used with `ToolCallingAgent`. The root cause is that the `boto3.converse` method rejects unsupported arguments passed to it. Specifically, the method was receiving `"tools"` and `"toolConfig"`, which are not valid parameters for the API call.

By filtering the arguments passed to `boto3.converse` and only including those that are explicitly supported by the API, this fix allows `AmazonBedrockServerModel` to function correctly with `ToolCallingAgent`.

#### Example:

```python
from smolagents import AmazonBedrockServerModel, ToolCallingAgent, WikipediaSearchTool

bedrock_model = AmazonBedrockServerModel(model_id="eu.amazon.nova-lite-v1:0")
agent = ToolCallingAgent(tools=[WikipediaSearchTool()], model=bedrock_model)
agent.run("Which year was Hugging Face founded?")
```

Without this fix, attempting to use `AmazonBedrockServerModel` with `ToolCallingAgent` results in a `Parameter validation failed` error.

```
smolagents.utils.AgentGenerationError: Error while generating output:
Parameter validation failed:
Unknown parameter in input: "tools", must be one of: modelId, messages, system, inferenceConfig, toolConfig, guardrailConfig, additionalModelRequestFields, promptVariables, additionalModelResponseFieldPaths, requestMetadata, performanceConfig
Unknown parameter in input: "tool_choice", must be one of: modelId, messages, system, inferenceConfig, toolConfig, guardrailConfig, additionalModelRequestFields, promptVariables, additionalModelResponseFieldPaths, requestMetadata, performanceConfig
```

With this fix, the `AmazonBedrockServerModel` correctly handles tool calls, enabling the `ToolCallingAgent` to function as expected.

```
╭────────────────────────────────────────────────────────────────────────────────────────── New run ───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                              │
│ Which year was Hugging Face founded?                                                                                                                                                         │
│                                                                                                                                                                                              │
╰─ AmazonBedrockServerModel - eu.amazon.nova-lite-v1:0 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Calling tool: 'wikipedia_search' with arguments: {'query': 'Hugging Face'}                                                                                                                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Observations: ✅ **Wikipedia Page:** Hugging Face

**Content:** Hugging Face, Inc. is an American company based in New York City that develops computation tools for building applications using machine learning. It is most notable for its 
transformers library built for natural language processing applications and its platform that allows users to share machine learning models and datasets and showcase their work.

History
The company was founded in 2016 by French entrepreneurs Clément Delangue, Julien Chaumond, and Thomas Wolf in New York City, originally as a company that developed a chatbot app targeted at 
teenagers. The company was named after the U+1F917 🤗 HUGGING FACE emoji. After open sourcing the model behind the chatbot, the company pivoted to focus on being a platform for machine 
learning.
In March 2021, Hugging Face raised US$40 million in a Series B funding round.
On April 28, 2021, the company launched the BigScience Research Workshop in collaboration with several other research groups to release an open large language model. In 2022, the workshop 
concluded with the announcement of BLOOM, a multilingual large language model with 176 billion parameters.
In December 2022, the company acquired Gradio, an open source library built for developing machine learning applications in Python.
On May 5, 2022, the company announced its Series C funding round led by Coatue and Sequoia. The company received a $2 billion valuation.
On August 3, 2022, the company announced the Private Hub, an enterprise version of its public Hugging Face Hub that supports SaaS or on-premises deployment.
In February 2023, the company announced partnership with Amazon Web Services (AWS) which would allow Hugging Face's products to be available to AWS customers to use them as the building blocks
for their custom applications. The company also said the next generation of BLOOM will be run on Trainium, a proprietary machine learning chip created by AWS.
In August 2023, the company announced that it raised $235 million in a Series D funding round, at a $4.5 billion valuation. The funding was led by Salesforce and notable participation came 
from Google, Amazon, Nvidia, AMD, Intel, IBM, and Qualcomm.
In June 2024, the company announced, along with Meta and Scaleway, their launch of a new AI accelerator program for European startups. This initiative aims to help startups integrate open 
foundation models into their products, accelerating the EU AI ecosystem. The program, based at STATION F in Paris, will run from September 2024 to February 2025. Selected startups will receive
mentoring, access to AI models and tools, and Scaleway’s computing power.
On September 23, 2024, to further the International Decade of Indigenous Languages, Hugging Face teamed up with Meta and UNESCO to launch a new online language translator built on Meta's No 
Language Left Behind open-source AI model, enabling free text translation across 200 languages, including many low-resource languages.
On April 2025, Hugging Face announced that they acquired a humanoid robotics startup, Pollen Robotics. Pollen Robotics is a France based Robotics Startup founded by Matthieu Lapeyre and Pierre
Rouanet in 2016. In an X tweet, Clément Delangue, CEO of Hugging Face, shared his vision to make Artificial Intelligence robotics Open Source.

Services and technologies
Transformers Library
The Transformers library is a Python package that contains open-source implementations of transformer models for text, image, and audio tasks. It is mainly compatible with the PyTorch library,
but previous versions were also compatible with TensorFlow and JAX deep learning libraries. It includes implementations of notable models like BERT and GPT-2. The library was originally called
"pytorch-pretrained-bert" which was then renamed to "pytorch-transformers" and finally "transformers."
A JavaScript version (Transformers.js) has also been developed, allowing models to run directly in the browser through the ONNX runtime.

Hugging Face Hub
The Hugging Face Hub is a platform (centralized web service) for hosting:

Git-based code repositories, including discussions and pull requests for projects;
models, also with Git-based version control;
datasets, mainly in text, images, and audio;
web applications ("spaces" and "widgets"), intended for small-scale demos of machine learning applications.
There are numerous pre-trained models that support common tasks in different modalities, such as:

Natural Language Processing: text classification, named entity recognition, question answering, language modeling, summarization, translation, multiple choice, and text generation.
Computer Vision: image classification, object detection, and segmentation.
Audio: automatic speech recognition and audio classification.

Other libraries
In addition to Transformers and the Hugging Face Hub, the Hugging Face ecosystem contains libraries for other tasks, such as dataset processing ("Datasets"), model evaluation ("Evaluate"), 
image generation ("Diffusers"), and machine learning demos ("Gradio").

Safetensors
The safetensors format was developed around 2021 to solve problems with the pickle format in Python. It was designed for saving and loading tensors. Compared to the pickle format, it allows 
lazy loading and avoids security problems. After a security audit, it became the default format in 2023.
The file format:

size of the header: 8 bytes, an unsigned little-endian 64-bit integer.
header: JSON UTF-8 string, formatted as {"TENSOR_NAME": {“dtype”: “F16”, “shape”: |1, 16, 256], “data_offsets”: |BEGIN, END]}, "NEXT_TENSOR_NAME": {…}, …}.
file: a byte buffer containing the tensors.

See also
OpenAI
Station F
Kaggle

References
External links
Official website

🔗 **Read more:** https://en.wikipedia.org/wiki/Hugging_Face
[Step 1: Duration 2.89 seconds| Input tokens: 902 | Output tokens: 26]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 2 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Calling tool: 'final_answer' with arguments: {'answer': '2016'}                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Observations: 2016
Final answer: 2016
[Step 2: Duration 0.69 seconds| Input tokens: 3,185 | Output tokens: 52]
```