### PR TITLE
Remove untranslated sections from the documentation

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -6,27 +6,5 @@
   sections:
   - local: examples/text_to_sql
     title: 스스로 오류를 수정하는 Text-to-SQL
-  - local: in_translation
-    title: (번역중) Master your knowledge base with agentic RAG
   - local: examples/multiagents
     title: 멀티 에이전트 시스템 오케스트레이션
-  - local: in_translation
-    title: (번역중) Build a web browser agent using vision models
-  - local: in_translation
-    title: (번역중) Using different models
-  - local: in_translation
-    title: "(번역중) Human-in-the-Loop: Customize agent plan interactively"
-  - local: in_translation
-    title: (번역중) Async Applications with Agents
-- title: Reference
-  sections:
-  - local: reference/agents
-    title: Agent-related objects
-  - local: reference/models
-    title: Model-related objects
-  - title: Tools
-    sections:
-    - title: Tool-related objects
-      local: reference/tools
-    - title: Built-in Tools
-      local: reference/default_tools


### PR DESCRIPTION
Remove untranslated sections from the documentation `_toctree.yml` file..

Fix #1728.

CC: @stevhliu 