### PR TITLE
Replace slim with bullseye base image in Docker executor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -305,7 +305,7 @@ class DockerExecutor(RemotePythonExecutor):
                         f.write(
                             dedent(
                                 """\
-                                FROM python:3.12-slim
+                                FROM python:3.12-bullseye
 
                                 RUN pip install jupyter_kernel_gateway jupyter_client
 


### PR DESCRIPTION
Replace slim with bullseye base image in Docker executor.

This PR updates the Dockerfile to use python:3.10-bullseye instead of python:3.12-slim as the base image in remote Docker executor.

Motivation:
- Switches from the slim variant to bullseye for better compatibility with system dependencies and improved stability during package installation.
- Reduces the need to manually install build tools and libraries that are often missing in slim images.

Impact:
- Slightly larger image size due to the full Debian base (bullseye), but this ensures smoother installation of Python packages, particularly those with native extensions.