### PR TITLE
Support custom Python code executor in CodeAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1502,6 +1502,7 @@ class CodeAgent(MultiStepAgent):
         prompt_templates ([`~agents.PromptTemplates`], *optional*): Prompt templates.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
+        executor ([`PythonExecutor`], *optional*): Custom Python code executor. If not provided, a default executor will be created based on `executor_type`.
         executor_type (`Literal["local", "e2b", "docker", "wasm"]`, default `"local"`): Type of code executor.
         executor_kwargs (`dict`, *optional*): Additional arguments to pass to initialize the executor.
         max_print_outputs_length (`int`, *optional*): Maximum length of the print outputs.
@@ -1520,6 +1521,7 @@ class CodeAgent(MultiStepAgent):
         prompt_templates: PromptTemplates | None = None,
         additional_authorized_imports: list[str] | None = None,
         planning_interval: int | None = None,
+        executor: PythonExecutor = None,
         executor_type: Literal["local", "e2b", "docker", "wasm"] = "local",
         executor_kwargs: dict[str, Any] | None = None,
         max_print_outputs_length: int | None = None,
@@ -1572,7 +1574,7 @@ class CodeAgent(MultiStepAgent):
             raise ValueError(f"Unsupported executor type: {executor_type}")
         self.executor_type = executor_type
         self.executor_kwargs: dict[str, Any] = executor_kwargs or {}
-        self.python_executor = self.create_python_executor()
+        self.python_executor = executor or self.create_python_executor()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Support custom Python code executor in `CodeAgent`.

This PR adds the `executor` param to CodeAgent class to allow users to provide custom executor instead of being limited to the hardcoded defaults depending on `executor_type`.

Follow-up to:
- #1705