### PR TITLE
fix: prevent FinalAnswerException from being caught by except Exception

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1516,7 +1516,13 @@ def evaluate_ast(
         raise InterpreterError(f"{expression.__class__.__name__} is not supported.")
 
 
-class FinalAnswerException(Exception):
+class FinalAnswerException(BaseException):
+    """Exception raised when final_answer is called.
+
+    Inherits from BaseException instead of Exception to prevent being caught
+    by generic `except Exception` clauses in agent-generated code.
+    """
+
     def __init__(self, value):
         self.value = value
 

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -133,7 +133,7 @@ locals().update(vars_dict)
             import base64
             import pickle
 
-            class FinalAnswerException(Exception):
+            class FinalAnswerException(BaseException):
                 def __init__(self, value):
                     self.value = value
 


### PR DESCRIPTION
## Summary
- Changed `FinalAnswerException` to inherit from `BaseException` instead of `Exception`
- This prevents agent-generated code with `try/except Exception` blocks from incorrectly catching the exception
- Added test case to verify the fix

## Test plan
- [x] Added test `test_final_answer_not_caught_by_except_exception`
- [x] All existing tests pass (`make test`)
- [x] Code quality checks pass (`make quality`)

Fixes #1905