### PR TITLE
fix(agent): remove unused get_variable_names function

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -17,7 +17,6 @@
 import importlib
 import json
 import os
-import re
 import tempfile
 import textwrap
 import time
@@ -96,11 +95,6 @@ from .utils import (
 
 
 logger = getLogger(__name__)
-
-
-def get_variable_names(self, template: str) -> set[str]:
-    pattern = re.compile(r"\{\{([^{}]+)\}\}")
-    return {match.group(1).strip() for match in pattern.finditer(template)}
 
 
 def populate_template(template: str, variables: dict[str, Any]) -> str:


### PR DESCRIPTION
### Description
This PR removes the unused `get_variable_names` function from `src/smolagents/agents.py` that was introduced in commit 8ba036bba0392b36b72d0e60e808cfe7e329b954.

### Motivation
The `get_variable_names` function is dead code that:
- Has no callers anywhere in the codebase
- Has no test coverage
- Is not referenced in documentation
- Contributes to unnecessary code bloat

Removing unused code improves:
- Code maintainability
- Codebase clarity
- Reduces potential confusion for developers

### Changes Made
- Removed the `get_variable_names` function (lines 101-103) and `import re` from `src/smolagents/agents.py`

**Note**: This function was originally introduced in [commit 8ba036b](https://github.com/huggingface/smolagents/commit/8ba036bba0392b36b72d0e60e808cfe7e329b954) but never actually used in the codebase.