### PR TITLE
Use context manager for per-operation websocket connection in DockerExecutor

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -366,7 +366,6 @@ class DockerExecutor(RemotePythonExecutor):
         super().__init__(additional_imports, logger)
         try:
             import docker
-            from websocket import create_connection
         except ModuleNotFoundError:
             raise ModuleNotFoundError(
                 "Please install 'docker' extra to use DockerExecutor: `pip install 'smolagents[docker]'`"
@@ -445,9 +444,7 @@ class DockerExecutor(RemotePythonExecutor):
 
             # Create new kernel via HTTP
             self.kernel_id = _create_kernel_http(f"{self.base_url}/api/kernels", self.logger)
-
-            ws_url = f"ws://{host}:{port}/api/kernels/{self.kernel_id}/channels"
-            self.ws = create_connection(ws_url)
+            self.ws_url = f"ws://{host}:{port}/api/kernels/{self.kernel_id}/channels"
 
             self.installed_packages = self.install_packages(additional_imports)
             self.logger.log(
@@ -459,7 +456,10 @@ class DockerExecutor(RemotePythonExecutor):
             raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
 
     def run_code_raise_errors(self, code: str) -> CodeOutput:
-        return _websocket_run_code_raise_errors(code, self.ws, self.logger)
+        from websocket import create_connection
+
+        with closing(create_connection(self.ws_url)) as ws:
+            return _websocket_run_code_raise_errors(code, ws, self.logger)
 
     def cleanup(self):
         """Clean up the Docker container and resources."""


### PR DESCRIPTION
Use context manager for per-operation websocket connection in DockerExecutor.

Refactor DockerExecutor to use per-operation websocket connections like ModalExecutor.

The current DockerExecutor maintains a persistent websocket connection that is created during initialization and stored as an instance variable. This approach has several drawbacks:
  - Requires manual cleanup logic in the cleanup() method
  - More error-prone due to connection state management
  - Inconsistent with ModalExecutor pattern
  - Connection can become stale over time

This PR refactors DockerExecutor to follow the same pattern as ModalExecutor by creating websocket connections per operation using context managers:
  1. Removed persistent websocket connection: No longer store self.ws during initialization
  2. Per-operation connections: Create websocket connection in run_code_raise_errors() method
  3. Context manager usage: Use contextlib.closing() to ensure automatic resource cleanup
  4. Simplified cleanup: Removed websocket cleanup from cleanup() method
