### PR TITLE
feat: Add YouTubeTranscriptTool with mocked tests

### DIFF
--- a/src/smolagents/youtube_transcript_tool.py
+++ b/src/smolagents/youtube_transcript_tool.py
@@ -1,0 +1,54 @@
+import re
+from .tools import Tool
+
+
+class YouTubeTranscriptTool(Tool):
+    name = "youtube_transcript_tool"
+    description = "Extracts the transcript (subtitles) from a YouTube video URL using youtube-transcript-api. Input: url (str). Output: transcript (str)."
+    inputs = {
+        "url": {
+            "type": "string",
+            "description": "The full YouTube URL (e.g., https://www.youtube.com/watch?v=dQw4w9WgXcQ)."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the YouTube Transcript tool.
+        """
+        super().__init__(**kwargs)
+
+    def forward(self, url: str) -> str:
+        """
+        Extracts the transcript (subtitles) from a YouTube video.
+        
+        Args:
+            url: The full YouTube URL (e.g., https://www.youtube.com/watch?v=dQw4w9WgXcQ).
+        """
+        # Lazy Import: Keeps the library lightweight
+        try:
+            from youtube_transcript_api import YouTubeTranscriptApi
+        except ImportError:
+            return "Error: Please install 'youtube-transcript-api' to use this tool."
+
+        try:
+            # 1. robust Regex to find Video ID (handles regular, short, and embed URLs)
+            video_id_match = re.search(r"(?:v=|\/)([0-9A-Za-z_-]{11}).*", url)
+            if not video_id_match:
+                return "Error: Could not extract a valid Video ID from the URL."
+            
+            video_id = video_id_match.group(1)
+
+            # 2. Fetch Transcript
+            transcript_list = YouTubeTranscriptApi.get_transcript(video_id)
+            
+            # 3. Format into a single string
+            full_text = " ".join([item['text'] for item in transcript_list])
+            
+            return f"Transcript for Video ID {video_id}:\n\n{full_text}"
+
+        except Exception as e:
+            if "Subtitles are disabled" in str(e):
+                return "Error: This video does not have subtitles/transcripts enabled."
+            return f"Error fetching transcript: {str(e)}"

--- a/tests/test_youtube_transcript_tool.py
+++ b/tests/test_youtube_transcript_tool.py
@@ -1,0 +1,46 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+from smolagents.youtube_transcript_tool import YouTubeTranscriptTool
+
+class TestYouTubeTranscriptTool(unittest.TestCase):
+    def test_transcript_extraction(self):
+        """
+        Test that the tool correctly parses the transcript 
+        WITHOUT actually connecting to YouTube (Mocking).
+        """
+        
+        # 1. Create a Fake YouTube API
+        mock_api = MagicMock()
+        mock_api.get_transcript.return_value = [
+            {'text': 'Hello world', 'start': 0.0},
+            {'text': 'This is a test', 'start': 1.0}
+        ]
+        
+        # 2. Inject the fake API into the system modules
+        # This prevents 'ImportError' during testing
+        with patch.dict(sys.modules, {'youtube_transcript_api': mock_api}):
+            # We also need to patch the class inside the module
+            mock_api.YouTubeTranscriptApi = mock_api
+            
+            tool = YouTubeTranscriptTool()
+            # Fake URL (doesn't matter, response is mocked)
+            result = tool.forward("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            
+            # 3. Verify Logic
+            self.assertIn("Hello world This is a test", result)
+            self.assertIn("dQw4w9WgXcQ", result)
+
+    def test_missing_dependency(self):
+        """Test that it fails gracefully if the library is missing."""
+        # Forcefully remove the library from modules to simulate it missing
+        with patch.dict(sys.modules):
+            if 'youtube_transcript_api' in sys.modules:
+                del sys.modules['youtube_transcript_api']
+            
+            tool = YouTubeTranscriptTool()
+            result = tool.forward("https://youtube.com/watch?v=123")
+            self.assertIn("Please install 'youtube-transcript-api'", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Agents currently cannot access video content. Users who want to "summarize this video" or "extract code from this tutorial" have no standardized tool.

### Solution
Added `YouTubeTranscriptTool` which extracts subtitles/transcripts from YouTube videos.

**Key Features:**
- **Lazy Loading:** `youtube_transcript_api` is only imported at runtime to keep core dependencies light.
- **Robust Regex:** Supports standard URLs, short URLs (`youtu.be`), and embeds.
- **CI-Ready:** Includes mocked unit tests (`tests/test_youtube_transcript_tool.py`) that pass without external network calls or dependencies.

### Verification
Local tests passed using `unittest.mock` to simulate API responses.