### PR TITLE
fix: add ipykernel in dockerfile of prebuilt docker executor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -379,7 +379,7 @@ class DockerExecutor(RemotePythonExecutor):
             """\
             FROM python:3.12-bullseye
 
-            RUN pip install jupyter_kernel_gateway jupyter_client
+            RUN pip install jupyter_kernel_gateway jupyter_client ipykernel
 
             EXPOSE 8888
             CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", "--KernelGatewayApp.allow_origin='*'"]


### PR DESCRIPTION
smolagents: latest version
root cause: no `ipykernel` in dockerfile

original error message:
```python
Failed to create kernel. Details: {
  "status_code": 500,
  "headers": {
    "Server": "TornadoServer/6.5.2",
    "Content-Type": "application/json",
    "Date": "Fri, 29 Aug 2025 03:25:58 GMT",
    "X-Content-Type-Options": "nosniff",
    "Content-Security-Policy": "frame-ancestors 'self'; report-uri /api/security/csp-report; default-src 'none'",
    "Content-Length": "3159",
    "Set-Cookie": 
"username-127-0-0-1-8888=2|1:0|10:1756437958|23:username-127-0-0-1-8888|144:eyJ1c2VybmFtZSI6ICJhbm9ueW1vdXMiLCAibmFtZSI6ICJBbm9ueW1vdXMiLCAiZGlzcGxhe
V9uYW1lIjogIkFub255bW91cyIsICJpbml0aWFscyI6ICJBbiIsICJjb2xvciI6IG51bGx9|a39a42202da90c340439923bd08451b7ea05a6db90512fcc315527283cefd7af; 
expires=Sun, 28 Sep 2025 03:25:58 GMT; HttpOnly; Path=/"
  },
  "url": "http://127.0.0.1:8888/api/kernels",
  "body": "{\"reason\": \"Internal Server Error\", \"message\": \"Unknown server error\", \"traceback\": \"Traceback (most recent call last):\\n  
File \\\"/usr/local/lib/python3.12/site-packages/tornado/web.py\\\", line 1848, in _execute\\n    result = await result\\n             
^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/handlers.py\\\", line 83, in post\\n    await 
super().post()\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_server/auth/decorator.py\\\", line 73, in inner\\n    return await out\\n
^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/handlers.py\\\", line 55, in post\\n    kernel_id = 
await ensure_async(\\n                ^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\\\", 
line 197, in ensure_async\\n    result = await obj\\n             ^^^^^^^^^\\n  File 
\\\"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/manager.py\\\", line 90, in start_kernel\\n    kernel_id = await 
super().start_kernel(*args, **kwargs)\\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File 
\\\"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/kernelmanager.py\\\", line 238, in _async_start_kernel\\n    kernel_id = 
await self.pinned_superclass._async_start_kernel(self, **kwargs)\\n                
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File 
\\\"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\\\", line 283, in _async_start_kernel\\n    raise 
km.ready.exception()  # type: ignore[misc\]\\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File 
\\\"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\\\", line 232, in _add_kernel_when_ready\\n    await 
kernel_awaitable\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\\\", line 197, in ensure_async\\n    result = 
await obj\\n             ^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\\\", line 96, in wrapper\\n    
raise e\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\\\", line 87, in wrapper\\n    out = await method(self, *args,
**kwargs)\\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\\\", line 
435, in _async_start_kernel\\n    kernel_cmd, kw = await self._async_pre_start_kernel(**kw)\\n                     
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\\\", line 397, in 
_async_pre_start_kernel\\n    self.kernel_spec,\\n    ^^^^^^^^^^^^^^^^\\n  File 
\\\"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\\\", line 195, in kernel_spec\\n    self._kernel_spec = 
self.kernel_spec_manager.get_kernel_spec(self.kernel_name)\\n                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  
File \\\"/usr/local/lib/python3.12/site-packages/jupyter_client/kernelspec.py\\\", line 285, in get_kernel_spec\\n    raise 
NoSuchKernel(kernel_name)\\njupyter_client.kernelspec.NoSuchKernel: No such kernel named python3\\n\"}",
  "request_method": "POST",
  "request_headers": {
    "User-Agent": "python-requests/2.32.5",
    "Accept-Encoding": "gzip, deflate",
    "Accept": "*/*",
    "Connection": "keep-alive",
    "Content-Length": "0"
  },
  "request_body": null
}
Stopping and removing container e69928a1c5a3...
Container cleanup completed
Traceback (most recent call last):
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/.venv/lib/python3.12/site-packages/smolagents/remote_executors.py", line 362, in __init__
    raise RuntimeError(f"Failed to create kernel: Status {r.status_code}\nResponse: {r.text}") from None
RuntimeError: Failed to create kernel: Status 500
Response: {"reason": "Internal Server Error", "message": "Unknown server error", "traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.12/site-packages/tornado/web.py\", line 1848, in _execute\n    result = await result\n             ^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/handlers.py\", line 83, in post\n    await super().post()\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/auth/decorator.py\", line 73, in inner\n    return await out\n           ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/handlers.py\", line 55, in post\n    kernel_id = await ensure_async(\n                ^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\", line 197, in ensure_async\n    result = await obj\n             ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/manager.py\", line 90, in start_kernel\n    kernel_id = await super().start_kernel(*args, **kwargs)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/kernelmanager.py\", line 238, in _async_start_kernel\n    kernel_id = await self.pinned_superclass._async_start_kernel(self, **kwargs)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\", line 283, in _async_start_kernel\n    raise km.ready.exception()  # type: ignore[misc]\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\", line 232, in _add_kernel_when_ready\n    await kernel_awaitable\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\", line 197, in ensure_async\n    result = await obj\n             ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 96, in wrapper\n    raise e\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 87, in wrapper\n    out = await method(self, *args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 435, in _async_start_kernel\n    kernel_cmd, kw = await self._async_pre_start_kernel(**kw)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 397, in _async_pre_start_kernel\n    self.kernel_spec,\n    ^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 195, in kernel_spec\n    self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)\n                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/kernelspec.py\", line 285, in get_kernel_spec\n    raise NoSuchKernel(kernel_name)\njupyter_client.kernelspec.NoSuchKernel: No such kernel named python3\n"}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/main.py", line 20, in <module>
    main()
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/main.py", line 6, in main
    with CodeAgent(
         ^^^^^^^^^^
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/.venv/lib/python3.12/site-packages/smolagents/agents.py", line 1527, in __init__
    self.python_executor = self.create_python_executor()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/.venv/lib/python3.12/site-packages/smolagents/agents.py", line 1554, in create_python_executor
    return remote_executors[self.executor_type](
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/cyyeh/Desktop/ai-stuffs/agents-playground/coding-agent/.venv/lib/python3.12/site-packages/smolagents/remote_executors.py", line 376, in __init__
    raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
RuntimeError: Failed to initialize Jupyter kernel: Failed to create kernel: Status 500
Response: {"reason": "Internal Server Error", "message": "Unknown server error", "traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.12/site-packages/tornado/web.py\", line 1848, in _execute\n    result = await result\n             ^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/handlers.py\", line 83, in post\n    await super().post()\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/auth/decorator.py\", line 73, in inner\n    return await out\n           ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/handlers.py\", line 55, in post\n    kernel_id = await ensure_async(\n                ^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\", line 197, in ensure_async\n    result = await obj\n             ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/kernel_gateway/services/kernels/manager.py\", line 90, in start_kernel\n    kernel_id = await super().start_kernel(*args, **kwargs)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_server/services/kernels/kernelmanager.py\", line 238, in _async_start_kernel\n    kernel_id = await self.pinned_superclass._async_start_kernel(self, **kwargs)\n                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\", line 283, in _async_start_kernel\n    raise km.ready.exception()  # type: ignore[misc]\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/multikernelmanager.py\", line 232, in _add_kernel_when_ready\n    await kernel_awaitable\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_core/utils/__init__.py\", line 197, in ensure_async\n    result = await obj\n             ^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 96, in wrapper\n    raise e\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 87, in wrapper\n    out = await method(self, *args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 435, in _async_start_kernel\n    kernel_cmd, kw = await self._async_pre_start_kernel(**kw)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 397, in _async_pre_start_kernel\n    self.kernel_spec,\n    ^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/manager.py\", line 195, in kernel_spec\n    self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)\n                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/jupyter_client/kernelspec.py\", line 285, in get_kernel_spec\n    raise NoSuchKernel(kernel_name)\njupyter_client.kernelspec.NoSuchKernel: No such kernel named python3\n"}
```