### PR TITLE
Fix LocalPythonExecutor support for Enum and other metaclasses

### DIFF
--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1344,6 +1344,38 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         assert state["TestClass"].key_data == {"key": "value"}
         assert state["TestClass"].index_data == ["a", "b", 30]
 
+    def test_evaluate_class_def_with_enum(self):
+        """
+        Test evaluate_class_def function with Enum classes.
+
+        This test ensures that Enum classes are correctly handled by using the
+        appropriate metaclass and __prepare__ method.
+        """
+        code = dedent("""
+        from enum import Enum
+
+        class Status(Enum):
+            SUCCESS = "Success"
+            FAILURE = "Failure"
+            PENDING = "Pending"
+            ERROR = "Error"
+
+        status_value = Status.SUCCESS.value
+        status_name = Status.SUCCESS.name
+        """)
+
+        state = {}
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state=state, authorized_imports=["enum"])
+
+        assert state["status_value"] == "Success"
+        assert state["status_name"] == "SUCCESS"
+        assert isinstance(state["Status"], type)
+        assert hasattr(state["Status"], "SUCCESS")
+        assert state["Status"].SUCCESS.value == "Success"
+        assert state["Status"].FAILURE.value == "Failure"
+        assert state["Status"].PENDING.value == "Pending"
+        assert state["Status"].ERROR.value == "Error"
+
     def test_evaluate_annassign(self):
         code = dedent("""\
             # Basic annotated assignment


### PR DESCRIPTION
## Summary

Fixes #1795

This PR fixes a bug where `LocalPythonExecutor` fails to execute code that defines Enum classes (or any class using a custom metaclass with `__prepare__`).

## Problem

The `LocalPythonExecutor` was using the generic `type()` function to create all classes, which fails for classes with custom metaclasses like Enum. Python's Enum metaclass (`EnumMeta`) requires a special `_EnumDict` namespace object during class creation, not a regular dict.

### Reproduction

```python
from smolagents.local_python_executor import LocalPythonExecutor
import builtins

code = """
from enum import Enum

class Status(Enum):
    SUCCESS = "Success"
    FAILURE = "Failure"

print(Status.SUCCESS)
"""

executor = LocalPythonExecutor(["enum"])
executor.send_tools({"print": builtins.print})
result = executor(code)  # Raises: AttributeError: 'dict' object has no attribute '_member_names'
```

## Solution

This PR modifies the `evaluate_class_def` function to:
1. Detect when a base class has a custom metaclass
2. Use the metaclass's `__prepare__()` method if available to create the proper namespace dictionary
3. Use the detected metaclass instead of `type()` when instantiating the class

This approach handles not just Enum, but any class with a custom metaclass that implements `__prepare__()`.

## Changes

- Modified `src/smolagents/local_python_executor.py`: Updated `evaluate_class_def` to support custom metaclasses
- Added test `test_evaluate_class_def_with_enum` to verify Enum support