### PR TITLE
Adds Modal Remote Executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ limitations under the License.
 
 ✨ **Simplicity**: the logic for agents fits in ~1,000 lines of code (see [agents.py](https://github.com/huggingface/smolagents/blob/main/src/smolagents/agents.py)). We kept abstractions to their minimal shape above raw code!
 
-🧑‍💻 **First-class support for Code Agents**. Our [`CodeAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.CodeAgent) writes its actions in code (as opposed to "agents being used to write code"). To make it secure, we support executing in sandboxed environments via [E2B](https://e2b.dev/), Docker, or Pyodide+Deno WebAssembly sandbox.
+🧑‍💻 **First-class support for Code Agents**. Our [`CodeAgent`](https://huggingface.co/docs/smolagents/reference/agents#smolagents.CodeAgent) writes its actions in code (as opposed to "agents being used to write code"). To make it secure, we support executing in sandboxed environments via [E2B](https://e2b.dev/), [Modal](https://modal.com/), Docker, or Pyodide+Deno WebAssembly sandbox.
 
 🤗 **Hub integrations**: you can [share/pull tools or agents to/from the Hub](https://huggingface.co/docs/smolagents/reference/tools#smolagents.Tool.from_hub) for instant sharing of the most efficient agents!
 
@@ -254,7 +254,7 @@ This comparison shows that open-source models can now take on the best closed mo
 ## Security
 
 Security is a critical consideration when working with code-executing agents. Our library provides:
-- Sandboxed execution options using [E2B](https://e2b.dev/), Docker, or Pyodide+Deno WebAssembly sandbox
+- Sandboxed execution options using [E2B](https://e2b.dev/), [Modal](https://modal.com/), Docker, or Pyodide+Deno WebAssembly sandbox
 - Best practices for running agent code securely
 
 For security policies, vulnerability reporting, and more information on secure agent execution, please see our [Security Policy](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,10 @@ To learn more about running agents more securely, please see the [Secure Code Ex
 
 1. **E2B Sandbox**: Uses [E2B](https://e2b.dev/) to run code in a secure, isolated environment.
 
-2. **Docker Sandbox**: Runs code in an isolated Docker container.
+2. **Modal Sandbox**: Uses [Modal](https://modal.com/) to run code in a secure, isolated environment.
 
-3. **WebAssembly Sandbox**: Executes Python code securely in a sandboxed WebAssembly environment using Pyodide and Deno's secure runtime.
+3. **Docker Sandbox**: Runs code in an isolated Docker container.
+
+4. **WebAssembly Sandbox**: Executes Python code securely in a sandboxed WebAssembly environment using Pyodide and Deno's secure runtime.
 
 We recommend using one of these sandboxed execution options when running untrusted code.

--- a/docs/source/en/reference/agents.md
+++ b/docs/source/en/reference/agents.md
@@ -71,6 +71,10 @@ Smolagents use memory to store information across multiple steps.
 
 [[autodoc]] smolagents.remote_executors.E2BExecutor
 
+#### ModalExecutor
+
+[[autodoc]] smolagents.remote_executors.ModalExecutor
+
 #### DockerExecutor
 
 [[autodoc]] smolagents.remote_executors.DockerExecutor

--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -118,7 +118,8 @@ When working with AI agents that execute code, security is paramount. There are 
 
 ![Sandbox approaches comparison](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/sandboxed_execution.png)
 
-1. **Running individual code snippets in a sandbox**: This approach (left side of diagram) only executes the agent-generated Python code snippets in a sandbox while keeping the rest of the agentic system in your local environment. It's simpler to set up using `executor_type="e2b"` or `executor_type="docker"`, but it doesn't support multi-agents and still requires passing state data between your environment and the sandbox.
+1. **Running individual code snippets in a sandbox**: This approach (left side of diagram) only executes the agent-generated Python code snippets in a sandbox while keeping the rest of the agentic system in your local environment. It's simpler to set up using `executor_type="e2b"`, `executor_type="modal"` , or
+`executor_type="docker"`, but it doesn't support multi-agents and still requires passing state data between your environment and the sandbox.
 
 2. **Running the entire agentic system in a sandbox**: This approach (right side of diagram) runs the entire agentic system, including the agent, model, and tools, within a sandbox environment. This provides better isolation but requires more manual setup and may require passing sensitive credentials (like API keys) to the sandbox environment.
 
@@ -217,6 +218,33 @@ print(response)
 execution_logs = run_code_raise_errors(sandbox, agent_code)
 print(execution_logs)
 ```
+
+### Modal setup
+
+#### Installation
+
+1. Create an Modal account at [e2b.dev](https://modal.com/signup)
+2. Install the required packages:
+```bash
+pip install 'smolagents[modal]'
+```
+
+#### Running your agent in Modal: quick start
+
+We provide a simple way to use an E2B Sandbox: simply add `executor_type="modal"` to the agent initialization, as follows:
+
+```py
+from smolagents import InferenceClientModel, CodeAgent
+
+with CodeAgent(model=InferenceClientModel(), tools=[], executor_type="modal") as agent:
+    agent.run("What is the 42th Fibonacci number?")
+```
+
+> [!TIP]
+> Using the agent as a context manager (with the `with` statement) ensures that the Modal sandbox is cleaned immediately after the agent completes its task.
+> Alternatively, you can manually call the agent's `cleanup()` method.
+
+The agent state and generated code from the `InferenceClientModel` are sent to a Modal sandbox, which can securely execute code inside them.
 
 ### Docker setup
 

--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -118,7 +118,7 @@ When working with AI agents that execute code, security is paramount. There are 
 
 ![Sandbox approaches comparison](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/sandboxed_execution.png)
 
-1. **Running individual code snippets in a sandbox**: This approach (left side of diagram) only executes the agent-generated Python code snippets in a sandbox while keeping the rest of the agentic system in your local environment. It's simpler to set up using `executor_type="e2b"`, `executor_type="modal"` , or
+1. **Running individual code snippets in a sandbox**: This approach (left side of diagram) only executes the agent-generated Python code snippets in a sandbox while keeping the rest of the agentic system in your local environment. It's simpler to set up using `executor_type="e2b"`, `executor_type="modal"`, or
 `executor_type="docker"`, but it doesn't support multi-agents and still requires passing state data between your environment and the sandbox.
 
 2. **Running the entire agentic system in a sandbox**: This approach (right side of diagram) runs the entire agentic system, including the agent, model, and tools, within a sandbox environment. This provides better isolation but requires more manual setup and may require passing sensitive credentials (like API keys) to the sandbox environment.
@@ -223,7 +223,7 @@ print(execution_logs)
 
 #### Installation
 
-1. Create an Modal account at [e2b.dev](https://modal.com/signup)
+1. Create a Modal account at [modal.com](https://modal.com/signup)
 2. Install the required packages:
 ```bash
 pip install 'smolagents[modal]'
@@ -231,7 +231,7 @@ pip install 'smolagents[modal]'
 
 #### Running your agent in Modal: quick start
 
-We provide a simple way to use an E2B Sandbox: simply add `executor_type="modal"` to the agent initialization, as follows:
+We provide a simple way to use an Modal Sandbox: simply add `executor_type="modal"` to the agent initialization, as follows:
 
 ```py
 from smolagents import InferenceClientModel, CodeAgent

--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -231,7 +231,7 @@ pip install 'smolagents[modal]'
 
 #### Running your agent in Modal: quick start
 
-We provide a simple way to use an Modal Sandbox: simply add `executor_type="modal"` to the agent initialization, as follows:
+We provide a simple way to use a Modal Sandbox: simply add `executor_type="modal"` to the agent initialization, as follows:
 
 ```py
 from smolagents import InferenceClientModel, CodeAgent

--- a/examples/sandboxed_execution.py
+++ b/examples/sandboxed_execution.py
@@ -13,6 +13,11 @@ with CodeAgent(tools=[WebSearchTool()], model=model, executor_type="e2b") as age
     output = agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")
 print("E2B executor result:", output)
 
+# Modal executor example
+with CodeAgent(tools=[WebSearchTool()], model=model, executor_type="modal") as agent:
+    output = agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")
+print("Modal executor result:", output)
+
 # WebAssembly executor example
 with CodeAgent(tools=[], model=model, executor_type="wasm") as agent:
     output = agent.run("Calculate the square root of 125.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ vllm = [
   "torch"
 ]
 all = [
-  "smolagents[audio,docker,e2b,gradio,litellm,mcp,mlx-lm,openai,telemetry,toolkit,transformers,vision,bedrock]",
+  "smolagents[audio,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
 ]
 quality = [
   "ruff>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ mcp = [
 mlx-lm = [
   "mlx-lm",
 ]
+modal = [
+  "modal>=1.1.3",
+  "websocket-client",
+]
 openai = [
   "openai>=1.58.1"
 ]

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -76,7 +76,7 @@ from .monitoring import (
     LogLevel,
     Monitor,
 )
-from .remote_executors import DockerExecutor, E2BExecutor, WasmExecutor
+from .remote_executors import DockerExecutor, E2BExecutor, WasmExecutor, ModalExecutor
 from .tools import BaseTool, Tool, validate_tool_arguments
 from .utils import (
     AgentError,
@@ -1501,7 +1501,7 @@ class CodeAgent(MultiStepAgent):
         prompt_templates ([`~agents.PromptTemplates`], *optional*): Prompt templates.
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
-        executor_type (`Literal["local", "e2b", "docker", "wasm"]`, default `"local"`): Type of code executor.
+        executor_type (`Literal["local", "e2b", "modal", "docker", "wasm"]`, default `"local"`): Type of code executor.
         executor_kwargs (`dict`, *optional*): Additional arguments to pass to initialize the executor.
         max_print_outputs_length (`int`, *optional*): Maximum length of the print outputs.
         stream_outputs (`bool`, *optional*, default `False`): Whether to stream outputs during execution.
@@ -1519,7 +1519,7 @@ class CodeAgent(MultiStepAgent):
         prompt_templates: PromptTemplates | None = None,
         additional_authorized_imports: list[str] | None = None,
         planning_interval: int | None = None,
-        executor_type: Literal["local", "e2b", "docker", "wasm"] = "local",
+        executor_type: Literal["local", "e2b", "modal", "docker", "wasm"] = "local",
         executor_kwargs: dict[str, Any] | None = None,
         max_print_outputs_length: int | None = None,
         stream_outputs: bool = False,
@@ -1567,7 +1567,7 @@ class CodeAgent(MultiStepAgent):
                 "Caution: you set an authorization for all imports, meaning your agent can decide to import any package it deems necessary. This might raise issues if the package is not installed in your environment.",
                 level=LogLevel.INFO,
             )
-        if executor_type not in {"local", "e2b", "docker", "wasm"}:
+        if executor_type not in {"local", "e2b", "modal", "docker", "wasm"}:
             raise ValueError(f"Unsupported executor type: {executor_type}")
         self.executor_type = executor_type
         self.executor_kwargs: dict[str, Any] = executor_kwargs or {}
@@ -1597,6 +1597,7 @@ class CodeAgent(MultiStepAgent):
                 "e2b": E2BExecutor,
                 "docker": DockerExecutor,
                 "wasm": WasmExecutor,
+                "modal": ModalExecutor,
             }
             return remote_executors[self.executor_type](
                 self.additional_authorized_imports, self.logger, **self.executor_kwargs

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -76,7 +76,7 @@ from .monitoring import (
     LogLevel,
     Monitor,
 )
-from .remote_executors import DockerExecutor, E2BExecutor, WasmExecutor, ModalExecutor
+from .remote_executors import DockerExecutor, E2BExecutor, ModalExecutor, WasmExecutor
 from .tools import BaseTool, Tool, validate_tool_arguments
 from .utils import (
     AgentError,

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -19,16 +19,20 @@ import inspect
 import json
 import os
 import pickle
+import re
+import secrets
 import subprocess
 import tempfile
 import time
+from contextlib import closing
 from io import BytesIO
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, Optional
 
 import PIL.Image
 import requests
+from requests.exceptions import RequestException
 
 from .default_tools import FinalAnswerTool
 from .local_python_executor import CodeOutput, PythonExecutor
@@ -37,7 +41,7 @@ from .tools import Tool, get_tools_definition_code
 from .utils import AgentError
 
 
-__all__ = ["E2BExecutor", "DockerExecutor", "WasmExecutor"]
+__all__ = ["E2BExecutor", "ModalExecutor", "DockerExecutor", "WasmExecutor"]
 
 
 try:
@@ -241,6 +245,95 @@ class E2BExecutor(RemotePythonExecutor):
             self.logger.log_error(f"Error during cleanup: {e}")
 
 
+def _websocket_send_execute_request(code: str, ws) -> str:
+    """Send code execution request to kernel."""
+    import uuid
+
+    # Generate a unique message ID
+    msg_id = str(uuid.uuid4())
+
+    # Create execute request
+    execute_request = {
+        "header": {
+            "msg_id": msg_id,
+            "username": "anonymous",
+            "session": str(uuid.uuid4()),
+            "msg_type": "execute_request",
+            "version": "5.0",
+        },
+        "parent_header": {},
+        "metadata": {},
+        "content": {
+            "code": code,
+            "silent": False,
+            "store_history": True,
+            "user_expressions": {},
+            "allow_stdin": False,
+        },
+    }
+
+    ws.send(json.dumps(execute_request))
+    return msg_id
+
+
+def _websocket_run_code_raise_errors(code: str, ws, logger) -> CodeOutput:
+    """Run code over a websocket."""
+    try:
+        # Send execute request
+        msg_id = _websocket_send_execute_request(code, ws)
+
+        # Collect output and results
+        outputs = []
+        result = None
+        is_final_answer = False
+
+        while True:
+            msg = json.loads(ws.recv())
+            parent_msg_id = msg.get("parent_header", {}).get("msg_id")
+            # Skip unrelated messages
+            if parent_msg_id != msg_id:
+                continue
+            msg_type = msg.get("msg_type", "")
+            msg_content = msg.get("content", {})
+            if msg_type == "stream":
+                outputs.append(msg_content["text"])
+            elif msg_type == "execute_result":
+                result = msg_content["data"].get("text/plain", None)
+            elif msg_type == "error":
+                if msg_content.get("ename", "") == RemotePythonExecutor.FINAL_ANSWER_EXCEPTION:
+                    result = pickle.loads(base64.b64decode(msg_content.get("evalue", "")))
+                    is_final_answer = True
+                else:
+                    raise AgentError("\n".join(msg_content.get("traceback", [])), logger)
+            elif msg_type == "status" and msg_content["execution_state"] == "idle":
+                break
+
+        return CodeOutput(output=result, logs="".join(outputs), is_final_answer=is_final_answer)
+
+    except Exception as e:
+        logger.log_error(f"Code execution failed: {e}")
+        raise
+
+
+def _create_kernel_http(crate_kernel_endpoint: str, logger) -> str:
+    """Create kernel using http."""
+
+    r = requests.post(crate_kernel_endpoint)
+    if r.status_code != 201:
+        error_details = {
+            "status_code": r.status_code,
+            "headers": dict(r.headers),
+            "url": r.url,
+            "body": r.text,
+            "request_method": r.request.method,
+            "request_headers": dict(r.request.headers),
+            "request_body": r.request.body,
+        }
+        logger.log_error(f"Failed to create kernel. Details: {json.dumps(error_details, indent=2)}")
+        raise RuntimeError(f"Failed to create kernel: Status {r.status_code}\nResponse: {r.text}") from None
+    return r.json()["id"]
+
+
 class DockerExecutor(RemotePythonExecutor):
     """
     Executes Python code using Jupyter Kernel Gateway in a Docker container.
@@ -348,21 +441,7 @@ class DockerExecutor(RemotePythonExecutor):
             self.base_url = f"http://{host}:{port}"
 
             # Create new kernel via HTTP
-            r = requests.post(f"{self.base_url}/api/kernels")
-            if r.status_code != 201:
-                error_details = {
-                    "status_code": r.status_code,
-                    "headers": dict(r.headers),
-                    "url": r.url,
-                    "body": r.text,
-                    "request_method": r.request.method,
-                    "request_headers": dict(r.request.headers),
-                    "request_body": r.request.body,
-                }
-                self.logger.log_error(f"Failed to create kernel. Details: {json.dumps(error_details, indent=2)}")
-                raise RuntimeError(f"Failed to create kernel: Status {r.status_code}\nResponse: {r.text}") from None
-
-            self.kernel_id = r.json()["id"]
+            self.kernel_id = _create_kernel_http(f"{self.base_url}/api/kernels", logger)
 
             ws_url = f"ws://{host}:{port}/api/kernels/{self.kernel_id}/channels"
             self.ws = create_connection(ws_url)
@@ -376,72 +455,8 @@ class DockerExecutor(RemotePythonExecutor):
             self.cleanup()
             raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
 
-    def run_code_raise_errors(self, code_action: str) -> CodeOutput:
-        try:
-            # Send execute request
-            msg_id = self._send_execute_request(code_action)
-
-            # Collect output and results
-            outputs = []
-            result = None
-            is_final_answer = False
-
-            while True:
-                msg = json.loads(self.ws.recv())
-                parent_msg_id = msg.get("parent_header", {}).get("msg_id")
-                # Skip unrelated messages
-                if parent_msg_id != msg_id:
-                    continue
-                msg_type = msg.get("msg_type", "")
-                msg_content = msg.get("content", {})
-                if msg_type == "stream":
-                    outputs.append(msg_content["text"])
-                elif msg_type == "execute_result":
-                    result = msg_content["data"].get("text/plain", None)
-                elif msg_type == "error":
-                    if msg_content.get("ename", "") == RemotePythonExecutor.FINAL_ANSWER_EXCEPTION:
-                        result = pickle.loads(base64.b64decode(msg_content.get("evalue", "")))
-                        is_final_answer = True
-                    else:
-                        raise AgentError("\n".join(msg_content.get("traceback", [])), self.logger)
-                elif msg_type == "status" and msg_content["execution_state"] == "idle":
-                    break
-
-            return CodeOutput(output=result, logs="".join(outputs), is_final_answer=is_final_answer)
-
-        except Exception as e:
-            self.logger.log_error(f"Code execution failed: {e}")
-            raise
-
-    def _send_execute_request(self, code: str) -> str:
-        """Send code execution request to kernel."""
-        import uuid
-
-        # Generate a unique message ID
-        msg_id = str(uuid.uuid4())
-
-        # Create execute request
-        execute_request = {
-            "header": {
-                "msg_id": msg_id,
-                "username": "anonymous",
-                "session": str(uuid.uuid4()),
-                "msg_type": "execute_request",
-                "version": "5.0",
-            },
-            "parent_header": {},
-            "metadata": {},
-            "content": {
-                "code": code,
-                "silent": False,
-                "store_history": True,
-                "user_expressions": {},
-                "allow_stdin": False,
-            },
-        }
-
-        self.ws.send(json.dumps(execute_request))
-        return msg_id
+    def run_code_raise_errors(self, code: str) -> CodeOutput:
+        return _websocket_run_code_raise_errors(code, self.ws, self.logger)
 
     def cleanup(self):
         """Clean up the Docker container and resources."""
@@ -458,6 +473,122 @@ class DockerExecutor(RemotePythonExecutor):
     def delete(self):
         """Ensure cleanup on deletion."""
         self.cleanup()
+
+
+class ModalExecutor(RemotePythonExecutor):
+    """
+    Executes Python code using Modal.
+
+    Args:
+        additional_imports: Additional imports to install.
+        logger (`Logger`): Logger to use for output and errors.
+        app (`str`): App name.
+        create_kwargs (`dict`, optional): Keyword arguments to pass to creating the sandbox. See
+            `modal.Sandbox.create` [docs](https://modal.com/docs/reference/modal.Sandbox#create) for all the
+            keyword arguments.
+    """
+
+    _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+    def __init__(
+        self,
+        additional_imports: list[str],
+        logger,
+        app_name: str = "smolagent-executor",
+        port: int = 8888,
+        create_kwargs: Optional[dict] = None,
+    ):
+        super().__init__(additional_imports, logger)
+        self.port = port
+        try:
+            import modal
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                """Please install 'modal' extra to use ModalExecutor: `pip install 'smolagents[modal]'`"""
+            )
+
+        if create_kwargs is None:
+            create_kwargs = {}
+
+        create_kwargs_ = {
+            "image": modal.Image.debian_slim().uv_pip_install("jupyter_kernel_gateway", "ipykernel"),
+            "timeout": 60 * 5,
+            **create_kwargs,
+        }
+
+        if "app" not in create_kwargs_:
+            create_kwargs_["app"] = modal.App.lookup(app_name, create_if_missing=True)
+
+        if "encrypted_ports" not in create_kwargs_:
+            create_kwargs_["encrypted_ports"] = [self.port]
+        else:
+            create_kwargs_["encrypted_ports"] = create_kwargs_["encrypted_ports"] + [port]
+
+        token = secrets.token_urlsafe(16)
+        default_secrets = [modal.Secret.from_dict({"KG_AUTH_TOKEN": token})]
+
+        if "secrets" not in create_kwargs_:
+            create_kwargs_["secrets"] = default_secrets
+        else:
+            create_kwargs_["secrets"] = create_kwargs_["secrets"] + default_secrets
+
+        entrypoint = [
+            "jupyter",
+            "kernelgateway",
+            "--KernelGatewayApp.ip='0.0.0.0'",
+            f"--KernelGatewayApp.port={port}",
+            "--KernelGatewayApp.allow_origin='*'",
+        ]
+
+        self.logger.log("Starting Modal sandbox", level=LogLevel.INFO)
+        self.sandbox = modal.Sandbox.create(
+            *entrypoint,
+            **create_kwargs_,
+        )
+
+        tunnel = self.sandbox.tunnels()[port]
+        self.logger.log(f"Waiting for Modal sandbox on {tunnel.host}:{port}", level=LogLevel.INFO)
+        self._wait_for_server(tunnel.host, token)
+
+        self.logger.log("Starting Jupyter kernel", level=LogLevel.INFO)
+        kernel_id = _create_kernel_http(f"https://{tunnel.host}/api/kernels?token={token}", logger)
+        self.ws_url = f"wss://{tunnel.host}/api/kernels/{kernel_id}/channels?token={token}"
+        self.installed_packages = self.install_packages(additional_imports)
+
+    def run_code_raise_errors(self, code: str) -> CodeOutput:
+        from websocket import create_connection
+
+        with closing(create_connection(self.ws_url)) as ws:
+            return _websocket_run_code_raise_errors(code, ws, self.logger)
+
+    def cleanup(self):
+        if hasattr(self, "sandbox"):
+            self.sandbox.terminate()
+
+    def delete(self):
+        """Ensure cleanup on deletion."""
+        self.cleanup()
+
+    def _wait_for_server(self, host: str, token: str):
+        """Wait for server to start up."""
+        n_retries = 0
+        while True:
+            try:
+                resp = requests.get(f"https://{host}/api/kernelspecs?token={token}")
+                if resp.status_code == 200:
+                    break
+            except RequestException:
+                n_retries += 1
+                if n_retries % 10 == 0:
+                    self.logger.log("Waiting for server to startup, retrying...", level=LogLevel.INFO)
+                if n_retries > 60:
+                    raise RuntimeError("Unable to connect to sandbox")
+                time.sleep(1.0)
+
+    @classmethod
+    def _strip_ansi_colors(cls, text: str) -> str:
+        """Remove ansi colors from text."""
+        return cls._ANSI_ESCAPE.sub("", text)
 
 
 class WasmExecutor(RemotePythonExecutor):

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -441,7 +441,7 @@ class DockerExecutor(RemotePythonExecutor):
             self.base_url = f"http://{host}:{port}"
 
             # Create new kernel via HTTP
-            self.kernel_id = _create_kernel_http(f"{self.base_url}/api/kernels", logger)
+            self.kernel_id = _create_kernel_http(f"{self.base_url}/api/kernels", self.logger)
 
             ws_url = f"ws://{host}:{port}/api/kernels/{self.kernel_id}/channels"
             self.ws = create_connection(ws_url)
@@ -482,7 +482,8 @@ class ModalExecutor(RemotePythonExecutor):
     Args:
         additional_imports: Additional imports to install.
         logger (`Logger`): Logger to use for output and errors.
-        app (`str`): App name.
+        app_name (`str`): App name.
+        port (`int`): Port for jupyter to bind to.
         create_kwargs (`dict`, optional): Keyword arguments to pass to creating the sandbox. See
             `modal.Sandbox.create` [docs](https://modal.com/docs/reference/modal.Sandbox#create) for all the
             keyword arguments.

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -521,7 +521,7 @@ class ModalExecutor(RemotePythonExecutor):
             create_kwargs_["app"] = modal.App.lookup(app_name, create_if_missing=True)
 
         if "encrypted_ports" not in create_kwargs_:
-            create_kwargs_["encrypted_ports"] = [self.port]
+            create_kwargs_["encrypted_ports"] = [port]
         else:
             create_kwargs_["encrypted_ports"] = create_kwargs_["encrypted_ports"] + [port]
 

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -511,27 +511,27 @@ class ModalExecutor(RemotePythonExecutor):
         if create_kwargs is None:
             create_kwargs = {}
 
-        create_kwargs_ = {
+        create_kwargs = {
             "image": modal.Image.debian_slim().uv_pip_install("jupyter_kernel_gateway", "ipykernel"),
             "timeout": 60 * 5,
             **create_kwargs,
         }
 
-        if "app" not in create_kwargs_:
-            create_kwargs_["app"] = modal.App.lookup(app_name, create_if_missing=True)
+        if "app" not in create_kwargs:
+            create_kwargs["app"] = modal.App.lookup(app_name, create_if_missing=True)
 
-        if "encrypted_ports" not in create_kwargs_:
-            create_kwargs_["encrypted_ports"] = [port]
+        if "encrypted_ports" not in create_kwargs:
+            create_kwargs["encrypted_ports"] = [port]
         else:
-            create_kwargs_["encrypted_ports"] = create_kwargs_["encrypted_ports"] + [port]
+            create_kwargs["encrypted_ports"] = create_kwargs["encrypted_ports"] + [port]
 
         token = secrets.token_urlsafe(16)
         default_secrets = [modal.Secret.from_dict({"KG_AUTH_TOKEN": token})]
 
-        if "secrets" not in create_kwargs_:
-            create_kwargs_["secrets"] = default_secrets
+        if "secrets" not in create_kwargs:
+            create_kwargs["secrets"] = default_secrets
         else:
-            create_kwargs_["secrets"] = create_kwargs_["secrets"] + default_secrets
+            create_kwargs["secrets"] = create_kwargs["secrets"] + default_secrets
 
         entrypoint = [
             "jupyter",
@@ -544,7 +544,7 @@ class ModalExecutor(RemotePythonExecutor):
         self.logger.log("Starting Modal sandbox", level=LogLevel.INFO)
         self.sandbox = modal.Sandbox.create(
             *entrypoint,
-            **create_kwargs_,
+            **create_kwargs,
         )
 
         tunnel = self.sandbox.tunnels()[port]

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from smolagents.default_tools import FinalAnswerTool, WikipediaSearchTool
 from smolagents.local_python_executor import CodeOutput
 from smolagents.monitoring import AgentLogger, LogLevel
-from smolagents.remote_executors import DockerExecutor, E2BExecutor, RemotePythonExecutor, WasmExecutor, ModalExecutor
+from smolagents.remote_executors import DockerExecutor, E2BExecutor, ModalExecutor, RemotePythonExecutor, WasmExecutor
 from smolagents.utils import AgentError
 
 from .utils.markers import require_run_all

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -8,8 +8,9 @@ import pytest
 from rich.console import Console
 
 from smolagents.default_tools import FinalAnswerTool, WikipediaSearchTool
+from smolagents.local_python_executor import CodeOutput
 from smolagents.monitoring import AgentLogger, LogLevel
-from smolagents.remote_executors import DockerExecutor, E2BExecutor, RemotePythonExecutor, WasmExecutor
+from smolagents.remote_executors import DockerExecutor, E2BExecutor, RemotePythonExecutor, WasmExecutor, ModalExecutor
 from smolagents.utils import AgentError
 
 from .utils.markers import require_run_all
@@ -198,25 +199,10 @@ class TestDockerExecutorUnit:
             mock_container.remove.assert_called_once()
 
 
-@pytest.fixture
-def docker_executor():
-    executor = DockerExecutor(
-        additional_imports=["pillow", "numpy"],
-        logger=AgentLogger(LogLevel.INFO, Console(force_terminal=False, file=io.StringIO())),
-    )
-    yield executor
-    executor.delete()
-
-
-@require_run_all
-class TestDockerExecutorIntegration:
+class CommonDockerExecutorIntegration:
     @pytest.fixture(autouse=True)
-    def set_executor(self, docker_executor):
-        self.executor = docker_executor
-
-    def test_initialization(self):
-        """Check if DockerExecutor initializes without errors"""
-        assert self.executor.container is not None, "Container should be initialized"
+    def set_executor(self, custom_executor):
+        self.executor = custom_executor
 
     def test_state_persistence(self):
         """Test that variables and imports form one snippet persist in the next"""
@@ -260,15 +246,6 @@ class TestDockerExecutorIntegration:
         with pytest.raises(AgentError) as exception_info:
             self.executor(code_action)
         assert "SyntaxError" in str(exception_info.value), "Should raise a syntax error"
-
-    def test_cleanup_on_deletion(self):
-        """Test if Docker container stops and removes on deletion"""
-        container_id = self.executor.container.id
-        self.executor.delete()  # Trigger cleanup
-
-        client = docker.from_env()
-        containers = [c.id for c in client.containers.list(all=True)]
-        assert container_id not in containers, "Container should be removed"
 
     @pytest.mark.parametrize(
         "code_action, expected_result",
@@ -341,6 +318,99 @@ class TestDockerExecutorIntegration:
         code_output = self.executor(code_action)
         assert code_output.is_final_answer is True
         assert code_output.output == "answer1_CUSTOM_answer2"
+
+
+@require_run_all
+class TestDockerExecutorIntegration(CommonDockerExecutorIntegration):
+    @pytest.fixture
+    def custom_executor(self):
+        executor = DockerExecutor(
+            additional_imports=["pillow", "numpy"],
+            logger=AgentLogger(LogLevel.INFO, Console(force_terminal=False, file=io.StringIO())),
+        )
+        yield executor
+        executor.delete()
+
+    def test_initialization(self):
+        """Check if DockerExecutor initializes without errors"""
+        assert self.executor.container is not None, "Container should be initialized"
+
+    def test_cleanup_on_deletion(self):
+        """Test if Docker container stops and removes on deletion"""
+        container_id = self.executor.container.id
+        self.executor.delete()  # Trigger cleanup
+
+        client = docker.from_env()
+        containers = [c.id for c in client.containers.list(all=True)]
+        assert container_id not in containers, "Container should be removed"
+
+
+@require_run_all
+class TestModalExecutorIntegration(CommonDockerExecutorIntegration):
+    @pytest.fixture
+    def custom_executor(self):
+        executor = ModalExecutor(
+            additional_imports=["pillow", "numpy"],
+            logger=AgentLogger(LogLevel.INFO, Console(force_terminal=False, file=io.StringIO())),
+        )
+        yield executor
+        executor.delete()
+
+
+class TestModalExecutorUnit:
+    @patch("smolagents.remote_executors._websocket_run_code_raise_errors")
+    @patch("requests.post")
+    @patch("requests.get")
+    @patch("websocket.create_connection")
+    @patch("modal.App.lookup")
+    @patch("modal.Sandbox.create")
+    def test_sandbox_lifecycle(
+        self, mock_sandbox_create, mock_app_lookup, mock_create_connection, mock_get, mock_post, mock_run_code_raises
+    ):
+        """Test that sandbox is created with the correct kwargs and cleaned up correctly."""
+        modal = pytest.importorskip("modal")
+        port = 8889
+
+        logger = MagicMock()
+        mock_sandbox = MagicMock()
+        tunnel_mock = MagicMock()
+        tunnel_mock.host = "r4234.modal.host"
+        mock_sandbox.tunnels.return_value = {port: tunnel_mock}
+
+        mock_get.return_value.status_code = 200
+        mock_post.return_value.status_code = 201
+        mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+        mock_run_code_raises.return_value = CodeOutput(output="3", logs="", is_final_answer=False)
+        mock_sandbox_create.return_value = mock_sandbox
+
+        executor = ModalExecutor(
+            additional_imports=[],
+            logger=logger,
+            app_name="my-custom-app-name",
+            port=port,
+            create_kwargs={
+                "secrets": [modal.Secret.from_dict({"MY_SECRET": "ABC"})],
+                "timeout": 100,
+                "cpu": 2,
+            },
+        )
+
+        create_call = mock_sandbox_create.mock_calls[0]
+        assert create_call.args == (
+            "jupyter",
+            "kernelgateway",
+            "--KernelGatewayApp.ip='0.0.0.0'",
+            f"--KernelGatewayApp.port={port}",
+            "--KernelGatewayApp.allow_origin='*'",
+        )
+        assert create_call.kwargs["timeout"] == 100
+        assert create_call.kwargs["cpu"] == 2
+        assert len(create_call.kwargs["secrets"]) == 2
+        mock_app_lookup.assert_called_with("my-custom-app-name", create_if_missing=True)
+
+        executor.run_code_raise_errors("1 + 2")
+        executor.cleanup()
+        mock_sandbox.terminate.assert_called()
 
 
 class TestWasmExecutorUnit:


### PR DESCRIPTION
This PR adds a remote executor backed by [Modal](https://modal.com/), by setting `executor_type="modal"`.

### Implementation Details

The Modal executor shares many of the same functionality as the `DockerExecutor` when it comes to creating an image with a `jupyter_kernel_gateway` and using websockets to talk to the container. With this PR:

1. The shared functionality is refactored into it's own functions and used between the `ModalExecutor` and `DockerExecutor`.
2. The integration tests for docker is refactored into a `CommonDockerExecutorIntegration` which is subclassed by `TestDockerExecutorIntegration` and `TestModalExecutorIntegration`.
3. `CodeAgent` can now accept a `executor_type="modal"`.