### PR TITLE
Fix YAML scanner error when building documentation

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -37,7 +37,7 @@
   - local: examples/using_different_models
     title: 다양한 모델 사용하기
   - local: examples/plan_customization
-    title: Human-in-the-Loop: 사용자와 상호작용하며 에이전트 계획 수정하기
+    title: "Human-in-the-Loop: 사용자와 상호작용하며 에이전트 계획 수정하기"
   - local: examples/async_agent
     title: 에이전트를 활용한 비동기 애플리케이션
 - title: Reference


### PR DESCRIPTION
Fix YAML scanner error: https://github.com/huggingface/smolagents/actions/runs/18935709361/job/54061973476
```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<unicode string>", line 40, column 29:
        title: Human-in-the-Loop: 사용자와 상호작용하며 에이전트 계획 수정하기
                                ^
Error: Process completed with exit code 1.
```

This bug was introduced in:
- #1771