### PR TITLE
Fix token count initialization when plan_message.token_usage is None

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -671,14 +671,10 @@ You have been provided with these additional arguments, that you can access dire
             else:
                 plan_message = self.model.generate(input_messages, stop_sequences=["<end_plan>"])
                 plan_message_content = plan_message.content
-                input_tokens, output_tokens = (
-                    (
-                        plan_message.token_usage.input_tokens,
-                        plan_message.token_usage.output_tokens,
-                    )
-                    if plan_message.token_usage
-                    else (0, 0)
-                )
+                input_tokens, output_tokens = 0, 0
+                if plan_message.token_usage:
+                    input_tokens = plan_message.token_usage.input_tokens
+                    output_tokens = plan_message.token_usage.output_tokens
             plan = textwrap.dedent(
                 f"""Here are the facts I know and the plan of action that I will follow to solve the task:\n```\n{plan_message_content}\n```"""
             )

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -665,8 +665,8 @@ You have been provided with these additional arguments, that you can access dire
                             plan_message_content += event.content
                             live.update(Markdown(plan_message_content))
                             if event.token_usage:
-                                output_tokens += event.token_usage.output_tokens
                                 input_tokens = event.token_usage.input_tokens
+                                output_tokens += event.token_usage.output_tokens
                         yield event
             else:
                 plan_message = self.model.generate(input_messages, stop_sequences=["<end_plan>"])
@@ -723,17 +723,16 @@ You have been provided with these additional arguments, that you can access dire
                             plan_message_content += event.content
                             live.update(Markdown(plan_message_content))
                             if event.token_usage:
-                                output_tokens += event.token_usage.output_tokens
                                 input_tokens = event.token_usage.input_tokens
+                                output_tokens += event.token_usage.output_tokens
                         yield event
             else:
                 plan_message = self.model.generate(input_messages, stop_sequences=["<end_plan>"])
                 plan_message_content = plan_message.content
-                if plan_message.token_usage is not None:
-                    input_tokens, output_tokens = (
-                        plan_message.token_usage.input_tokens,
-                        plan_message.token_usage.output_tokens,
-                    )
+                input_tokens, output_tokens = 0, 0
+                if plan_message.token_usage:
+                    input_tokens = plan_message.token_usage.input_tokens
+                    output_tokens = plan_message.token_usage.output_tokens
             plan = textwrap.dedent(
                 f"""I still need to solve the task I was given:\n```\n{self.task}\n```\n\nHere are the facts I know and my new/updated plan of action to solve the task:\n```\n{plan_message_content}\n```"""
             )

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -677,7 +677,7 @@ You have been provided with these additional arguments, that you can access dire
                         plan_message.token_usage.output_tokens,
                     )
                     if plan_message.token_usage
-                    else (None, None)
+                    else (0, 0)
                 )
             plan = textwrap.dedent(
                 f"""Here are the facts I know and the plan of action that I will follow to solve the task:\n```\n{plan_message_content}\n```"""


### PR DESCRIPTION
When plan_message.token_usage is None, the code was assigning (None, None) to input_tokens and output_tokens, which later caused UnboundLocalError when creating TokenUsage objects that expect integer values.

This fix changes the fallback from (None, None) to (0, 0) to ensure token usage tracking works correctly even when token usage information is unavailable from the LLM provider.

Fixes issue where agent planning step crashes with: 'cannot access local variable "input_tokens" where it is not associated with a value'