### PR TITLE
CI hotfix: Pin openai < 1.100.0 for litellm extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ gradio = [
 ]
 litellm = [
   "litellm>=1.60.2",
+  "openai<1.100.0",
 ]
 mcp = [
   "mcpadapt>=0.1.11",  # Support Image and Audio content


### PR DESCRIPTION
CI hotfix: Pin openai < 1.100.0 for litellm extra.

Fix #1692.
Upstream issue:
- https://github.com/BerriAI/litellm/issues/13711