### PR TITLE
Fix deprecation warning about parameter messages

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -884,7 +884,7 @@ class TestRunResult:
         assert result.output == "This is the final answer."
         assert result.state == "success"
         assert result.token_usage is None
-        assert isinstance(result.messages, list)
+        assert isinstance(result.steps, list)
         assert result.timing.duration > 0
 
     @pytest.mark.parametrize(
@@ -910,7 +910,7 @@ class TestRunResult:
             assert result.output == "This is the final answer."
             assert result.state == "success"
             assert result.token_usage == TokenUsage(input_tokens=10, output_tokens=20)
-            assert isinstance(result.messages, list)
+            assert isinstance(result.steps, list)
             assert result.timing.duration > 0
         else:
             assert isinstance(result, str)


### PR DESCRIPTION
Fix deprecation warning about parameter `messages`: https://github.com/huggingface/smolagents/actions/runs/17234970996/job/48897627718?pr=1690
> FutureWarning: Parameter 'messages' is deprecated and will be removed in version 1.25. Please use 'steps' instead.
```python
tests/test_agents.py::TestRunResult::test_no_token_usage[CodeAgent]
tests/test_agents.py::TestRunResult::test_no_token_usage[ToolCallingAgent]
  /home/runner/work/smolagents/smolagents/tests/test_agents.py:887: FutureWarning: Parameter 'messages' is deprecated and will be removed in version 1.25. Please use 'steps' instead.
    assert isinstance(result.messages, list)

tests/test_agents.py::TestRunResult::test_full_result[True-None-True]
tests/test_agents.py::TestRunResult::test_full_result[False-True-True]
  /home/runner/work/smolagents/smolagents/tests/test_agents.py:913: FutureWarning: Parameter 'messages' is deprecated and will be removed in version 1.25. Please use 'steps' instead.
    assert isinstance(result.messages, list)
```