### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ limitations under the License.
     <a href="https://huggingface.co/docs/smolagents"><img alt="Documentation" src="https://img.shields.io/website/http/huggingface.co/docs/smolagents/index.html.svg?down_color=red&down_message=offline&up_message=online"></a>
     <a href="https://github.com/huggingface/smolagents/releases"><img alt="GitHub release" src="https://img.shields.io/github/release/huggingface/smolagents.svg"></a>
     <a href="https://github.com/huggingface/smolagents/blob/main/CODE_OF_CONDUCT.md"><img alt="Contributor Covenant" src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg"></a>
+    <a href="https://deepwiki.com/huggingface/smolagents"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 <h3 align="center">


### PR DESCRIPTION
Deepwiki is crazy helpful, just check this out: [https://deepwiki.com/huggingface/smolagents](https://deepwiki.com/huggingface/smolagents)
The homepage has an execution graph which is honestly better than everything else I've seen, makes the process crystal clear.

<img width="957" height="907" alt="image" src="https://github.com/user-attachments/assets/67cb80f5-b209-440f-94bd-36ff24e96397" />

This change adds the deepwiki badge to readme, both to let users access it more easily and to let our deepwiki graph auto-update to always be fresh.