### PR TITLE
Fix E2BExecutor by pinning e2b-code-interpreter to < 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docker = [
   "websocket-client",
 ]
 e2b = [
-  "e2b-code-interpreter>=1.0.3",
+  "e2b-code-interpreter>=1.0.3, < 2",
   "python-dotenv>=1.0.1",
 ]
 gradio = [


### PR DESCRIPTION
Fix E2BExecutor by pinning e2b-code-interpreter to < 2.

The e2b-code-interpreter package introduced breaking changes in the 2.0.0 release, which currently cause the E2BExecutor to fail:
- [@e2b/code-interpreter-python@2.0.0](https://github.com/e2b-dev/code-interpreter/releases/tag/%40e2b%2Fcode-interpreter-python%402.0.0)

This PR updates our dependencies to pin e2b-code-interpreter to versions < 2, ensuring the executor works as expected until we add support for 2.x.

Notes:
- Users experiencing issues can reinstall with:
  ```shell
  pip install -U "e2b-code-interpreter<2"
  ```
- We will update or remove the pin once compatibility with 2.x is implemented.

Fix #1730.