### PR TITLE
Remove duplicate yield action_step in _run_stream()

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -602,7 +602,6 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         yield FinalAnswerStep(handle_agent_output_types(final_answer))
 
     def _validate_final_answer(self, final_answer: Any):


### PR DESCRIPTION
# Fix duplicate action_step yield and NameError in _run_stream()

## Description

This PR fixes two issues in the `_run_stream` method of the `MultiStepAgent` class:

1. When an agent reaches max_steps, the final action_step was being yielded twice - once in the finally block and again after the while loop
2. When max_steps=0, the code attempted to yield an undefined action_step variable, causing a NameError

## Changes

- Removed the duplicate `yield action_step` on line 605 in `src/smolagents/agents.py`
- The action_step is already properly yielded in the finally block (line 600), so the additional yield was both redundant and problematic

## Impact

This fix ensures that:
- Stream consumers receive each action_step exactly once
- Edge cases like max_steps=0 are handled gracefully without errors
- Both CodeAgent and ToolCallingAgent benefit from this fix since they inherit from MultiStepAgent

Fixes #1816 

