### PR TITLE
Update documentation to clarify `instructions` are appended

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -166,7 +166,7 @@ Put yourself in the shoes of your model: if you were the model solving the task,
 
 Would you need detailed instructions?
 
-- If the instruction is to always be given to the agent (as we generally understand a system prompt to work): you can pass it as a string under argument `instructions` upon agent initialization.
+- If the instruction is to always be given to the agent (as we generally understand a system prompt to work): you can pass it as a string under argument `instructions` upon agent initialization. *(Note: instructions are appended to the system prompt, not replacing it.)*
 - If it's about a specific task to solve: add all these details to the task. The task could be very long, like dozens of pages.
 - If it's about how to use specific tools: include it in the `description` attribute of these tools.
 

--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -393,6 +393,8 @@ But generally it's just simpler to pass argument `instructions` upon agent inita
 agent = CodeAgent(tools=[], model=InferenceClientModel(model_id=model_id), instructions="Always talk like a 5 year old.")
 ```
 
+Note that `instructions` are appended to the system prompt, not replacing it.
+
 
 ### 4. Extra planning
 


### PR DESCRIPTION
Added a note in `docs/source/en/tutorials/building_good_agents.md` explaining that the `instructions` parameter is appended to the system prompt, rather than replacing it.