### PR TITLE
Support parsing `anyOf` from MCP tools

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -246,8 +246,6 @@ def get_tool_json_schema(tool: Tool) -> dict:
     for key, value in properties.items():
         if value["type"] == "any":
             value["type"] = "string"
-        if "anyOf" in value and any(t["type"] == "null" for t in value["anyOf"]):
-            value["nullable"] = True
         if not ("nullable" in value and value["nullable"]):
             required.append(key)
 
@@ -257,6 +255,7 @@ def get_tool_json_schema(tool: Tool) -> dict:
             enum = None
             for t in value["anyOf"]:
                 if t["type"] == "null":
+                    value["nullable"] = True
                     continue
                 if t["type"] == "any":
                     types.append("string")


### PR DESCRIPTION
Smolagents uses MCPAdapt, one problem is that it doesn't handle `anyOf` field from the input schema.

To mitigate this problem, I expanded `get_tool_json_schema` function that parses the argument properly. 

Here is an example of before and after the change:
Before:
```
    'lifecycle_stage': {'anyOf': [{'enum': ['development',
        'ideation',
        'r_and_d',
        'testing',
        'production',
        'retired'],
       'type': 'string'},
      {'type': 'null'}],
     'default': None,
     'description': 'The lifecycle stage of the Software.',
     'title': 'Lifecycle Stage',
     'type': 'string'},
```
After
```
    'lifecycle_stage': {'default': None,
     'description': 'The lifecycle stage of the Software',
     'title': 'Lifecycle Stage',
     'type': 'string',
     'nullable': True,
     'enum': ['development',
      'ideation',
      'r_and_d',
      'testing',
      'production',
      'retired']},
```