### PR TITLE
Fixed SyntaxError format: keep exception type and message on same line (#835)

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1553,10 +1553,9 @@ def evaluate_python_code(
         expression = ast.parse(code)
     except SyntaxError as e:
         raise InterpreterError(
-            f"Code parsing failed on line {e.lineno} due to: {type(e).__name__}\n"
+            f"Code parsing failed on line {e.lineno} due to: {type(e).__name__}: {str(e)}\n"
             f"{e.text}"
-            f"{' ' * (e.offset or 0)}^\n"
-            f"Error: {str(e)}"
+            f"{' ' * (e.offset or 0)}^"
         )
 
     if state is None:


### PR DESCRIPTION
Resolves (#835)

**Problem**
SyntaxError messages separated exception type from error message across multiple lines, making harder for LLMs to identify error categories.

**Before**
Code parsing failed on line 4 due to: SyntaxError give_yes(os.environ['PWD']) ^ Error: '(' was never closed (<unknown>, line 4)

**After**
Code parsing failed on line 4 due to: SyntaxError: '(' was never closed (<unknown>, line 4) give_yes(os.environ['PWD']) ^

**Changes
- Reformatted SyntaxError handler in `local_python_executor.py:1555-1559`
- Exception type + message now on single line (consistent with runtime errors)
- Removed redundant "Error:" separator