### PR TITLE
fix typos in the system prompt

### DIFF
--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -29,7 +29,7 @@ system_prompt: |-
   ---
   Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
-  Thought: I will use python code to compute the result of the operation and then return the final answer using the `final_answer` tool
+  Thought: I will use Python code to compute the result of the operation and then return the final answer using the `final_answer` tool.
   {{code_block_opening_tag}}
   result = 5 + 3 + 1294.678
   final_answer(result)
@@ -38,7 +38,7 @@ system_prompt: |-
   ---
   Task:
   "Answer the question in the variable `question` about the image stored in the variable `image`. The question is in French.
-  You have been provided with these additional arguments, that you can access using the keys as variables in your python code:
+  You have been provided with these additional arguments, that you can access using the keys as variables in your Python code:
   {'question': 'Quel est l'animal sur l'image?', 'image': 'path/to/image.jpg'}"
 
   Thought: I will use the following tools: `translator` to translate the question into English and then `image_qa` to answer the question on the input image.
@@ -99,7 +99,7 @@ system_prompt: |-
   Thought: I need to get the populations for both cities and compare them: I will use the tool `web_search` to get the population of both cities.
   {{code_block_opening_tag}}
   for city in ["Guangzhou", "Shanghai"]:
-      print(f"Population {city}:", web_search(f"{city} population")
+      print(f"Population {city}:", web_search(f"{city} population"))
   {{code_block_closing_tag}}
   Observation:
   Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
@@ -123,13 +123,13 @@ system_prompt: |-
   Observation:
   Pope age: "The pope Francis is currently 88 years old."
 
-  Thought: I know that the pope is 88 years old. Let's compute the result using python code.
+  Thought: I know that the pope is 88 years old. Let's compute the result using Python code.
   {{code_block_opening_tag}}
   pope_current_age = 88 ** 0.36
   final_answer(pope_current_age)
   {{code_block_closing_tag}}
 
-  Above example were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
+  Above examples were using notional tools that might not exist for you. On top of performing computations in the Python code snippets that you create, you only have access to these tools, behaving like regular python functions:
   {{code_block_opening_tag}}
   {%- for tool in tools.values() %}
   {{ tool.to_code_prompt() }}


### PR DESCRIPTION
Fixing CodeAgent system prompt that contained an example of Python code with a syntax error. Additionally, fixing some typos and consistency issues. 