### PR TITLE
handled new code pattern

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -179,6 +179,13 @@ def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str |
         return "\n\n".join(match.strip() for match in matches)
     return None
 
+def extract_and_fix_code(text: str, code_block_tags: tuple[str, str] | None = None) -> str | None:
+    """Extracts code pattern between ``` and ```</code>, from LLM's output"""
+    pattern = r"```(?:[a-zA-Z0-9_-]*)?(.*?)```</code>"
+    matches = re.search(pattern, text, re.DOTALL)
+    if matches:
+        return f"{matches.group(1).strip()}"
+    return None
 
 def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     """Extract code blocs from the LLM's output.
@@ -197,6 +204,8 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     matches = extract_code_from_text(text, code_block_tags)
     if not matches:  # Fallback to markdown pattern
         matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))
+    if not matches:
+        matches=extract_and_fix_code(text)
     if matches:
         return matches
     # Maybe the LLM outputted a code blob directly


### PR DESCRIPTION
This update improves the code extraction regex to correctly handle LLM outputs that contain mixed or malformed code block patterns, such as:

Sample :
<img width="1492" height="432" alt="Screenshot 2025-11-09 200517" src="https://github.com/user-attachments/assets/287753e3-22ff-4c21-9fad-49bd4f9b0fa1" />


Previously, these patterns caused parsing failures.

The updated logic adds a fallback extractor that:
Detects code blocks ending with </code>
Handles mixed markdown + HTML-style code patterns
Extracts and cleans code reliably even when the LLM produces inconsistent formatting


