### PR TITLE
Improve error handling for short output token lengths

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -155,7 +155,7 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
         json_data = json.loads(json_str, strict=False)
         return json_data, json_blob[:first_accolade_index]
     except IndexError:
-        raise ValueError("The model output does not contain any JSON blob.")
+        raise ValueError("The model output does not contain any JSON blob. Try increasing the maximum output token length.")
     except json.JSONDecodeError as e:
         place = e.pos
         if json_blob[place - 1 : place + 2] == "},\n":


### PR DESCRIPTION
When the output token length is smaller than required for a particular use case, the user sees parsing errors. It is unclear to them that the issue might be with the shorter token length. They might see errors like 
```
Error while parsing tool call from model output: The model output does not contain any JSON blob.
```
for ToolCallingAgents and 
```
The code blob is invalid, because the regex pattern ```(?:py|python)?\n(.*?)\n``` was not found in code_blob
```
for CodeAgents


Issues: https://github.com/huggingface/smolagents/issues/1783, https://github.com/huggingface/smolagents/issues/1732, etc

There are older threads were the issue is mentioned. https://github.com/huggingface/smolagents/issues/201#issuecomment-2698686267, Workaround was to increase the output tokens

> That happens with some models. Sometimes it can be tweaked by increasing max_tokens or num_ctx


It is also mentioned that longer contexts are better in an example in the docs
https://github.com/huggingface/smolagents/blob/f76dee172666d7dad178aed06b257c629967733b/docs/source/en/guided_tour.md?plain=1#L189

This PR tries to 
1. Improve error logging
2. Adding a note in the documentation