### PR TITLE
feat: Add ArxivResearchTool for academic paper search

### DIFF
--- a/src/smolagents/arxiv_tool.py
+++ b/src/smolagents/arxiv_tool.py
@@ -1,0 +1,66 @@
+from .tools import Tool
+
+class ArxivResearchTool(Tool):
+    name = "arxiv_research_tool"
+    description = "Searches arXiv for research papers and returns summaries and PDF links. Input: query (str). Output: formatted string with top results."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "The search query (e.g., 'LLM quantization', 'Attention Is All You Need')."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the Arxiv Research tool.
+        """
+        super().__init__(**kwargs)
+
+    def forward(self, query: str) -> str:
+        """
+        Searches arXiv for research papers and returns summaries.
+        Useful for finding academic sources, latest techniques, or technical details.
+        
+        Args:
+            query: The search query (e.g., 'LLM quantization', 'Attention Is All You Need').
+        """
+        try:
+            # Lazy Import
+            import arxiv
+        except ImportError:
+            return "Error: Please install 'arxiv' package to use this tool."
+
+        try:
+            # 1. Construct Client (Robustness)
+            client = arxiv.Client()
+            
+            # 2. Search Config
+            search = arxiv.Search(
+                query=query,
+                max_results=3, # Keep context window clean (Top 3 only)
+                sort_by=arxiv.SortCriterion.Relevance
+            )
+
+            results = []
+            # 3. Fetch and Format
+            for r in client.results(search):
+                published_date = r.published.strftime("%Y-%m-%d")
+                # Clean up newlines in summary to save tokens
+                summary = r.summary.replace("\n", " ").strip()
+                
+                entry = (
+                    f"\U0001F4C4 TITLE: {r.title}\n"
+                    f"\U0001F4C5 DATE: {published_date}\n"
+                    f"\U0001F517 PDF: {r.pdf_url}\n"
+                    f"\U0001F4DD SUMMARY: {summary[:500]}..." # Truncate summary
+                )
+                results.append(entry)
+
+            if not results:
+                return "No papers found for this query."
+
+            return "\n\n".join(results)
+
+        except Exception as e:
+            return f"Error searching arXiv: {str(e)}"

--- a/tests/test_arxiv_tool.py
+++ b/tests/test_arxiv_tool.py
@@ -1,0 +1,52 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+from smolagents.arxiv_tool import ArxivResearchTool
+
+class TestArxivTool(unittest.TestCase):
+    def test_search_papers(self):
+        """
+        Test paper search with mocked arXiv response.
+        """
+        # 1. Create Fake Result Object
+        mock_paper = MagicMock()
+        mock_paper.title = "Attention Is All You Need"
+        mock_paper.published.strftime.return_value = "2017-06-12"
+        mock_paper.pdf_url = "http://arxiv.org/pdf/1706.03762v5"
+        mock_paper.summary = "The Transformer is a deep learning architecture..."
+
+        # 2. Mock the Client
+        mock_client = MagicMock()
+        mock_client.results.return_value = [mock_paper]
+
+        # 3. Patch the module
+        with patch.dict(sys.modules):
+            # Create a mock module for 'arxiv'
+            mock_arxiv_module = MagicMock()
+            mock_arxiv_module.Client.return_value = mock_client
+            mock_arxiv_module.SortCriterion.Relevance = "relevance"
+            mock_arxiv_module.Search = MagicMock()
+            
+            sys.modules["arxiv"] = mock_arxiv_module
+            
+            # 4. Run Test
+            tool = ArxivResearchTool()
+            result = tool.forward("transformers")
+
+            # 5. Verify
+            self.assertIn("Attention Is All You Need", result)
+            self.assertIn("http://arxiv.org/pdf/", result)
+            self.assertIn("SUMMARY:", result)
+
+    def test_missing_dependency(self):
+        """Test graceful failure if arxiv is missing."""
+        with patch.dict(sys.modules):
+            if 'arxiv' in sys.modules:
+                del sys.modules['arxiv']
+            
+            tool = ArxivResearchTool()
+            result = tool.forward("query")
+            self.assertIn("Please install 'arxiv'", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Agents lack access to academic literature. Users cannot ask for "latest research on X" without using a general web search, which often returns SEO-spam blogs instead of primary sources.

### Solution
Added `ArxivResearchTool` which interfaces with the arXiv API.

**Features:**
- **Lazy Loading:** `arxiv` package is only imported when needed.
- **Context Optimized:** Returns Top 3 results with truncated summaries to preserve context window.
- **Direct Access:** Provides direct PDF links for the user.

### Verification
Added `tests/test_arxiv_tool.py` using `unittest.mock` to simulate API responses, ensuring CI stability.