### PR TITLE
Allow builtin functions when "*" in authorized imports

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -858,7 +858,12 @@ def evaluate_call(
         state["_print_outputs"] += " ".join(map(str, args)) + "\n"
         return None
     else:  # Assume it's a callable object
-        if ("*" not in authorized_imports) and (inspect.getmodule(func) == builtins) and inspect.isbuiltin(func) and (func not in static_tools.values()):
+        if (
+            ("*" not in authorized_imports)
+            and (inspect.getmodule(func) == builtins)
+            and inspect.isbuiltin(func)
+            and (func not in static_tools.values())
+        ):
             raise InterpreterError(
                 f"Invoking a builtin function that has not been explicitly added as a tool is not allowed ({func_name})."
             )

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2661,3 +2661,30 @@ class TestLocalPythonExecutorSecurity:
         )
         with expectation:
             executor(code)
+
+    @pytest.mark.parametrize(
+        "static_tools, authorized_imports, expectation, expected_result",
+        [
+            ({}, ["*"], does_not_raise(), 3),
+            ({}, [], pytest.raises(InterpreterError, match="Forbidden function evaluation: 'eval'"), None),
+            ({"eval": eval}, [], does_not_raise(), 3),
+            (
+                {},
+                ["math", "numpy"],
+                pytest.raises(InterpreterError, match="Forbidden function evaluation: 'eval'"),
+                None,
+            ),
+        ],
+    )
+    def test_builtin_with_wildcard_authorized_imports(
+        self, static_tools, authorized_imports, expectation, expected_result
+    ):
+        code = "result = eval('1 + 2')"
+        state = {}
+
+        with expectation:
+            result, _ = evaluate_python_code(
+                code, static_tools=static_tools, state=state, authorized_imports=authorized_imports
+            )
+            if expected_result is not None:
+                assert result == expected_result


### PR DESCRIPTION
Fix for https://github.com/huggingface/smolagents/issues/1830

Even if the user passes "*" in the authorized imports (Unrestricted mode), builtin functions aren't allowed
I think it is fair for the user to assume that builtin functions will be available when they use `*`

#### Repro example

Code to reproduce the issue
```
from smolagents import LocalPythonExecutor
executor = LocalPythonExecutor(additional_authorized_imports=['*'])
executor.send_tools({})
print(executor("""with open('sample.txt', 'rb') as f:
    data = f.read()
print(data)"""))
```
Error
```
smolagents.local_python_executor.InterpreterError: Code execution failed at line 'with open('myfile.xlsx', 'rb') as f:
    data = f.read()' due to: InterpreterError: Forbidden function evaluation: 'open' is not among the explicitly allowed tools or defined/imported in the preceding code
```
After change
```
CodeOutput(output=None, logs="b'hello world!'\n", is_final_answer=False)
```

#### Use case from GH Issue
- User wants to make smolagents work with local files. 
- They've modified the prompt to indicate that there are authorized files the LLM can access. 
- They are passing `additional_authorized_imports=["*"]`. 
- But when the generated python code tries to open the file the forbidden function error is faced. 
Side note: The LLM retries with `pandas.open` and that passes