### PR TITLE
Use stopping criteria from transformers (and other minor transformer fixes)

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -895,6 +895,7 @@ class TransformersModel(Model):
         warnings.warn("`make_stopping_criteria` is deprecated, pass `stop_strings` directly to `generate` instead")
 
         from transformers import StoppingCriteria, StoppingCriteriaList
+
         class StopOnStrings(StoppingCriteria):
             def __init__(self, stop_strings: list[str], tokenizer):
                 self.stop_strings = stop_strings

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -545,7 +545,7 @@ class TestTransformersModel:
             assert model.model == mocks["transformers.AutoModelForCausalLM.from_pretrained"].return_value
             assert mocks["transformers.AutoModelForCausalLM.from_pretrained"].call_args.kwargs == {
                 "device_map": "cpu",
-                "torch_dtype": "float16",
+                "dtype": "float16",
                 "trust_remote_code": True,
             }
             assert model.tokenizer == mocks["transformers.AutoTokenizer.from_pretrained"].return_value
@@ -555,7 +555,7 @@ class TestTransformersModel:
             assert model.model == mocks["transformers.AutoModelForImageTextToText.from_pretrained"].return_value
             assert mocks["transformers.AutoModelForImageTextToText.from_pretrained"].call_args.kwargs == {
                 "device_map": "cpu",
-                "torch_dtype": "float16",
+                "dtype": "float16",
                 "trust_remote_code": True,
             }
             assert model.processor == mocks["transformers.AutoProcessor.from_pretrained"].return_value


### PR DESCRIPTION
Related to #1703

This PR:
1. [bugfix] Uses the [`transformers` stopping criteria](https://github.com/huggingface/transformers/blob/78f32c3917596b4558d4738e61ff0c39ec0d16ac/src/transformers/generation/stopping_criteria.py#L111) to stop on arbitrary strings, as opposed to using a custom class (more details below)
2. [removes a warning] Updates `torch_dtype` -> `dtype` on transformers-related code. This was a recent deprecation.
3. [removes a warning, possibly fixes bugs] Passes the attention mask from the tokenizer to `generate`. Generating the attention mask on the fly from `input_ids` in `generate` is very brittle and should be avoided.

____________________________

The custom stopping criteria defined in `smolagents` compares the generated text against the defined strings. If the generated text ends in the same strings, it stops generation.

This has two problems:
1. The comparison is done at a text level, so we have to decode the generated tokens at each step (= move tensors to CPU and then decode). In general, this is slow;
2. [source of bugs] to work, the model's generation at a given step has to end exactly on that piece of text. For instance, if we want to stop in `foo bar`, but the model generates `foo bar ` or `foo bar:`, generation won't stop, and we probably want it to stop.

Both issues are addressed in the [class present in `transformers`](https://github.com/huggingface/transformers/blob/78f32c3917596b4558d4738e61ff0c39ec0d16ac/src/transformers/generation/stopping_criteria.py#L111), so let's use it instead 🤗 