### PR TITLE
Fix AttributeError when trying to log a None

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1663,7 +1663,7 @@ class CodeAgent(MultiStepAgent):
                 memory_step.model_output_message = chat_message
                 output_text = chat_message.content
                 self.logger.log_markdown(
-                    content=output_text,
+                    content=output_text or "",
                     title="Output message of the LLM:",
                     level=LogLevel.DEBUG,
                 )


### PR DESCRIPTION
Fix `AttributeError` when trying to log a None.

This pull request makes a minor update to the `_step_stream` method in `src/smolagents/agents.py` to improve logging robustness. The change ensures that the logger always receives a string, preventing AttributeError if `output_text` is `None`.

Fix #1785.