### PR TITLE
Fix: Add backward compatibility for deprecated HfApiModel

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1111,7 +1111,6 @@ You have been provided with these additional arguments, that you can access dire
         # Load agent.json
         folder = Path(folder)
         agent_dict = json.loads((folder / "agent.json").read_text())
-
         # Handle HfApiModel -> InferenceClientModel rename for old agents
         if agent_dict.get("model", {}).get("class") == "HfApiModel":
             agent_dict["model"]["class"] = "InferenceClientModel"


### PR DESCRIPTION
This PR fixes an **AttributeError:** module 'smolagents.models' has no attribute 'HfApiModel' that occurs when loading older agents from the Hub.
I faced this problem when loading Alfred 

The fix adds backward compatibility to the from_dict method, mapping the deprecated HfApiModel class name to the new InferenceClientModel and logging a warning.

Tested locally by successfully loading sergiopaniego/AlfredAgent.

Running on Colab without the Modification:

```python
Fetching 14 files: 100%
 14/14 [00:00<00:00, 699.67it/s]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[/tmp/ipython-input-3564958758.py](https://localhost:8080/#) in <cell line: 0>()
      1 agent = CodeAgent(tools=[], model=InferenceClientModel())
----> 2 alfred_agent = agent.from_hub('sergiopaniego/AlfredAgent', trust_remote_code=True)

3 frames
[/usr/local/lib/python3.12/dist-packages/smolagents/agents.py](https://localhost:8080/#) in from_dict(cls, agent_dict, **kwargs)
   1015         # Load model
   1016         model_info = agent_dict["model"]
-> 1017         model_class = getattr(importlib.import_module("smolagents.models"), model_info["class"])
   1018         model = model_class.from_dict(model_info["data"])
   1019         # Load tools

AttributeError: module 'smolagents.models' has no attribute 'HfApiModel'
```

Running after Modification:
```python
Fetching 14 files: 100%|14/14 [00:00<?, ?it/s] 
WARNING:smolagents.agents:Loading an agent created with the deprecated 'HfApiModel' class. This class has been renamed to 'InferenceClientModel'. The agent's model class has been automatically updated for compatibility.
```
