### PR TITLE
Adding time limit parameter to duck duck go search tool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -142,7 +142,7 @@ class DuckDuckGoSearchTool(Tool):
 
     def forward(self, query: str, timelimit: str | None = None) -> str:
         self._enforce_rate_limit()
-        results = self.ddgs.text(query, max_results=self.max_results)
+        results = self.ddgs.text(query, max_results=self.max_results, timelimit=timelimit)
         if len(results) == 0:
             raise Exception("No results found! Try a less restrictive/shorter query.")
         postprocessed_results = [f"[{result['title']}]({result['href']})\n{result['body']}" for result in results]


### PR DESCRIPTION
This adds an addition argument to the run method in the DuckDuckGoSearchTool, which adds optional filtering based on a time range -- d, w, m, y give results from the last day, week, month, or year respectively and a filter in the format "YYYY.MM.DD..YYYY.MM.DD" gives results between the two provided dates.

This is useful for
1. Backtesting -- we can test frameworks like open deep research by limiting web search to a limited timeframe, and test predictions against realized events from dates beyond the timeframe
2. Historical research -- we can limit the tool to pull results from a given historical range