### PR TITLE
fix: Wait for jupyter start in docker executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -486,8 +486,6 @@ def evaluate_function_def(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> Callable:
-    if func_def.name in static_tools:
-        raise InterpreterError(f"Cannot define function '{func_def.name}': doing this would override an existing tool!")
     custom_tools[func_def.name] = create_function(func_def, state, static_tools, custom_tools, authorized_imports)
     return custom_tools[func_def.name]
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -486,6 +486,8 @@ def evaluate_function_def(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> Callable:
+    if func_def.name in static_tools:
+        raise InterpreterError(f"Cannot define function '{func_def.name}': doing this would override an existing tool!")
     custom_tools[func_def.name] = create_function(func_def, state, static_tools, custom_tools, authorized_imports)
     return custom_tools[func_def.name]
 

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -345,6 +345,15 @@ class DockerExecutor(RemotePythonExecutor):
 
             self.base_url = f"http://{host}:{port}"
 
+            # Wait for Jupyter to start
+            for _ in range(10):
+                try:
+                    if requests.get(f"{self.base_url}/api", timeout=2).status_code == 200:
+                        break
+                except:
+                    pass
+                time.sleep(1)
+
             # Create new kernel via HTTP
             r = requests.post(f"{self.base_url}/api/kernels")
             if r.status_code != 201:


### PR DESCRIPTION
Issue: Trying to send request to jupyter API before the process is ready - gives error occasionally.

Solution: Wait until the jupyter API shows ok health status before continuing.