### PR TITLE
Fix logging "None" and simplify the logic

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1288,7 +1288,7 @@ class ToolCallingAgent(MultiStepAgent):
                 if chat_message.content is None and chat_message.raw is not None:
                     log_content = str(chat_message.raw)
                 else:
-                    log_content = str(chat_message.content) or ""
+                    log_content = str(chat_message.content or "")
 
                 self.logger.log_markdown(
                     content=log_content,

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1285,13 +1285,8 @@ class ToolCallingAgent(MultiStepAgent):
                     stop_sequences=["Observation:", "Calling tools:"],
                     tools_to_call_from=self.tools_and_managed_agents,
                 )
-                if chat_message.content is None and chat_message.raw is not None:
-                    log_content = str(chat_message.raw)
-                else:
-                    log_content = str(chat_message.content or "")
-
                 self.logger.log_markdown(
-                    content=log_content,
+                    content=str(chat_message.content or chat_message.raw or ""),
                     title="Output message of the LLM:",
                     level=LogLevel.DEBUG,
                 )


### PR DESCRIPTION
This PR simplifies how the output message from the LLM is logged by `ToolCalligAgent._step_stream`, ensuring that either the `content` or `raw` field is used, whichever is available, and that `"None"` is not logged.
* Simplified the logic for logging reducing unnecessary conditional checks.

Follow-up to:
- #1786