### PR TITLE
Fix error for GPT-5 not supporting the `stop` parameter

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -359,7 +359,7 @@ def supports_stop_parameter(model_id: str) -> bool:
     """
     Check if the model supports the `stop` parameter.
 
-    Not supported with reasoning models openai/o3 and openai/o4-mini (and their versioned variants).
+    Not supported with reasoning models openai/o3, openai/o4-mini, and the openai/gpt-5 series (and their versioned variants).
 
     Args:
         model_id (`str`): Model identifier (e.g. "openai/o3", "o4-mini-2025-04-16")
@@ -368,8 +368,8 @@ def supports_stop_parameter(model_id: str) -> bool:
         bool: True if the model supports the stop parameter, False otherwise
     """
     model_name = model_id.split("/")[-1]
-    # o3 and o4-mini (including versioned variants, o3-2025-04-16) don't support stop parameter
-    pattern = r"^(o3[-\d]*|o4-mini[-\d]*)$"
+    # o3, o4-mini, and the gpt-5 series (including versioned variants, o3-2025-04-16) don't support stop parameter
+    pattern = r"^(o3[-\d]*|o4-mini[-\d]*|gpt-5(-mini|-nano)?[-\d]*)$"
     return not re.match(pattern, model_name)
 
 


### PR DESCRIPTION
The `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` models do not support the `stop` parameter.

```console
smolagents.utils.AgentGenerationError: Error while generating output:
Error code: 400 - {'error': {'message': "Unsupported parameter: 'stop' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'stop', 'code': 'unsupported_parameter'}}
```