### PR TITLE
Fix CI 403 error for Wikipedia page in test_visit_webpage

### DIFF
--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -31,10 +31,10 @@ from .utils.markers import require_run_all
 
 class DefaultToolTests(unittest.TestCase):
     def test_visit_webpage(self):
-        arguments = {"url": "https://en.wikipedia.org/wiki/United_States_Secretary_of_Homeland_Security"}
+        arguments = {"url": "https://huggingface.co/"}
         result = VisitWebpageTool()(arguments)
         assert isinstance(result, str)
-        assert "United States Secretary of Homeland Security - Wikipedia\n\n[Jump to content]" in result
+        assert "Hugging Face – The AI community building the future" in result
 
     @require_run_all
     def test_ddgs_with_kwargs(self):


### PR DESCRIPTION
Fix CI 403 error for Wikipedia page in test_visit_webpage.

This PR changes the URL in test_visit_webpage to avoid the 403 Forbidden error.