### PR TITLE
Move executor type validation to python executor creation

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1551,8 +1551,6 @@ class CodeAgent(MultiStepAgent):
                 "Caution: you set an authorization for all imports, meaning your agent can decide to import any package it deems necessary. This might raise issues if the package is not installed in your environment.",
                 level=LogLevel.INFO,
             )
-        if executor_type not in {"local", "e2b", "modal", "docker", "wasm"}:
-            raise ValueError(f"Unsupported executor type: {executor_type}")
         self.executor_type = executor_type
         self.executor_kwargs: dict[str, Any] = executor_kwargs or {}
         self.python_executor = self.create_python_executor()
@@ -1569,6 +1567,9 @@ class CodeAgent(MultiStepAgent):
             self.python_executor.cleanup()
 
     def create_python_executor(self) -> PythonExecutor:
+        if self.executor_type not in {"local", "e2b", "modal", "docker", "wasm"}:
+            raise ValueError(f"Unsupported executor type: {self.executor_type}")
+
         if self.executor_type == "local":
             return LocalPythonExecutor(
                 self.additional_authorized_imports,


### PR DESCRIPTION
Fix proposition for #1799  

Moves the executor type validation logic from the `CodeAgent.__init__` method to the `create_python_executor` method.  
This small refactor enables users to subclass CodeAgent, implement custom executors without triggering a ValueError during initialization and keeps backward compatibility and existing validation logic for built-in executors.

If appropriate please feel free to make changes directly.

Tested with local, docker and 2 other custom remote executor.