### PR TITLE
make additional_args nullable for managed agents

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -379,6 +379,7 @@ class MultiStepAgent(ABC):
                     "additional_args": {
                         "type": "object",
                         "description": "Dictionary of extra inputs to pass to the managed agent, e.g. images, dataframes, or any other contextual data it may need.",
+                        "nullable": True,
                     },
                 }
                 agent.output_type = "string"


### PR DESCRIPTION
_setup_managed_agents in MultiStepAgent defines a schema for managed_agents.
The schema contains additional_args.
additional_args is not always needed when managed_agents are called and some models don't set it when calling the agent.

When using managed agents I ran into them being called  and giving the error 
`Argument additional_args is required`
 until the maximum number of steps is exhausted. 

Making additional_args nullable in the schema fixes this.