### PR TITLE
Add gpt-5.1 support

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -403,7 +403,7 @@ def supports_stop_parameter(model_id: str) -> bool:
     """
     model_name = model_id.split("/")[-1]
     # o3, o4-mini, grok-3-mini, grok-4, grok-code-fast and the gpt-5 series (including versioned variants, o3-2025-04-16) don't support stop parameter
-    openai_model_pattern = r"(o3[-\d]*|o4-mini[-\d]*|gpt-5(-mini|-nano)?[-\d]*)"
+    openai_model_pattern = r"(o3[-\d]*|o4-mini[-\d]*|gpt-5(-mini|-nano)?[-\d]*|gpt-5.1[-\d]*)"
     grok_model_pattern = r"([a-zA-Z]+\.)?(grok-3-mini|grok-4|grok-code-fast)(-[A-Za-z0-9]*)?"
     pattern = rf"^({openai_model_pattern}|{grok_model_pattern})$"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -845,6 +845,7 @@ def test_flatten_messages_as_text_for_all_models(
         # Unsupported base models
         ("o3", False),
         ("o4-mini", False),
+        ("gpt-5.1", False),
         ("gpt-5", False),
         ("gpt-5-mini", False),
         ("gpt-5-nano", False),


### PR DESCRIPTION
gpt-5.1 does not support the stop parameter. This PR adds it to the exclusion regex in `supports_stop_parameter`

Before change
```
smolagents.utils.AgentGenerationError: Error in generating model output:
Error code: 400 - {'error': {'message': "Unsupported parameter: 'stop' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'stop', 'code': 'unsupported_parameter'}}
```
After change
```
╭──────────────────────────────────────────────────────────────────────── New run ─────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                          │
│ Could you give me the 118th number in the Fibonacci sequence?                                                                                            │
│                                                                                                                                                          │
╰─ OpenAIModel - gpt-5.1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ─ Executing parsed code: ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  def fib(n):
      a, b = 0, 1
      for _ in range(n):
          a, b = b, a + b
      return a

  result_118 = fib(118)
  final_answer(result_118)
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 