### PR TITLE
Support MCP structured output and output schema

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -130,7 +130,7 @@ To access gated models or rise your rate limits with a PRO account, you need to 
 ```python
 from smolagents import CodeAgent, InferenceClientModel
 
-model_id = "meta-llama/Llama-3.3-70B-Instruct" 
+model_id = "meta-llama/Llama-3.3-70B-Instruct"
 
 model = InferenceClientModel(model_id=model_id, token="<YOUR_HUGGINGFACEHUB_API_TOKEN>") # You can choose to not pass any model_id to InferenceClientModel to use a default model
 # you can also specify a particular provider e.g. provider="together" or provider="sambanova"
@@ -377,6 +377,8 @@ A tool is an atomic function to be used by an agent. To be used by an LLM, it al
 You can for instance check the [`PythonInterpreterTool`]: it has a name, a description, input descriptions, an output type, and a `forward` method to perform the action.
 
 When the agent is initialized, the tool attributes are used to generate a tool description which is baked into the agent's system prompt. This lets the agent know which tools it can use and why.
+
+**Schema Information**: For tools that have an `output_schema` defined (such as MCP tools with structured output), the `CodeAgent` system prompt automatically includes the JSON schema information. This helps the agent understand the expected structure of tool outputs and access the data appropriately.
 
 ### Default toolbox
 

--- a/docs/source/en/reference/tools.md
+++ b/docs/source/en/reference/tools.md
@@ -39,7 +39,7 @@ contains the API docs for the underlying classes.
 ## Agent Types
 
 Agents can handle any type of object in-between tools; tools, being completely multimodal, can accept and return
-text, image, audio, video, among other types. In order to increase compatibility between tools, as well as to 
+text, image, audio, video, among other types. In order to increase compatibility between tools, as well as to
 correctly render these returns in ipython (jupyter, colab, ipython notebooks, ...), we implement wrapper classes
 around these types.
 

--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -184,10 +184,10 @@ Here is what you get:
 ```text
 You are an expert assistant who can solve any task using code blobs. You will be given a task to solve as best you can.
 To do so, you have been given access to a list of tools: these tools are basically Python functions which you can call with code.
-To solve the task, you must plan forward to proceed in a series of steps, in a cycle of 'Thought:', 'Code:', and 'Observation:' sequences.
+To solve the task, you must plan forward to proceed in a series of steps, in a cycle of Thought, Code, and Observation sequences.
 
 At each step, in the 'Thought:' sequence, you should first explain your reasoning towards solving the task and the tools that you want to use.
-Then in the 'Code:' sequence, you should write the code in simple Python. The code sequence must end with '<end_code>' sequence.
+Then in the Code sequence you should write the code in simple Python. The code sequence must be opened with '{{code_block_opening_tag}}', and closed with '{{code_block_closing_tag}}'.
 During each intermediate step, you can use 'print()' to save whatever important information you will then need.
 These print outputs will then appear in the 'Observation:' field, which will be available as input for the next step.
 In the end you have to return a final answer using the `final_answer` tool.
@@ -197,26 +197,26 @@ Here are a few examples using notional tools:
 Task: "Generate an image of the oldest person in this document."
 
 Thought: I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.
-<code>
+{{code_block_opening_tag}}
 answer = document_qa(document=document, question="Who is the oldest person mentioned?")
 print(answer)
-</code>
+{{code_block_closing_tag}}
 Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
 
 Thought: I will now generate an image showcasing the oldest person.
-<code>
+{{code_block_opening_tag}}
 image = image_generator("A portrait of John Doe, a 55-year-old man living in Canada.")
 final_answer(image)
-</code>
+{{code_block_closing_tag}}
 
 ---
 Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
 Thought: I will use python code to compute the result of the operation and then return the final answer using the `final_answer` tool
-<code>
+{{code_block_opening_tag}}
 result = 5 + 3 + 1294.678
 final_answer(result)
-</code>
+{{code_block_closing_tag}}
 
 ---
 Task:
@@ -225,12 +225,12 @@ You have been provided with these additional arguments, that you can access usin
 {'question': 'Quel est l'animal sur l'image?', 'image': 'path/to/image.jpg'}"
 
 Thought: I will use the following tools: `translator` to translate the question into English and then `image_qa` to answer the question on the input image.
-<code>
+{{code_block_opening_tag}}
 translated_question = translator(question=question, src_lang="French", tgt_lang="English")
 print(f"The translated question is {translated_question}.")
 answer = image_qa(image=image, question=translated_question)
 final_answer(f"The answer is {answer}")
-</code>
+{{code_block_closing_tag}}
 
 ---
 Task:
@@ -238,20 +238,18 @@ In a 1979 interview, Stanislaus Ulam discusses with Martin Sherwin about other g
 What does he say was the consequence of Einstein learning too much math on his creativity, in one word?
 
 Thought: I need to find and read the 1979 interview of Stanislaus Ulam with Martin Sherwin.
-Code:
-```py
-pages = search(query="1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein")
+{{code_block_opening_tag}}
+pages = web_search(query="1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein")
 print(pages)
-```<end_code>
+{{code_block_closing_tag}}
 Observation:
 No result found for query "1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein".
 
 Thought: The query was maybe too restrictive and did not find any results. Let's try again with a broader query.
-Code:
-```py
-pages = search(query="1979 interview Stanislaus Ulam")
+{{code_block_opening_tag}}
+pages = web_search(query="1979 interview Stanislaus Ulam")
 print(pages)
-```<end_code>
+{{code_block_closing_tag}}
 Observation:
 Found 6 pages:
 [Stanislaus Ulam 1979 interview](https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/)
@@ -261,13 +259,12 @@ Found 6 pages:
 (truncated)
 
 Thought: I will read the first 2 pages to know more.
-Code:
-```py
+{{code_block_opening_tag}}
 for url in ["https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/", "https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/"]:
     whole_page = visit_webpage(url)
     print(whole_page)
     print("\n" + "="*80 + "\n")  # Print separator between pages
-```<end_code>
+{{code_block_closing_tag}}
 Observation:
 Manhattan Project Locations:
 Los Alamos, NM
@@ -275,80 +272,89 @@ Stanislaus Ulam was a Polish-American mathematician. He worked on the Manhattan 
 (truncated)
 
 Thought: I now have the final answer: from the webpages visited, Stanislaus Ulam says of Einstein: "He learned too much mathematics and sort of diminished, it seems to me personally, it seems to me his purely physics creativity." Let's answer in one word.
-Code:
-```py
+{{code_block_opening_tag}}
 final_answer("diminished")
-```<end_code>
+{{code_block_closing_tag}}
 
 ---
 Task: "Which city has the highest population: Guangzhou or Shanghai?"
 
-Thought: I need to get the populations for both cities and compare them: I will use the tool `search` to get the population of both cities.
-Code:
-```py
+Thought: I need to get the populations for both cities and compare them: I will use the tool `web_search` to get the population of both cities.
+{{code_block_opening_tag}}
 for city in ["Guangzhou", "Shanghai"]:
-    print(f"Population {city}:", search(f"{city} population")
-```<end_code>
+    print(f"Population {city}:", web_search(f"{city} population")
+{{code_block_closing_tag}}
 Observation:
 Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
 Population Shanghai: '26 million (2019)'
 
 Thought: Now I know that Shanghai has the highest population.
-Code:
-```py
+{{code_block_opening_tag}}
 final_answer("Shanghai")
-```<end_code>
+{{code_block_closing_tag}}
 
 ---
 Task: "What is the current age of the pope, raised to the power 0.36?"
 
-Thought: I will use the tool `wiki` to get the age of the pope, and confirm that with a web search.
-Code:
-```py
-pope_age_wiki = wiki(query="current pope age")
+Thought: I will use the tool `wikipedia_search` to get the age of the pope, and confirm that with a web search.
+{{code_block_opening_tag}}
+pope_age_wiki = wikipedia_search(query="current pope age")
 print("Pope age as per wikipedia:", pope_age_wiki)
 pope_age_search = web_search(query="current pope age")
 print("Pope age as per google search:", pope_age_search)
-```<end_code>
+{{code_block_closing_tag}}
 Observation:
 Pope age: "The pope Francis is currently 88 years old."
 
 Thought: I know that the pope is 88 years old. Let's compute the result using python code.
-Code:
-```py
+{{code_block_opening_tag}}
 pope_current_age = 88 ** 0.36
 final_answer(pope_current_age)
-```<end_code>
+{{code_block_closing_tag}}
 
-Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools:
+Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
+{{code_block_opening_tag}}
 {%- for tool in tools.values() %}
-- {{ tool.to_tool_calling_prompt() }}
-{%- endfor %}
+{{ tool.to_code_prompt() }}
+{% endfor %}
+{{code_block_closing_tag}}
 
 {%- if managed_agents and managed_agents.values() | list %}
 You can also give tasks to team members.
 Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
 You can also include any relevant variables or context using the 'additional_args' argument.
 Here is a list of the team members that you can call:
+{{code_block_opening_tag}}
 {%- for agent in managed_agents.values() %}
-- {{ agent.name }}: {{ agent.description }}
-{%- endfor %}
-{%- else %}
+def {{ agent.name }}(task: str, additional_args: dict[str, Any]) -> str:
+    """{{ agent.description }}
+
+    Args:
+        task: Long detailed description of the task.
+        additional_args: Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.
+    """
+{% endfor %}
+{{code_block_closing_tag}}
 {%- endif %}
 
 Here are the rules you should always follow to solve your task:
-1. Always provide a 'Thought:' sequence, and a 'Code:\n```py' sequence ending with '```<end_code>' sequence, else you will fail.
+1. Always provide a 'Thought:' sequence, and a '{{code_block_opening_tag}}' sequence ending with '{{code_block_closing_tag}}', else you will fail.
 2. Use only variables that you have defined!
-3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wiki({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wiki(query="What is the place where James Bond lives?")'.
-4. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
-5. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
-6. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
-7. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
-8. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
-9. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
-10. Don't give up! You're in charge of solving the task, not providing directions to solve it.
+3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
+4. For tools WITHOUT JSON output schema: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
+5. For tools WITH JSON output schema: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
+6. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
+7. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
+8. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
+9. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
+10. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
+11. Don't give up! You're in charge of solving the task, not providing directions to solve it.
 
-Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
+{%- if custom_instructions %}
+{{custom_instructions}}
+{%- endif %}
+
+Now Begin!
 ```
 
 As you can see, there are placeholders like `"{{ tool.description }}"`: these will be used upon agent initialization to insert certain automatically generated descriptions of tools or managed agents.

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -245,7 +245,9 @@ with MCPClient(server_parameters, structured_output=True) as tools:
 
 When structured output is enabled, the `CodeAgent` system prompt is enhanced to include JSON schema information for tools, helping the agent understand the expected structure of tool outputs and access the data appropriately.
 
-**Backwards Compatibility**: The `structured_output` parameter defaults to `False` to maintain backwards compatibility. Existing code will continue to work without changes, receiving simple text outputs as before.
+**Backwards Compatibility**: The `structured_output` parameter currently defaults to `False` to maintain backwards compatibility. Existing code will continue to work without changes, receiving simple text outputs as before.
+
+**Future Change**: In a future release, the default value of `structured_output` will change from `False` to `True`. It is recommended to explicitly set `structured_output=True` to opt into the enhanced functionality, which provides better tool output handling and improved agent performance. Use `structured_output=False` only if you specifically need to maintain the current text-only behavior.
 
 ### Import a Space as a tool
 

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -120,7 +120,7 @@ with MCPClient({"url": "http://127.0.0.1:8000/mcp", "transport": "streamable-htt
 
 #### Structured Output and Output Schema Support
 
-The latest MCP specifications (2025-06-18+) include support for `outputSchema`, which enables tools to return structured data with defined schemas. `smolagents` takes advantage of these structured output capabilities, allowing agents to work with tools that return complex data structures, JSON objects, and other structured formats. With this feature, the agent's LLMs can "see" the structure of the tool output before calling a tool, enabling more intelligent and context-aware interactions.
+The latest [MCP specifications (2025-06-18+)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) include support for `outputSchema`, which enables tools to return structured data with defined schemas. `smolagents` takes advantage of these structured output capabilities, allowing agents to work with tools that return complex data structures, JSON objects, and other structured formats. With this feature, the agent's LLMs can "see" the structure of the tool output before calling a tool, enabling more intelligent and context-aware interactions.
 
 To enable structured output support, pass `structured_output=True` when initializing the `MCPClient`:
 

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -118,6 +118,79 @@ with MCPClient({"url": "http://127.0.0.1:8000/mcp", "transport": "streamable-htt
     agent.run("Please find a remedy for hangover.")
 ```
 
+#### Structured Output and Output Schema Support
+
+The latest MCP specifications (2025-06-18+) include support for `outputSchema`, which enables tools to return structured data with defined schemas. `smolagents` takes advantage of these structured output capabilities, allowing agents to work with tools that return complex data structures, JSON objects, and other structured formats. With this feature, the agent's LLMs can "see" the structure of the tool output before calling a tool, enabling more intelligent and context-aware interactions.
+
+To enable structured output support, pass `structured_output=True` when initializing the `MCPClient`:
+
+```python
+from smolagents import MCPClient, CodeAgent
+
+# Enable structured output support
+with MCPClient(server_parameters, structured_output=True) as tools:
+    agent = CodeAgent(tools=tools, model=model, add_base_tools=True)
+    agent.run("Get weather information for Paris")
+```
+
+When `structured_output=True`, the following features are enabled:
+- **Output Schema Support**: Tools can define JSON schemas for their outputs
+- **Structured Content Handling**: Support for `structuredContent` in MCP responses
+- **JSON Parsing**: Automatic parsing of structured data from tool responses
+
+Here's an example using a weather MCP server with structured output:
+
+```python
+# demo/weather.py - Example MCP server with structured output
+from pydantic import BaseModel, Field
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("Weather Service")
+
+class WeatherInfo(BaseModel):
+    location: str = Field(description="The location name")
+    temperature: float = Field(description="Temperature in Celsius")
+    conditions: str = Field(description="Weather conditions")
+    humidity: int = Field(description="Humidity percentage", ge=0, le=100)
+
+@mcp.tool(
+    name="get_weather_info",
+    description="Get weather information for a location as structured data.",
+    # structured_output=True is enabled by default in FastMCP
+)
+def get_weather_info(city: str) -> WeatherInfo:
+    """Get weather information for a city."""
+    return WeatherInfo(
+        location=city,
+        temperature=22.5,
+        conditions="partly cloudy",
+        humidity=65
+    )
+```
+
+Agent using output schema and structured output:
+
+```python
+from smolagents import MCPClient, CodeAgent
+
+# Using the weather server with structured output
+from mcp import StdioServerParameters
+
+server_parameters = StdioServerParameters(
+    command="python",
+    args=["demo/weather.py"]
+)
+
+with MCPClient(server_parameters, structured_output=True) as tools:
+    agent = CodeAgent(tools=tools, model=model)
+    result = agent.run("What's the weather like in London?")
+    print(result)
+```
+
+When structured output is enabled, the `CodeAgent` system prompt is enhanced to include JSON schema information for tools, helping the agent understand the expected structure of tool outputs and access the data appropriately.
+
+**Backwards Compatibility**: The `structured_output` parameter defaults to `False` to maintain backwards compatibility. Existing code will continue to work without changes, receiving simple text outputs as before.
+
 You can also manually manage the connection lifecycle with the try...finally pattern:
 
 ```python
@@ -296,6 +369,13 @@ server_parameters = StdioServerParameters(
 )
 
 with ToolCollection.from_mcp(server_parameters, trust_remote_code=True) as tool_collection:
+    agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
+    agent.run("Please find a remedy for hangover.")
+```
+
+To enable structured output support with ToolCollection, add the `structured_output=True` parameter:
+```py
+with ToolCollection.from_mcp(server_parameters, trust_remote_code=True, structured_output=True) as tool_collection:
     agent = CodeAgent(tools=[*tool_collection.tools], model=model, add_base_tools=True)
     agent.run("Please find a remedy for hangover.")
 ```

--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -183,7 +183,7 @@ server_parameters = StdioServerParameters(
 
 with MCPClient(server_parameters, structured_output=True) as tools:
     agent = CodeAgent(tools=tools, model=model)
-    result = agent.run("What's the weather like in London?")
+    result = agent.run("What is the temperature in Tokyo in Fahrenheit?")
     print(result)
 ```
 

--- a/examples/structured_output_tool.py
+++ b/examples/structured_output_tool.py
@@ -1,0 +1,77 @@
+# How to run with uv:
+#   uv run structured_output_tool.py
+#
+# Modify the smolagents dependency to point to the local smolagents repo or
+# remove `@ file:///Users/chahn/smolagents`
+#
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "smolagents[mcp,litellm] @ file:///Users/chahn/smolagents",
+#   "pydantic",
+# ]
+# ///
+
+from textwrap import dedent
+
+from mcp import StdioServerParameters
+
+from smolagents import CodeAgent, InferenceClientModel, LiteLLMModel, MCPClient  # noqa: F401
+
+
+def weather_server_script() -> str:
+    """Return an inline MCP server script that exposes a weather tool."""
+    return dedent(
+        '''
+        from pydantic import BaseModel, Field
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Weather Service")
+
+        class WeatherInfo(BaseModel):
+            location: str = Field(description="The location name")
+            temperature: float = Field(description="Temperature in Celsius")
+            conditions: str = Field(description="Weather conditions")
+            humidity: int = Field(description="Humidity percentage", ge=0, le=100)
+
+        @mcp.tool(
+            name="get_weather_info",
+            description="Get weather information for a location as structured data.",
+        )
+        def get_weather_info(city: str) -> WeatherInfo:
+            """Get weather information for a city."""
+            return WeatherInfo(
+                location=city,
+                temperature=22.5,
+                conditions="partly cloudy",
+                humidity=65
+            )
+
+        mcp.run()
+        '''
+    )
+
+
+def main() -> None:
+    # Configure your inference model
+    # model = InferenceClientModel()
+    model = LiteLLMModel(
+        model_id="mistral/mistral-small-latest",
+        # model_id="openai/gpt-4o-mini",
+    )
+
+    # Start the Weather MCP server from an inline script in this same file
+    serverparams = StdioServerParameters(command="python", args=["-c", weather_server_script()])
+
+    # Bridge MCP tools into SmolAgents with structured outputs enabled
+    with MCPClient(
+        serverparams,
+        structured_output=True,
+    ) as tools:
+        agent = CodeAgent(tools=tools, model=model)
+        # Example query that encourages tool use and unit conversion
+        agent.run("What is the temperature in Tokyo in Fahrenheit?")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/structured_output_tool.py
+++ b/examples/structured_output_tool.py
@@ -7,7 +7,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "smolagents[mcp,litellm] @ file:///Users/chahn/smolagents",
+#   "smolagents[mcp,litellm] @ file:///<path-to-smolagents>",
 #   "pydantic",
 # ]
 # ///

--- a/examples/structured_output_tool.py
+++ b/examples/structured_output_tool.py
@@ -2,7 +2,7 @@
 #   uv run structured_output_tool.py
 #
 # Modify the smolagents dependency to point to the local smolagents repo or
-# remove `@ file:///Users/chahn/smolagents`
+# remove `@ file:///<path-to-smolagents>`
 #
 # /// script
 # requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ openai = [
 ]
 telemetry = [
   "arize-phoenix",
-  "opentelemetry-sdk", 
+  "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
   "openinference-instrumentation-smolagents>=0.1.4"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ litellm = [
   "litellm>=1.60.2",
 ]
 mcp = [
-  "mcpadapt>=0.1.11",  # Support Image and Audio content
+  "mcpadapt>=0.1.13",  # Support Image and Audio content
   "mcp",
 ]
 mlx-lm = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ litellm = [
   "litellm>=1.60.2",
 ]
 mcp = [
-  "mcpadapt>=0.1.13",  # Support Image and Audio content
+  "mcpadapt>=0.1.13",  # Support structured output
   "mcp",
 ]
 mlx-lm = [

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -102,7 +102,9 @@ class MCPClient:
                     f"Unsupported transport: {transport}. Supported transports are 'streamable-http' and 'sse'."
                 )
         adapter_kwargs = adapter_kwargs or {}
-        self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter(structured_output=structured_output), **adapter_kwargs)
+        self._adapter = MCPAdapt(
+            server_parameters, SmolAgentsAdapter(structured_output=structured_output), **adapter_kwargs
+        )
         self._tools: list[Tool] | None = None
         self.connect()
 

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -91,9 +91,9 @@ class MCPClient:
         # Handle future warning for structured_output default value change
         if structured_output is None:
             warnings.warn(
-                "The 'structured_output' parameter was not specified and currently defaults to False. "
-                "In a future release, the default will change to True. "
-                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (current behavior). "
+                "Parameter 'structured_output' was not specified. "
+                "Currently it defaults to False, but in version 1.25, the default will change to True. "
+                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (legacy behavior). "
                 "See documentation at https://huggingface.co/docs/smolagents/tutorials/tools#structured-output-and-output-schema-support for more details.",
                 FutureWarning,
                 stacklevel=2,

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -49,6 +49,12 @@ class MCPClient:
                 - "sse": Legacy HTTP+SSE transport (deprecated).
         adapter_kwargs (dict[str, Any], optional):
             Additional keyword arguments to be passed directly to `MCPAdapt`.
+        structured_output (bool, optional, defaults to False):
+            Whether to enable structured output features for MCP tools. If True, enables:
+            - Support for outputSchema in MCP tools
+            - Structured content handling (structuredContent from MCP responses)
+            - JSON parsing fallback for structured data
+            If False, uses the original simple text-only behavior for backwards compatibility.
 
     Example:
         ```python
@@ -59,6 +65,10 @@ class MCPClient:
         # context manager + Streamable HTTP transport:
         with MCPClient({"url": "http://localhost:8000/mcp", "transport": "streamable-http"}) as tools:
             # tools are now available
+
+        # Enable structured output for advanced MCP tools:
+        with MCPClient(server_parameters, structured_output=True) as tools:
+            # tools with structured output support are now available
 
         # manually manage the connection via the mcp_client object:
         try:
@@ -75,6 +85,7 @@ class MCPClient:
         self,
         server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
         adapter_kwargs: dict[str, Any] | None = None,
+        structured_output: bool = False,
     ):
         try:
             from mcpadapt.core import MCPAdapt
@@ -91,7 +102,7 @@ class MCPClient:
                     f"Unsupported transport: {transport}. Supported transports are 'streamable-http' and 'sse'."
                 )
         adapter_kwargs = adapter_kwargs or {}
-        self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter(), **adapter_kwargs)
+        self._adapter = MCPAdapt(server_parameters, SmolAgentsAdapter(structured_output=structured_output), **adapter_kwargs)
         self._tools: list[Tool] | None = None
         self.connect()
 

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import warnings
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -85,8 +86,20 @@ class MCPClient:
         self,
         server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
         adapter_kwargs: dict[str, Any] | None = None,
-        structured_output: bool = False,
+        structured_output: bool | None = None,
     ):
+        # Handle future warning for structured_output default value change
+        if structured_output is None:
+            warnings.warn(
+                "The 'structured_output' parameter was not specified and currently defaults to False. "
+                "In a future release, the default will change to True. "
+                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (current behavior). "
+                "See documentation at https://huggingface.co/docs/smolagents/tutorials/tools#structured-output-and-output-schema-support for more details.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            structured_output = False
+
         try:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -132,7 +132,24 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   {{code_block_opening_tag}}
   {%- for tool in tools.values() %}
-  {{ tool.to_code_prompt() }}
+  def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
+      """{{ tool.description }}
+      {% if tool.output_schema %}
+      Important:
+          If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
+
+      {%- endif %}
+
+      Args:
+      {%- for arg_name, arg_info in tool.inputs.items() %}
+          {{ arg_name }}: {{ arg_info.description }}
+      {%- endfor %}
+      {% if tool.output_schema %}
+      Returns:
+          {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
+              {{ tool.output_schema | tojson(indent=4) | indent(12) }}
+      {%- endif %}
+      """
   {% endfor %}
   {{code_block_closing_tag}}
 
@@ -158,13 +175,14 @@ system_prompt: |-
   1. Always provide a 'Thought:' sequence, and a '{{code_block_opening_tag}}' sequence ending with '{{code_block_closing_tag}}', else you will fail.
   2. Use only variables that you have defined!
   3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
-  4. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to wikipedia_search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
-  5. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
-  6. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
-  7. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
-  8. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
-  9. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
-  10. Don't give up! You're in charge of solving the task, not providing directions to solve it.
+  4. For tools WITHOUT JSON output schemas: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
+  5. For tools WITH JSON output schemas: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
+  6. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
+  7. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
+  8. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
+  9. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
+  10. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
+  11. Don't give up! You're in charge of solving the task, not providing directions to solve it.
 
   {%- if custom_instructions %}
   {{custom_instructions}}
@@ -200,7 +218,25 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    {{ tool.to_code_prompt() }}
+    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
+        """{{ tool.description }}
+
+        {% if tool.output_schema %}
+        Important:
+            If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
+
+        {%- endif %}
+
+        Args:
+        {%- for arg_name, arg_info in tool.inputs.items() %}
+            {{ arg_name }}: {{ arg_info.description }}
+        {%- endfor %}
+        {% if tool.output_schema %}
+        Returns:
+            {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
+                {{ tool.output_schema | tojson(indent=4) | indent(12) }}
+        {%- endif %}
+        """
     {% endfor %}
     ```
 
@@ -234,7 +270,7 @@ planning:
     ```
     {{task}}
     ```
-  
+
     Below you will find a history of attempts made to solve this task.
     You will first have to produce a survey of known and unknown facts, then propose a step-by-step high-level plan to solve the task.
     If the previous tries so far have met some success, your updated plan can build on these results.
@@ -248,7 +284,7 @@ planning:
     ### 1.2. Facts that we have learned
     ### 1.3. Facts still to look up
     ### 1.4. Facts still to derive
-  
+
     Then write a step-by-step high-level plan to solve the task above.
     ## 2. Plan
     ### 2. 1. ...
@@ -261,7 +297,25 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    {{ tool.to_code_prompt() }}
+    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
+        """{{ tool.description }}
+
+        {% if tool.output_schema %}
+        Important:
+            If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
+
+        {%- endif %}
+
+        Args:
+        {%- for arg_name, arg_info in tool.inputs.items() %}
+            {{ arg_name }}: {{ arg_info.description }}
+        {%- endfor %}
+        {% if tool.output_schema %}
+        Returns:
+            {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
+                {{ tool.output_schema | tojson(indent=4) | indent(12) }}
+        {%- endif %}
+        """
     {% endfor %}
     ```
 

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -132,24 +132,7 @@ system_prompt: |-
   Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   {{code_block_opening_tag}}
   {%- for tool in tools.values() %}
-  def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-      """{{ tool.description }}
-      {% if tool.output_schema %}
-      Important:
-          If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
-
-      {%- endif %}
-
-      Args:
-      {%- for arg_name, arg_info in tool.inputs.items() %}
-          {{ arg_name }}: {{ arg_info.description }}
-      {%- endfor %}
-      {% if tool.output_schema %}
-      Returns:
-          {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
-              {{ tool.output_schema | tojson(indent=4) | indent(12) }}
-      {%- endif %}
-      """
+  {{ tool.to_code_prompt() }}
   {% endfor %}
   {{code_block_closing_tag}}
 
@@ -175,8 +158,8 @@ system_prompt: |-
   1. Always provide a 'Thought:' sequence, and a '{{code_block_opening_tag}}' sequence ending with '{{code_block_closing_tag}}', else you will fail.
   2. Use only variables that you have defined!
   3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
-  4. For tools WITHOUT JSON output schemas: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
-  5. For tools WITH JSON output schemas: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
+  4. For tools WITHOUT JSON output schema: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
+  5. For tools WITH JSON output schema: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
   6. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
   7. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
   8. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
@@ -218,25 +201,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        {% if tool.output_schema %}
-        Important:
-            If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
-
-        {%- endif %}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}
-        {% if tool.output_schema %}
-        Returns:
-            {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
-                {{ tool.output_schema | tojson(indent=4) | indent(12) }}
-        {%- endif %}
-        """
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 
@@ -297,25 +262,7 @@ planning:
     You can leverage these tools, behaving like regular python functions:
     ```python
     {%- for tool in tools.values() %}
-    def {{ tool.name }}({% for arg_name, arg_info in tool.inputs.items() %}{{ arg_name }}: {{ arg_info.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {{tool.output_type}}:
-        """{{ tool.description }}
-
-        {% if tool.output_schema %}
-        Important:
-            If this tool is used in your code, you must use the JSON schema below – describing the output of the tool – to access values of the tool output!
-
-        {%- endif %}
-
-        Args:
-        {%- for arg_name, arg_info in tool.inputs.items() %}
-            {{ arg_name }}: {{ arg_info.description }}
-        {%- endfor %}
-        {% if tool.output_schema %}
-        Returns:
-            {{tool.output_type}}: The output object is a dictionary conforming to the following JSON schema:
-                {{ tool.output_schema | tojson(indent=4) | indent(12) }}
-        {%- endif %}
-        """
+    {{ tool.to_code_prompt() }}
     {% endfor %}
     ```
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -952,7 +952,7 @@ class ToolCollection:
         cls,
         server_parameters: "mcp.StdioServerParameters" | dict,
         trust_remote_code: bool = False,
-        structured_output: bool = False,
+        structured_output: bool | None = None,
     ) -> "ToolCollection":
         """Automatically load a tool collection from an MCP server.
 
@@ -1021,6 +1021,18 @@ class ToolCollection:
         >>>     agent.run("Please find a remedy for hangover.")
         ```
         """
+        # Handle future warning for structured_output default value change
+        if structured_output is None:
+            warnings.warn(
+                "The 'structured_output' parameter was not specified and currently defaults to False. "
+                "In a future release, the default will change to True. "
+                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (current behavior). "
+                "See documentation at https://huggingface.co/docs/smolagents/tutorials/tools#structured-output-and-output-schema-support for more details.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            structured_output = False
+
         try:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -161,9 +161,7 @@ class Tool(BaseTool):
         # Validate optional output_schema attribute
         output_schema = getattr(self, "output_schema", None)
         if output_schema is not None and not isinstance(output_schema, dict):
-            raise TypeError(
-                f"Attribute output_schema should have type dict, got {type(output_schema)} instead."
-            )
+            raise TypeError(f"Attribute output_schema should have type dict, got {type(output_schema)} instead.")
 
         # - Validate name
         if not is_valid_name(self.name):
@@ -261,7 +259,7 @@ class Tool(BaseTool):
         args_signature = ", ".join(f"{arg_name}: {arg_schema['type']}" for arg_name, arg_schema in self.inputs.items())
 
         # Use dict type for tools with output schema to indicate structured return
-        has_schema = hasattr(self, 'output_schema') and self.output_schema is not None
+        has_schema = hasattr(self, "output_schema") and self.output_schema is not None
         output_type = "dict" if has_schema else self.output_type
         tool_signature = f"({args_signature}) -> {output_type}"
         tool_doc = self.description
@@ -281,7 +279,7 @@ class Tool(BaseTool):
         # Add returns documentation with output schema if it exists
         if has_schema:
             formatted_schema = json.dumps(self.output_schema, indent=4)
-            indented_schema = textwrap.indent(formatted_schema, '        ')
+            indented_schema = textwrap.indent(formatted_schema, "        ")
             returns_doc = f"\nReturns:\n    dict (structured output): This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:\n{indented_schema}"
             tool_doc += f"\n{returns_doc}"
 
@@ -322,7 +320,7 @@ class Tool(BaseTool):
 
             # Add output_schema if it exists
             if hasattr(self, "output_schema") and self.output_schema is not None:
-                tool_code += f'\n                output_schema = {repr(self.output_schema)}'
+                tool_code += f"\n                output_schema = {repr(self.output_schema)}"
             import re
 
             def add_self_argument(source_code: str) -> str:
@@ -951,7 +949,10 @@ class ToolCollection:
     @classmethod
     @contextmanager
     def from_mcp(
-        cls, server_parameters: "mcp.StdioServerParameters" | dict, trust_remote_code: bool = False, structured_output: bool = False
+        cls,
+        server_parameters: "mcp.StdioServerParameters" | dict,
+        trust_remote_code: bool = False,
+        structured_output: bool = False,
     ) -> "ToolCollection":
         """Automatically load a tool collection from an MCP server.
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -1024,9 +1024,9 @@ class ToolCollection:
         # Handle future warning for structured_output default value change
         if structured_output is None:
             warnings.warn(
-                "The 'structured_output' parameter was not specified and currently defaults to False. "
-                "In a future release, the default will change to True. "
-                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (current behavior). "
+                "Parameter 'structured_output' was not specified. "
+                "Currently it defaults to False, but in version 1.25, the default will change to True. "
+                "To suppress this warning, explicitly set structured_output=True (new behavior) or structured_output=False (legacy behavior). "
                 "See documentation at https://huggingface.co/docs/smolagents/tutorials/tools#structured-output-and-output-schema-support for more details.",
                 FutureWarning,
                 stacklevel=2,

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -264,7 +264,7 @@ class Tool(BaseTool):
         tool_signature = f"({args_signature}) -> {output_type}"
         tool_doc = self.description
 
-        # Add important note about output schema if it exists
+        # Add an important note for smaller models (e.g. Mistral Small, Gemma 3, etc.) to properly handle structured output.
         if has_schema:
             tool_doc += "\n\nImportant: This tool returns structured output! Use the JSON schema below to directly access fields like result['field_name']. NO print() statements needed to inspect the output!"
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -983,7 +983,6 @@ class ToolCollection:
                 - Support for outputSchema in MCP tools
                 - Structured content handling (structuredContent from MCP responses)
                 - JSON parsing fallback for structured data
-                - Output validation against schemas
                 If False, uses the original simple text-only behavior for backwards compatibility.
 
         Returns:

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -51,7 +51,7 @@ def structured_output_server_script():
 
 
 # Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -101,7 +101,7 @@ def test_mcp_client_without_structured_output(structured_output_server_script: s
 
 
 # Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
 def test_mcp_client_try_finally_syntax(echo_server_script: str):
     """Test the MCPClient with the try ... finally syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -116,7 +116,7 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
 
 
 # Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
     server_parameters = [

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -50,8 +50,8 @@ def structured_output_server_script():
     )
 
 
-# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore::FutureWarning")
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -100,8 +100,8 @@ def test_mcp_client_without_structured_output(structured_output_server_script: s
         assert parsed_result["name"] == "Alice"
 
 
-# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore::FutureWarning")
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
 def test_mcp_client_try_finally_syntax(echo_server_script: str):
     """Test the MCPClient with the try ... finally syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -115,8 +115,8 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
         mcp_client.disconnect()
 
 
-# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore::FutureWarning")
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
     server_parameters = [

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -50,6 +50,8 @@ def structured_output_server_script():
     )
 
 
+# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -98,6 +100,8 @@ def test_mcp_client_without_structured_output(structured_output_server_script: s
         assert parsed_result["name"] == "Alice"
 
 
+# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_mcp_client_try_finally_syntax(echo_server_script: str):
     """Test the MCPClient with the try ... finally syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -111,6 +115,8 @@ def test_mcp_client_try_finally_syntax(echo_server_script: str):
         mcp_client.disconnect()
 
 
+# Ignore FutureWarning about structured_output default value change - this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_multiple_servers(echo_server_script: str):
     """Test the MCPClient with multiple servers."""
     server_parameters = [

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,3 +1,4 @@
+import json
 from textwrap import dedent
 
 import pytest
@@ -24,6 +25,31 @@ def echo_server_script():
     )
 
 
+@pytest.fixture
+def structured_output_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+        from typing import Any
+
+        mcp = FastMCP("Structured Output Server")
+
+        @mcp.tool()
+        def user_info_tool(name: str) -> dict[str, Any]:
+            """Get user information as structured data"""
+            user_data = {
+                "name": name,
+                "age": 25,
+                "email": f"{name.lower()}@example.com",
+                "active": True
+            }
+            return user_data
+
+        mcp.run()
+        '''
+    )
+
+
 def test_mcp_client_with_syntax(echo_server_script: str):
     """Test the MCPClient with the context manager syntax."""
     server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
@@ -31,6 +57,45 @@ def test_mcp_client_with_syntax(echo_server_script: str):
         assert len(tools) == 1
         assert tools[0].name == "echo_tool"
         assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
+
+
+def test_mcp_client_with_structured_output(structured_output_server_script: str):
+    """Test the MCPClient with structured_output=True parameter."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", structured_output_server_script])
+    with MCPClient(server_parameters, structured_output=True) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "user_info_tool"
+        assert tools[0].output_type == "object"  # Should be object due to outputSchema
+
+        # Check the output schema {'additionalProperties': True, 'title': 'user_info_toolDictOutput', 'type': 'object'}
+        assert tools[0].output_schema is not None
+        schema = tools[0].output_schema
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+
+        # Test that structured output is properly parsed
+        result = tools[0].forward(**{"name": "Alice"})
+        assert isinstance(result, dict)
+        assert result["name"] == "Alice"
+        assert result["age"] == 25
+        assert result["email"] == "alice@example.com"
+        assert result["active"] is True
+
+
+def test_mcp_client_without_structured_output(structured_output_server_script: str):
+    """Test the MCPClient with structured_output=False (default) for comparison."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", structured_output_server_script])
+    with MCPClient(server_parameters, structured_output=False) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "user_info_tool"
+        assert tools[0].output_type == "object"
+
+        # Test that output is returned as raw text
+        result = tools[0].forward(**{"name": "Alice"})
+        assert isinstance(result, str)
+        # Should be JSON string, not parsed object
+        parsed_result = json.loads(result)
+        assert parsed_result["name"] == "Alice"
 
 
 def test_mcp_client_try_finally_syntax(echo_server_script: str):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -815,6 +815,8 @@ def mock_smolagents_adapter():
         yield mock
 
 
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
 class TestToolCollection:
     def test_from_mcp(self, mock_server_parameters, mock_mcp_adapt, mock_smolagents_adapter):
         with ToolCollection.from_mcp(mock_server_parameters, trust_remote_code=True) as tool_collection:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -816,7 +816,7 @@ def mock_smolagents_adapter():
 
 
 # Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
-@pytest.mark.filterwarnings("ignore:Parameter 'structured_output':FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
 class TestToolCollection:
     def test_from_mcp(self, mock_server_parameters, mock_mcp_adapt, mock_smolagents_adapter):
         with ToolCollection.from_mcp(mock_server_parameters, trust_remote_code=True) as tool_collection:


### PR DESCRIPTION
# Summary

This PR implements structured output and output schema support for smolagents, leveraging [MCPAdapt >= 0.1.13](https://github.com/grll/mcpadapt/releases/tag/v0.1.13) capabilities to enable MCP tools that return complex structured data with defined output schemas. Changes are fully backwards compatible and opt-in only.

## Motivation

**The key advantage is that the agent LLM sees what to expect from a tool call before calling the tool, without the need for `print(tool_output)`.**

The latest [MCP specifications (2025-06-18+)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema) include support for `outputSchema`, enabling tools to return [structured data](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) with defined schemas. This enhancement allows smolagents to work with tools that return complex data structures and JSON objects, while providing agents with schema visibility **before tool execution** for more intelligent interactions.

Addresses issue: https://github.com/huggingface/smolagents/issues/1596

## Implementation

### Changes

**MCPClient:**
- Added `structured_output` parameter (defaults to `False` for full backwards compatibility)
- When enabled, supports `outputSchema` and structured content handling from MCP responses
- Enhanced `ToolCollection.from_mcp()` with matching `structured_output` parameter

```python
with MCPClient(server_parameters, structured_output=True) as tools:
    agent = CodeAgent(tools=tools, model=model)
```

**Tool Class:**
- Added `output_schema` attribute to Tool class for JSON schema definitions
- Enhanced `to_code_prompt()` method for improved tool signature generation with schema information

**CodeAgent System Prompt:**
- Modified **only** the CodeAgent system prompt (`code_agent.yaml`) to include JSON schema information
- Added conditional tool documentation with "Important" notices and structured "Returns" sections to help guide small LLMs (e.g., Mistral Small) in understanding tool output structure. **It was observed that without this "Important" note, smaller models tend to ignore the output schema and fall back to using `print()` to inspect results.**
- Improved guidance for using tools with structured outputs vs. text outputs
- Enables confident tool chaining for schema-enabled tools vs. cautious print-based approach for text outputs

### Agent Behavior

Tools with output schemas generate enhanced documentation in the CodeAgent system prompt.

**Example (snippet of system prompt)**:
```python
...

def weather_tool(location: string) -> dict:
    """Get the weather for a given location

    Important: This tool returns structured output! Use the JSON schema below to directly access fields like result['field_name']. NO print() statements needed to inspect the output!

    Args:
        location: The location to get the weather for

    Returns:
        dict (structured output): This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:
            {
                "properties": {
                    "weather": {
                        "description": "The weather condition",
                        "title": "Weather",
                        "type": "string"
                    },
                    "temperature": {
                        "description": "The temperature in Celsius",
                        "title": "Temperature",
                        "type": "integer"
                    },
                    "humidity": {
                        "description": "The humidity in percentage",
                        "title": "Humidity",
                        "type": "integer"
                    },
                    "wind_speed": {
                        "description": "The wind speed in miles per hour",
                        "title": "Wind Speed",
                        "type": "integer"
                    }
                },
                "required": [
                    "weather",
                    "temperature",
                    "humidity",
                    "wind_speed"
                ],
                "title": "Weather",
                "type": "object"
            }
    """
...
```

This enables efficient tool use and direct field access without print statements.

In the following example, the tool output schema above indicates the `temperature` field is in Celsius, so the agent reads that from the schema, converts to Fahrenheit inline, and produces the final answer in ONE single step.

**Example in** [`examples/structured_output_tool.py`](https://github.com/chahn/smolagents/blob/feature/output-schema/examples/structured_output_tool.py):
```
╭──────────────────────────────── New run ─────────────────────────────────╮
│                                                                          │
│ What is the temperature in Tokyo in Fahrenheit?                          │
│                                                                          │
╰─ LiteLLMModel - mistral/mistral-small-latest ────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ─ Executing parsed code: ─────────────────────────────────────────────────
  weather = weather_tool(location="Tokyo")
  temperature_fahrenheit = weather['temperature'] * 9/5 + 32
  final_answer(temperature_fahrenheit)
 ──────────────────────────────────────────────────────────────────────────
[08/05/25 15:07:07] INFO     Processing request of type        server.py:619
                             CallToolRequest
Final answer: 73.4
[Step 1: Duration 1.28 seconds| Input tokens: 2,694 | Output tokens: 71]
```

### Backwards Compatibility & Testing

**Backwards Compatibility:**
- All new parameters default to `False`/disabled to ensure existing code continues working unchanged
- Structured output features are opt-in only via explicit `structured_output=True` parameter
- Non-structured output behavior remains identical to previous versions

**Testing:**
- Comprehensive test coverage for both structured and non-structured output modes in `test_mcp_client.py`
- Tests validate backwards compatibility and new structured output functionality

**Documentation:**
- Updated guided tour, reference documentation, and tutorials with detailed examples
- Enhanced `docs/source/en/tutorials/tools.md` with structured output usage patterns

**Thanks a lot for feedback or support as I'm new to smolagents internals!**