### PR TITLE
feat(agents): add CustomCodeAgent with OpenHands SDK integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "software-agent-sdk"]
+	path = software-agent-sdk
+	url = https://github.com/OpenHands/software-agent-sdk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "software-agent-sdk"]
-	path = software-agent-sdk
-	url = https://github.com/OpenHands/software-agent-sdk.git

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -20,22 +20,24 @@ model = LiteLLMModel(model_id="gpt-4")
 # Default: custom LLM, local execution
 agent = CustomCodeAgent(tools=[], model=model)
 
-# Auto mode: agent manages Docker container
+# Local container: agent manages Docker container
 agent = CustomCodeAgent(
     tools=[],
     model=model,
     use_custom_provider_code_execution_sandbox=True,
-    container_handler="auto",  # default
-    openhands_agent_auto_image="ghcr.io/openhands/agent-server:latest-python"
+    sandbox_mode="local_container",  # default
+    openhands_agent_image="ghcr.io/openhands/agent-server:latest-python"
 )
 
-# Manual mode: connect to existing container
+# Remote: connect to existing container
 agent = CustomCodeAgent(
     tools=[],
     model=model,
     use_custom_provider_code_execution_sandbox=True,
-    container_handler="manual",
-    openhands_agent_manual_host="http://localhost:8010"
+    sandbox_mode="remote",
+    openhands_agent_host="http://localhost:8010",
+    openhands_runtime_api_key="your-api-key",  # optional
+    openhands_runtime_api_url="https://api.example.com"  # optional
 )
 ```
 

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -36,6 +36,7 @@ agent = CustomCodeAgent(
     is_code_executed_by_the_custom_agent=True,
     agent_type="remote",
     openhands_agent_host="http://localhost:8010",
+    additional_authorized_imports=["time", "json", "pandas"],
     openhands_runtime_api_key="your-api-key"  # optional
 )
 

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -24,20 +24,30 @@ agent = CustomCodeAgent(tools=[], model=model)
 agent = CustomCodeAgent(
     tools=[],
     model=model,
-    use_custom_provider_code_execution_sandbox=True,
-    sandbox_mode="local_container",  # default
-    openhands_agent_image="ghcr.io/openhands/agent-server:latest-python"
+    is_code_executed_by_the_custom_agent=True,
+    agent_type="local_container",  # default
+    openhands_agent_image="ghcr.io/openhands/agent-server:1.6.0-python" # important: must correstond with the installed version of the OpenHands SDK (openhands-sdk==1.6.0", "openhands-tools==1.6.0", "openhands-workspace==1.6.0")
 )
 
-# Remote: connect to existing container
+# Remote: connect to existing local container
 agent = CustomCodeAgent(
     tools=[],
     model=model,
-    use_custom_provider_code_execution_sandbox=True,
-    sandbox_mode="remote",
+    is_code_executed_by_the_custom_agent=True,
+    agent_type="remote",
     openhands_agent_host="http://localhost:8010",
-    openhands_runtime_api_key="your-api-key",  # optional
-    openhands_runtime_api_url="https://api.example.com"  # optional
+    openhands_runtime_api_key="your-api-key"  # optional
+)
+
+# Remote API: connect to runtime API service
+agent = CustomCodeAgent(
+    tools=[],
+    model=model,
+    is_code_executed_by_the_custom_agent=True,
+    agent_type="remote_api",
+    openhands_runtime_api_url="https://runtime.all-hands.dev",
+    openhands_runtime_api_key="your-api-key",
+    openhands_agent_image="ghcr.io/openhands/agent-server:1.6.0-python" # important: must correstond with the installed version of the OpenHands SDK (openhands-sdk==1.6.0", "openhands-tools==1.6.0")
 )
 ```
 

--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -4,10 +4,44 @@
 
 In this guided visit, you will learn how to build an agent, how to run it, and how to customize it to make it work better for your use-case.
 
-## Choosing an agent type: CodeAgent or ToolCallingAgent
+## Choosing an agent type: CodeAgent, CustomCodeAgent, or ToolCallingAgent
 
-`smolagents` comes with two agent classes: [`CodeAgent`] and [`ToolCallingAgent`], which represent two different paradigms for how agents interact with tools.
-The key difference lies in how actions are specified and executed: code generation vs structured tool calling.
+`smolagents` comes with three agent classes: [`CodeAgent`], [`CustomCodeAgent`], and [`ToolCallingAgent`], which represent different paradigms for how agents interact with tools.
+
+### CustomCodeAgent
+
+[`CustomCodeAgent`] integrates custom providers (like OpenHands SDK) for LLM calls and optional Docker-sandboxed code execution:
+
+```python
+from smolagents import CustomCodeAgent, LiteLLMModel
+
+model = LiteLLMModel(model_id="gpt-4")
+
+# Default: custom LLM, local execution
+agent = CustomCodeAgent(tools=[], model=model)
+
+# Auto mode: agent manages Docker container
+agent = CustomCodeAgent(
+    tools=[],
+    model=model,
+    use_custom_provider_code_execution_sandbox=True,
+    container_handler="auto",  # default
+    openhands_agent_auto_image="ghcr.io/openhands/agent-server:latest-python"
+)
+
+# Manual mode: connect to existing container
+agent = CustomCodeAgent(
+    tools=[],
+    model=model,
+    use_custom_provider_code_execution_sandbox=True,
+    container_handler="manual",
+    openhands_agent_manual_host="http://localhost:8010"
+)
+```
+
+### CodeAgent vs ToolCallingAgent
+
+The key difference between [`CodeAgent`] and [`ToolCallingAgent`] lies in how actions are specified and executed: code generation vs structured tool calling.
 
 - [`CodeAgent`] generates tool calls as Python code snippets.
   - The code is executed either locally (potentially unsecure) or in a secure sandbox.

--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -12,7 +12,7 @@ Key features of `smolagents` include:
 
 ✨ **Simplicity**: The logic for agents fits in ~thousand lines of code. We kept abstractions to their minimal shape above raw code!
 
-🧑‍💻 **First-class support for Code Agents**: [`CodeAgent`](reference/agents#smolagents.CodeAgent) writes its actions in code (as opposed to "agents being used to write code") to invoke tools or perform computations, enabling natural composability (function nesting, loops, conditionals). To make it secure, we support [executing in sandboxed environment](tutorials/secure_code_execution) via [Modal](https://modal.com/), [Blaxel](https://blaxel.ai), [E2B](https://e2b.dev/), or Docker.
+🧑‍💻 **First-class support for Code Agents**: [`CodeAgent`](reference/agents#smolagents.CodeAgent) writes its actions in code (as opposed to "agents being used to write code") to invoke tools or perform computations, enabling natural composability (function nesting, loops, conditionals). To make it secure, we support [executing in sandboxed environment](tutorials/secure_code_execution) via [Modal](https://modal.com/), [Blaxel](https://blaxel.ai), [E2B](https://e2b.dev/), or Docker. [`CustomCodeAgent`](reference/agents#smolagents.CustomCodeAgent) extends this with custom provider integration for LLM calls and optional sandboxed execution.
 
 📡 **Common Tool-Calling Agent Support**: In addition to CodeAgents, [`ToolCallingAgent`](reference/agents#smolagents.ToolCallingAgent) supports usual JSON/text-based tool-calling for scenarios where that paradigm is preferred.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name="Aymeric Roucher", email="aymeric@hf.co" },
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
   "huggingface-hub>=0.31.2,<1.0.0",
   "requests>=2.32.3",
@@ -19,6 +19,9 @@ dependencies = [
   "pillow>=10.0.1",
   # Security fix for CVE-2023-4863: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html
   "python-dotenv",
+  "openhands-sdk==1.6.0",
+  "openhands-tools==1.6.0",
+  "openhands-workspace==1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1951,7 +1951,7 @@ class CustomCodeAgent(CodeAgent):
         """Initialize OpenHands SDK components for sandboxed execution."""
         try:
             from openhands.sdk import Agent as OpenHandsAgent
-            from openhands.workspace import DockerWorkspace, RemoteWorkspace
+            from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
         except ImportError as e:
             raise ImportError(
                 "OpenHands SDK with workspace support is required for sandbox mode. "
@@ -1995,7 +1995,7 @@ class CustomCodeAgent(CodeAgent):
             if self.openhands_runtime_api_url:
                 workspace_kwargs["api_url"] = self.openhands_runtime_api_url
 
-            self._openhands_workspace = RemoteWorkspace(**workspace_kwargs)
+            self._openhands_workspace = APIRemoteWorkspace(**workspace_kwargs)
 
         # Create OpenHands agent with default tools
         try:

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -314,15 +314,15 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            assert (
+                not missing_keys
+            ), f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        assert (
+                            key in prompt_templates.keys() and (subkey in prompt_templates[key].keys())
+                        ), f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -369,9 +369,9 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            assert all(
+                agent.name and agent.description for agent in managed_agents
+            ), "All managed agents need both a name and a description!"
             self.managed_agents = {agent.name: agent for agent in managed_agents}
             # Ensure managed agents can be called as tools by the model: set their inputs and output_type
             for agent in self.managed_agents.values():
@@ -386,9 +386,9 @@ class MultiStepAgent(ABC):
                 agent.output_type = "string"
 
     def _setup_tools(self, tools, add_base_tools):
-        assert all(isinstance(tool, BaseTool) for tool in tools), (
-            "All elements must be instance of BaseTool (or a subclass)"
-        )
+        assert all(
+            isinstance(tool, BaseTool) for tool in tools
+        ), "All elements must be instance of BaseTool (or a subclass)"
         self.tools = {tool.name: tool for tool in tools}
         if add_base_tools:
             self.tools.update(
@@ -1911,15 +1911,11 @@ class CustomCodeAgent(CodeAgent):
 
         # Validate provider
         if provider not in ["OpenHandsSDK"]:
-            raise ValueError(
-                f"Unsupported provider: {provider}. Supported providers: OpenHandsSDK"
-            )
+            raise ValueError(f"Unsupported provider: {provider}. Supported providers: OpenHandsSDK")
 
         # Validate agent_type
         if agent_type not in ["local_container", "remote", "remote_api"]:
-            raise ValueError(
-                f"Invalid agent_type: {agent_type}. Must be 'local_container', 'remote', or 'remote_api'"
-            )
+            raise ValueError(f"Invalid agent_type: {agent_type}. Must be 'local_container', 'remote', or 'remote_api'")
 
         # Store the original model for config extraction
         self._original_model = model
@@ -1951,13 +1947,11 @@ class CustomCodeAgent(CodeAgent):
             A Model instance that delegates LLM calls to OpenHands SDK.
         """
         try:
-            from pydantic import SecretStr
-
             from openhands.sdk import LLM as OpenHandsLLM
+            from pydantic import SecretStr
         except ImportError as e:
             raise ImportError(
-                "OpenHands SDK is required for CustomCodeAgent. "
-                "Please install it with: pip install openhands-sdk"
+                "OpenHands SDK is required for CustomCodeAgent. " "Please install it with: pip install openhands-sdk"
             ) from e
 
         # Extract configuration from the smolagents model
@@ -1972,9 +1966,7 @@ class CustomCodeAgent(CodeAgent):
             "max_output_tokens": 4096,  # Reasonable limit to avoid context window issues
         }
         if api_key:
-            openhands_llm_kwargs["api_key"] = (
-                SecretStr(api_key) if isinstance(api_key, str) else api_key
-            )
+            openhands_llm_kwargs["api_key"] = SecretStr(api_key) if isinstance(api_key, str) else api_key
         if api_base:
             openhands_llm_kwargs["base_url"] = api_base
 
@@ -2001,9 +1993,7 @@ class CustomCodeAgent(CodeAgent):
         if self.agent_type == "local_container":
             # Local container mode: manage container lifecycle
             if not self.openhands_agent_image:
-                raise ValueError(
-                    "openhands_agent_image is required when agent_type='local_container'"
-                )
+                raise ValueError("openhands_agent_image is required when agent_type='local_container'")
 
             workspace_kwargs = {"server_image": self.openhands_agent_image}
             if self.openhands_agent_platform:
@@ -2018,8 +2008,7 @@ class CustomCodeAgent(CodeAgent):
             # Remote mode: connect to existing local container
             if not self.openhands_agent_host:
                 raise ValueError(
-                    "openhands_agent_host is required when agent_type='remote' "
-                    "(e.g., 'http://localhost:8010')"
+                    "openhands_agent_host is required when agent_type='remote' " "(e.g., 'http://localhost:8010')"
                 )
 
             # Create a RemoteWorkspace that connects to existing container
@@ -2039,9 +2028,7 @@ class CustomCodeAgent(CodeAgent):
                     "(e.g., 'https://runtime.all-hands.dev')"
                 )
             if not self.openhands_runtime_api_key:
-                raise ValueError(
-                    "openhands_runtime_api_key is required when agent_type='remote_api'"
-                )
+                raise ValueError("openhands_runtime_api_key is required when agent_type='remote_api'")
             if not self.openhands_agent_image:
                 raise ValueError(
                     "openhands_agent_image is required when agent_type='remote_api' "
@@ -2067,10 +2054,10 @@ class CustomCodeAgent(CodeAgent):
             self._openhands_workspace = APIRemoteWorkspace(**workspace_kwargs)
 
         # Create OpenHands agent configured for the appropriate mode
+        import yaml
         from openhands.sdk import AgentContext
         from openhands.sdk.tool import Tool
         from openhands.tools.terminal import TerminalTool
-        import yaml
 
         # Load the appropriate prompt based on execution mode
         prompt_dir = os.path.join(os.path.dirname(__file__), "prompts")
@@ -2083,14 +2070,12 @@ class CustomCodeAgent(CodeAgent):
             prompt_file = os.path.join(prompt_dir, "openhands_code_generation_mode.yaml")
 
         # Load prompt from YAML file
-        with open(prompt_file, 'r') as f:
+        with open(prompt_file, "r") as f:
             prompt_config = yaml.safe_load(f)
 
-        system_message_suffix = prompt_config.get('system_message_suffix', '')
+        system_message_suffix = prompt_config.get("system_message_suffix", "")
 
-        agent_context = AgentContext(
-            system_message_suffix=system_message_suffix
-        )
+        agent_context = AgentContext(system_message_suffix=system_message_suffix)
 
         self._openhands_agent = OpenHandsAgent(
             llm=openhands_llm,
@@ -2137,6 +2122,7 @@ class CustomCodeAgent(CodeAgent):
         the final result. smolagents should NOT re-execute the code.
         """
         from openhands.sdk import Conversation as OpenHandsConversation
+        from openhands.sdk.conversation.response_utils import get_agent_final_response
 
         # Build the task from memory
         task = self._build_task_from_memory()
@@ -2156,44 +2142,12 @@ class CustomCodeAgent(CodeAgent):
         # Get the conversation history to extract the final result
         events = self._openhands_conversation.state.events
 
-        # Extract the final result from the last message or observation
-        final_result = None
-
-        for event in reversed(events):
-            event_type = type(event).__name__
-
-            # Check for MessageEvent (agent's LLM responses)
-            if event_type == 'MessageEvent' and hasattr(event, 'llm_message'):
-                llm_msg = event.llm_message
-                if hasattr(llm_msg, 'content') and llm_msg.content:
-                    content = llm_msg.content
-                    # Content can be a list of TextContent objects or a string
-                    if isinstance(content, list):
-                        # Extract text from TextContent objects
-                        text_parts = []
-                        for item in content:
-                            if hasattr(item, 'text'):
-                                text_parts.append(item.text)
-                            elif isinstance(item, str):
-                                text_parts.append(item)
-                        final_result = '\n'.join(text_parts) if text_parts else None
-                    elif isinstance(content, str):
-                        final_result = content
-
-                    if final_result:
-                        break
-
-            # Check for ObservationEvent (tool execution results)
-            elif event_type == 'ObservationEvent' and hasattr(event, 'observation'):
-                obs = event.observation
-                if hasattr(obs, 'content') and obs.content:
-                    content = obs.content
-                    if isinstance(content, str) and content.strip():
-                        final_result = content.strip()
-                        # Keep looking for a MessageEvent, but save this as fallback
+        # Use OpenHands SDK's utility function to extract the final response
+        # This properly handles both finish tool calls and message events
+        final_result = get_agent_final_response(events)
 
         # If we found a result, yield it as the final answer
-        if final_result:
+        if final_result and final_result.strip():
             memory_step.observations = final_result
             yield ActionOutput(output=final_result, is_final_answer=True)
         else:
@@ -2246,14 +2200,18 @@ class CustomCodeAgent(CodeAgent):
             if self.agent_type == "local_container":
                 # Local container mode: cleanup based on configuration
                 try:
-                    if hasattr(self._openhands_workspace, '_container_id') and self._openhands_workspace._container_id:
+                    if hasattr(self._openhands_workspace, "_container_id") and self._openhands_workspace._container_id:
                         import subprocess
+
                         container_id = self._openhands_workspace._container_id
 
                         # Stop logs streaming first
-                        if hasattr(self._openhands_workspace, '_stop_logs'):
+                        if hasattr(self._openhands_workspace, "_stop_logs"):
                             self._openhands_workspace._stop_logs.set()
-                        if hasattr(self._openhands_workspace, '_logs_thread') and self._openhands_workspace._logs_thread:
+                        if (
+                            hasattr(self._openhands_workspace, "_logs_thread")
+                            and self._openhands_workspace._logs_thread
+                        ):
                             if self._openhands_workspace._logs_thread.is_alive():
                                 self._openhands_workspace._logs_thread.join(timeout=2)
 
@@ -2261,6 +2219,8 @@ class CustomCodeAgent(CodeAgent):
                             subprocess.run(["docker", "stop", container_id], check=False, capture_output=True)
 
                         if self.delete_container_on_completion:
+                            # Note: docker stop may already trigger container removal in some configurations
+                            # We ignore errors here as the container may already be removed
                             subprocess.run(["docker", "rm", container_id], check=False, capture_output=True)
 
                         # Clear the container ID if we stopped or deleted it
@@ -2332,9 +2292,20 @@ class OpenHandsModelWrapper(Model):
         return self._convert_response_to_smolagents(response)
 
     def _convert_messages_to_openhands(self, messages: list) -> list:
-        """Convert smolagents messages to OpenHands format."""
+        """Convert smolagents messages to OpenHands format.
+
+        OpenHands only supports roles: 'user', 'system', 'assistant', 'tool'
+        SmolAgents has additional roles: 'tool-call', 'tool-response'
+        We convert these to OpenHands-compatible roles.
+        """
         from openhands.sdk.llm import Message as OpenHandsMessage
         from openhands.sdk.llm import TextContent
+
+        # Role conversion mapping: SmolAgents -> OpenHands
+        role_conversions = {
+            "tool-call": "assistant",  # Tool calls are made by the assistant
+            "tool-response": "user",   # Tool responses come back as user messages
+        }
 
         oh_messages = []
         for msg in messages:
@@ -2346,6 +2317,15 @@ class OpenHandsModelWrapper(Model):
                 if hasattr(role, "value"):
                     role = role.value
                 content = getattr(msg, "content", "")
+
+            # Convert SmolAgents roles to OpenHands-compatible roles
+            role = role_conversions.get(role, role)
+
+            # Validate role is one of the OpenHands-supported roles
+            valid_roles = {"user", "system", "assistant", "tool"}
+            if role not in valid_roles:
+                # Default to 'user' for unknown roles
+                role = "user"
 
             # Handle content that might be a list
             if isinstance(content, list):
@@ -2359,7 +2339,7 @@ class OpenHandsModelWrapper(Model):
 
             oh_messages.append(
                 OpenHandsMessage(
-                    role=role,
+                    role=role,  # type: ignore[arg-type]
                     content=[TextContent(text=str(content))],
                 )
             )

--- a/src/smolagents/prompts/openhands_code_execution_mode.yaml
+++ b/src/smolagents/prompts/openhands_code_execution_mode.yaml
@@ -1,0 +1,57 @@
+# OpenHands System Prompt for Mode 2: Code Generation AND Execution
+# In this mode, OpenHands generates Python code AND executes it in the sandbox, returning only the final result
+
+system_message_suffix: |
+  
+  <SMOLAGENTS_CODE_EXECUTION_MODE>
+  CRITICAL: You are operating in CODE EXECUTION mode for the smolagents framework.
+  
+  YOUR ROLE:
+  - Generate Python code that solves the user's request
+  - Execute the code in your sandboxed environment
+  - Return ONLY the final result to smolagents
+  - Use the Finish tool to return the final answer
+  
+  WORKFLOW:
+  1. Analyze the user's request
+  2. Generate Python code to solve it
+  3. Execute the code using the terminal tool
+  4. Extract the result from the execution
+  5. Use Finish tool to return the result to smolagents
+  
+  EXAMPLES:
+  
+  User: "What is 2 + 2?"
+  Correct Workflow:
+    Step 1: terminal(command="python3 -c 'result = 2 + 2; print(result)'")
+    Step 2: Observe output: 4
+    Step 3: Finish(message="4")
+  
+  WRONG Workflow:
+    - Finish(message="2 + 2 is 4") without executing code
+    - Only executing code without using Finish
+  
+  User: "What is the square root of 16?"
+  Correct Workflow:
+    Step 1: terminal(command="python3 -c 'import math; result = math.sqrt(16); print(result)'")
+    Step 2: Observe output: 4.0
+    Step 3: Finish(message="4.0")
+  
+  WRONG Workflow:
+    - Finish(message="The square root of 16 is 4") without executing code
+  
+  IMPORTANT RULES:
+  1. ALWAYS execute Python code using the terminal tool
+  2. ALWAYS use Finish tool to return the final result
+  3. Return ONLY the computed result, not explanations
+  4. The result should be concise and directly answer the question
+  5. smolagents will receive your Finish message as the final answer
+  
+  RESULT FORMAT:
+  - For calculations: Return just the number (e.g., "4", "4.0")
+  - For text results: Return the text directly
+  - For complex results: Return in a clear, parseable format
+  - NO explanations like "The answer is..." - just the result
+  
+  </SMOLAGENTS_CODE_EXECUTION_MODE>
+

--- a/src/smolagents/prompts/openhands_code_generation_mode.yaml
+++ b/src/smolagents/prompts/openhands_code_generation_mode.yaml
@@ -1,0 +1,47 @@
+# OpenHands System Prompt for Mode 1: Code Generation Only
+# In this mode, OpenHands generates Python code that smolagents will execute locally
+
+system_message_suffix: |
+  
+  <SMOLAGENTS_CODE_GENERATION_MODE>
+  CRITICAL: You are operating in CODE GENERATION mode for the smolagents framework.
+  
+  YOUR ROLE:
+  - Generate Python code that solves the user's request
+  - Return the code in a format that smolagents can parse and execute
+  - DO NOT execute the code yourself
+  - DO NOT use the Finish tool to provide direct answers
+  
+  CODE FORMAT REQUIREMENTS:
+  1. Use the terminal tool to output Python code
+  2. Format: terminal(command="python3 -c '<your_python_code_here>'")
+  3. The code must use final_answer() to return results
+  4. Example format: terminal(command="python3 -c 'result = 2 + 2; print(f\"final_answer({result})\")'")
+  
+  EXAMPLES:
+  
+  User: "What is 2 + 2?"
+  Correct Response:
+    terminal(command="python3 -c 'result = 2 + 2; print(f\"final_answer({result})\")'")
+  
+  WRONG Response:
+    - Finish(message="2 + 2 is 4")
+    - terminal(command="python3 -c 'print(4)'")  # Missing final_answer()
+  
+  User: "What is the square root of 16?"
+  Correct Response:
+    terminal(command="python3 -c 'import math; result = math.sqrt(16); print(f\"final_answer({result})\")'")
+  
+  WRONG Response:
+    - Finish(message="The square root of 16 is 4")
+    - Direct calculation without final_answer()
+  
+  IMPORTANT RULES:
+  1. ALWAYS wrap results in final_answer()
+  2. ALWAYS use terminal tool to show the code
+  3. NEVER use Finish tool for computational tasks
+  4. The code you generate will be executed by smolagents, not by you
+  5. Print the code so smolagents can capture and execute it
+  
+  </SMOLAGENTS_CODE_GENERATION_MODE>
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2638,8 +2638,8 @@ class TestCustomCodeAgent:
             agent = CustomCodeAgent(tools=[], model=mock_model)
 
             assert agent.provider == "OpenHandsSDK"
-            assert agent.use_custom_provider_code_execution_sandbox is False
-            assert agent.sandbox_mode == "local_container"
+            assert agent.is_code_executed_by_the_custom_agent is False
+            assert agent.agent_type == "local_container"
             assert agent.openhands_agent_image is None
             assert agent.openhands_agent_host is None
             assert agent.openhands_agent_port is None
@@ -2661,18 +2661,21 @@ class TestCustomCodeAgent:
                 provider="InvalidProvider",
             )
 
-    def test_custom_code_agent_invalid_sandbox_mode(self):
-        """Test that invalid sandbox_mode raises ValueError."""
+    def test_custom_code_agent_invalid_agent_type(self):
+        """Test that invalid agent_type raises ValueError.
+
+        Valid agent_types are: 'local_container', 'remote', 'remote_api'
+        """
         from smolagents.agents import CustomCodeAgent
 
         mock_model = MagicMock()
         mock_model.model_id = "test-model"
 
-        with pytest.raises(ValueError, match="Invalid sandbox_mode"):
+        with pytest.raises(ValueError, match="Invalid agent_type"):
             CustomCodeAgent(
                 tools=[],
                 model=mock_model,
-                sandbox_mode="invalid",
+                agent_type="invalid",
             )
 
     def test_custom_code_agent_local_container_mode_requires_image(self):
@@ -2700,8 +2703,8 @@ class TestCustomCodeAgent:
                 CustomCodeAgent(
                     tools=[],
                     model=mock_model,
-                    use_custom_provider_code_execution_sandbox=True,
-                    sandbox_mode="local_container",
+                    is_code_executed_by_the_custom_agent=True,
+                    agent_type="local_container",
                 )
 
     def test_custom_code_agent_remote_mode_requires_host(self):
@@ -2727,8 +2730,8 @@ class TestCustomCodeAgent:
                 CustomCodeAgent(
                     tools=[],
                     model=mock_model,
-                    use_custom_provider_code_execution_sandbox=True,
-                    sandbox_mode="remote",
+                    is_code_executed_by_the_custom_agent=True,
+                    agent_type="remote",
                 )
 
     def test_custom_code_agent_cleanup_local_container_mode(self):
@@ -2746,7 +2749,7 @@ class TestCustomCodeAgent:
             agent = CustomCodeAgent(
                 tools=[],
                 model=mock_model,
-                sandbox_mode="local_container",
+                agent_type="local_container",
             )
 
             # Mock the workspace and conversation
@@ -2758,9 +2761,8 @@ class TestCustomCodeAgent:
             # Call cleanup
             agent.cleanup()
 
-            # Verify conversation close and workspace cleanup were called
+            # Verify conversation close was called
             mock_conversation.close.assert_called_once()
-            mock_workspace.cleanup.assert_called_once()
             assert agent._openhands_workspace is None
             assert agent._openhands_conversation is None
 
@@ -2779,7 +2781,7 @@ class TestCustomCodeAgent:
             agent = CustomCodeAgent(
                 tools=[],
                 model=mock_model,
-                sandbox_mode="remote",
+                agent_type="remote",
             )
 
             # Mock the workspace and conversation
@@ -2791,14 +2793,13 @@ class TestCustomCodeAgent:
             # Call cleanup
             agent.cleanup()
 
-            # Verify conversation close was called but workspace cleanup was NOT
+            # Verify conversation close was called
             mock_conversation.close.assert_called_once()
-            mock_workspace.cleanup.assert_not_called()
             assert agent._openhands_workspace is None
             assert agent._openhands_conversation is None
 
     def test_custom_code_agent_step_stream_delegates_to_parent(self):
-        """Test that _step_stream delegates to parent when sandbox mode is disabled."""
+        """Test that _step_stream delegates to parent when code execution by custom agent is disabled."""
         from smolagents.agents import CustomCodeAgent
 
         mock_model = MagicMock()
@@ -2814,11 +2815,11 @@ class TestCustomCodeAgent:
             agent = CustomCodeAgent(
                 tools=[],
                 model=mock_model,
-                use_custom_provider_code_execution_sandbox=False,
+                is_code_executed_by_the_custom_agent=False,
             )
 
-            # Verify sandbox mode is disabled
-            assert agent.use_custom_provider_code_execution_sandbox is False
+            # Verify code execution by custom agent is disabled
+            assert agent.is_code_executed_by_the_custom_agent is False
 
 
 class TestOpenHandsModelWrapper:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2584,3 +2584,302 @@ def test_tool_calling_agents_raises_agent_execution_error_when_tool_raises():
     agent = ToolCallingAgent(model=FakeToolCallModel(), tools=[_sample_tool])
     with pytest.raises(AgentExecutionError):
         agent.execute_tool_call(_sample_tool.name, "sample")
+
+
+# ============================================================================
+# CustomCodeAgent Tests
+# ============================================================================
+
+
+class TestCustomCodeAgent:
+    """Tests for CustomCodeAgent with OpenHands SDK integration."""
+
+    def test_custom_code_agent_import(self):
+        """Test that CustomCodeAgent can be imported."""
+        from smolagents.agents import CustomCodeAgent
+
+        assert CustomCodeAgent is not None
+
+    def test_custom_code_agent_inherits_from_code_agent(self):
+        """Test that CustomCodeAgent inherits from CodeAgent."""
+        from smolagents.agents import CodeAgent, CustomCodeAgent
+
+        assert issubclass(CustomCodeAgent, CodeAgent)
+
+    def test_custom_code_agent_requires_openhands_sdk(self):
+        """Test that CustomCodeAgent raises ImportError when OpenHands SDK is not available."""
+        from smolagents.agents import CustomCodeAgent
+
+        # Create a mock model
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+        mock_model.api_key = "test-key"
+        mock_model.api_base = None
+
+        # Patch the import to simulate missing OpenHands SDK
+        with patch.dict("sys.modules", {"openhands.sdk": None}):
+            with pytest.raises(ImportError, match="OpenHands SDK is required"):
+                CustomCodeAgent(tools=[], model=mock_model)
+
+    def test_custom_code_agent_default_parameters(self):
+        """Test CustomCodeAgent default parameter values."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+        mock_model.api_key = "test-key"
+        mock_model.api_base = None
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_model,
+        ):
+            agent = CustomCodeAgent(tools=[], model=mock_model)
+
+            assert agent.provider == "OpenHandsSDKDocker"
+            assert agent.use_custom_provider_code_execution_sandbox is False
+            assert agent.container_handler == "auto"
+            assert agent.openhands_agent_auto_image is None
+            assert agent.openhands_agent_manual_host is None
+            assert agent.openhands_agent_manual_port is None
+            assert agent.openhands_agent_platform is None
+
+    def test_custom_code_agent_invalid_provider(self):
+        """Test that invalid provider raises ValueError."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            CustomCodeAgent(
+                tools=[],
+                model=mock_model,
+                provider="InvalidProvider",
+            )
+
+    def test_custom_code_agent_invalid_container_handler(self):
+        """Test that invalid container_handler raises ValueError."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+
+        with pytest.raises(ValueError, match="Invalid container_handler"):
+            CustomCodeAgent(
+                tools=[],
+                model=mock_model,
+                container_handler="invalid",
+            )
+
+    def test_custom_code_agent_auto_mode_requires_server_image(self):
+        """Test that auto mode requires openhands_server_image."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+        mock_model.api_key = "test-key"
+        mock_model.api_base = None
+
+        # Mock the wrapper creation
+        mock_wrapper = MagicMock()
+        mock_wrapper._openhands_llm = MagicMock()
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_wrapper,
+        ):
+            # When SDK is not installed, it raises ImportError
+            # When SDK is installed but no server_image in auto mode, it should raise ValueError
+            # We test both cases by checking for either exception
+            with pytest.raises((ValueError, ImportError)):
+                CustomCodeAgent(
+                    tools=[],
+                    model=mock_model,
+                    use_custom_provider_code_execution_sandbox=True,
+                    container_handler="auto",
+                )
+
+    def test_custom_code_agent_manual_mode_requires_host(self):
+        """Test that manual mode requires openhands_host."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+        mock_model.api_key = "test-key"
+        mock_model.api_base = None
+
+        # Mock the wrapper creation
+        mock_wrapper = MagicMock()
+        mock_wrapper._openhands_llm = MagicMock()
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_wrapper,
+        ):
+            # Manual mode without openhands_host should raise ValueError or ImportError
+            with pytest.raises((ValueError, ImportError)):
+                CustomCodeAgent(
+                    tools=[],
+                    model=mock_model,
+                    use_custom_provider_code_execution_sandbox=True,
+                    container_handler="manual",
+                )
+
+    def test_custom_code_agent_cleanup_auto_mode(self):
+        """Test that cleanup properly cleans up workspace in auto mode."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_model,
+        ):
+            agent = CustomCodeAgent(
+                tools=[],
+                model=mock_model,
+                container_handler="auto",
+            )
+
+            # Mock the workspace and conversation
+            mock_workspace = MagicMock()
+            mock_conversation = MagicMock()
+            agent._openhands_workspace = mock_workspace
+            agent._openhands_conversation = mock_conversation
+
+            # Call cleanup
+            agent.cleanup()
+
+            # Verify conversation close and workspace cleanup were called
+            mock_conversation.close.assert_called_once()
+            mock_workspace.cleanup.assert_called_once()
+            assert agent._openhands_workspace is None
+            assert agent._openhands_conversation is None
+
+    def test_custom_code_agent_cleanup_manual_mode(self):
+        """Test that cleanup doesn't stop container in manual mode."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_model,
+        ):
+            agent = CustomCodeAgent(
+                tools=[],
+                model=mock_model,
+                container_handler="manual",
+            )
+
+            # Mock the workspace and conversation
+            mock_workspace = MagicMock()
+            mock_conversation = MagicMock()
+            agent._openhands_workspace = mock_workspace
+            agent._openhands_conversation = mock_conversation
+
+            # Call cleanup
+            agent.cleanup()
+
+            # Verify conversation close was called but workspace cleanup was NOT
+            mock_conversation.close.assert_called_once()
+            mock_workspace.cleanup.assert_not_called()
+            assert agent._openhands_workspace is None
+            assert agent._openhands_conversation is None
+
+    def test_custom_code_agent_step_stream_delegates_to_parent(self):
+        """Test that _step_stream delegates to parent when sandbox mode is disabled."""
+        from smolagents.agents import CustomCodeAgent
+
+        mock_model = MagicMock()
+        mock_model.model_id = "test-model"
+        mock_model.api_key = "test-key"
+        mock_model.api_base = None
+
+        with patch.object(
+            CustomCodeAgent,
+            "_create_provider_model_wrapper",
+            return_value=mock_model,
+        ):
+            agent = CustomCodeAgent(
+                tools=[],
+                model=mock_model,
+                use_custom_provider_code_execution_sandbox=False,
+            )
+
+            # Verify sandbox mode is disabled
+            assert agent.use_custom_provider_code_execution_sandbox is False
+
+
+class TestOpenHandsModelWrapper:
+    """Tests for OpenHandsModelWrapper."""
+
+    def test_openhands_model_wrapper_import(self):
+        """Test that OpenHandsModelWrapper can be imported."""
+        from smolagents.agents import OpenHandsModelWrapper
+
+        assert OpenHandsModelWrapper is not None
+
+    def test_openhands_model_wrapper_inherits_from_model(self):
+        """Test that OpenHandsModelWrapper inherits from Model."""
+        from smolagents.agents import OpenHandsModelWrapper
+        from smolagents.models import Model
+
+        assert issubclass(OpenHandsModelWrapper, Model)
+
+    def test_openhands_model_wrapper_stores_llm(self):
+        """Test that OpenHandsModelWrapper stores the OpenHands LLM."""
+        from smolagents.agents import OpenHandsModelWrapper
+
+        mock_openhands_llm = MagicMock()
+        mock_original_model = MagicMock()
+        mock_original_model.model_id = "test-model"
+
+        wrapper = OpenHandsModelWrapper(
+            openhands_llm=mock_openhands_llm,
+            original_model=mock_original_model,
+        )
+
+        assert wrapper._openhands_llm is mock_openhands_llm
+        assert wrapper._original_model is mock_original_model
+        assert wrapper.model_id == "test-model"
+
+    def test_openhands_model_wrapper_generate_calls_openhands_llm(self):
+        """Test that generate() calls the OpenHands LLM."""
+        from smolagents.agents import OpenHandsModelWrapper
+        from smolagents.models import ChatMessage, MessageRole
+
+        mock_openhands_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_message = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "Test response"
+        mock_message.content = [mock_content]
+        mock_response.message = mock_message
+        mock_response.usage = None
+        mock_openhands_llm.completion.return_value = mock_response
+
+        mock_original_model = MagicMock()
+        mock_original_model.model_id = "test-model"
+
+        wrapper = OpenHandsModelWrapper(
+            openhands_llm=mock_openhands_llm,
+            original_model=mock_original_model,
+        )
+
+        # Mock the message conversion
+        with patch.object(wrapper, "_convert_messages_to_openhands", return_value=[]):
+            result = wrapper.generate(messages=[])
+
+        assert isinstance(result, ChatMessage)
+        assert result.role == MessageRole.ASSISTANT
+        assert result.content == "Test response"
+        mock_openhands_llm.completion.assert_called_once()


### PR DESCRIPTION
Instead of competing with SotA Coding Agents like OpenHands that focus on code generation, Smolagents could benefit from integrating with them.

While Smolagents is excellent in creating a general agentic framework, the security limitations of the produced code, retry mechanisms, and code output verification, it can leverage OpenHands superior capabilities in producing high-quality code and testing it.

feat(agents): add CustomCodeAgent with OpenHands SDK integration and sandbox support

docs(guided_tour): document CustomCodeAgent usage, auto/manual modes, and sandbox options

docs(index): list CustomCodeAgent alongside CodeAgent in feature overview

I implemented `local_container` (which handles container lifecycle: starts, stops, and deletes the container) and `remote` (RemoteWorkspace), which uses an existing, already running container - both for locally running containers.

Passed for code related to the newly introduced CustomCodeAgent:
```shell
make test
make style
make quality
```