### PR TITLE
fix(gradio_ui): Gradio 6 compatibility

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -433,36 +433,31 @@ class GradioUI:
         import gradio as gr
 
         # Gradio 5.x requires type="messages", but Gradio 6 removed this parameter
-        chatbot_kwargs = {
-            "label": "Agent",
-            "avatar_images": (
+        type_messages_kwarg = {"type": "messages"} if gr.__version__.startswith("5") else {}
+
+        chatbot = gr.Chatbot(
+            label="Agent",
+            avatar_images=(
                 None,
                 "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/mascot_smol.png",
             ),
-            "latex_delimiters": [
+            latex_delimiters=[
                 {"left": r"$$", "right": r"$$", "display": True},
                 {"left": r"$", "right": r"$", "display": False},
                 {"left": r"\[", "right": r"\]", "display": True},
                 {"left": r"\(", "right": r"\)", "display": False},
             ],
-        }
-        if gr.__version__.startswith("5"):
-            chatbot_kwargs["type"] = "messages"
+            **type_messages_kwarg,
+        )
 
-        chatbot = gr.Chatbot(**chatbot_kwargs)
-
-        # Build ChatInterface kwargs with version-specific parameters
-        chat_kwargs = {
-            "fn": self._stream_response,
-            "chatbot": chatbot,
-            "title": self.name.replace("_", " ").capitalize(),
-            "multimodal": self.file_upload_folder is not None,
-            "save_history": True,
-        }
-        if gr.__version__.startswith("5"):
-            chat_kwargs["type"] = "messages"
-
-        demo = gr.ChatInterface(**chat_kwargs)
+        demo = gr.ChatInterface(
+            fn=self._stream_response,
+            chatbot=chatbot,
+            title=self.name.replace("_", " ").capitalize(),
+            multimodal=self.file_upload_folder is not None,
+            save_history=True,
+            **type_messages_kwarg,
+        )
         return demo
 
 


### PR DESCRIPTION
## Summary

- Migrate `GradioUI` from custom `gr.Blocks` implementation to `gr.ChatInterface` for Gradio 6 compatibility
- Fix intermediate tool calls not displaying in the chatbot conversation

## Changes

### Gradio 6 Migration

The previous implementation used `gr.Blocks` with manual event handlers and passed `theme` to `gr.Blocks()`. Gradio 6 moved the `theme` parameter to `.launch()` and changed other APIs.

This PR migrates to `gr.ChatInterface` which:
- Provides a native chatbot experience with built-in input handling
- Handles the theme parameter correctly
- Supports multimodal input (file attachments) when `file_upload_folder` is set
- Enables `save_history=True` for conversation persistence

### Tool Calls Display Fix

Tool calls were not appearing because `ChatInterface` streaming replaces each yield with the next one (designed for streaming a single response). 

Fixed by accumulating all messages into a list and yielding the full list on each update, so all intermediate steps (tool calls, execution logs, planning steps) persist in the conversation.

## Closes

- Closes #1901 
- Closes #1887

## Test Plan

- [x] Tested with Gradio 6.1.0
- [x] Verified tool calls appear as collapsible accordions
- [x] Verified streaming text updates work correctly
- [x] Verified final answer displays properly
- [x] Verified multimodal file upload works when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>