### PR TITLE
feat: Add OpenMeteoTool for real-time weather data

### DIFF
--- a/src/smolagents/weather_tool.py
+++ b/src/smolagents/weather_tool.py
@@ -1,0 +1,69 @@
+import requests
+from .tools import Tool
+
+class OpenMeteoTool(Tool):
+    name = "OpenMeteoTool"
+    description = "Get real-time weather (temperature, humidity, wind) for any city using Open-Meteo. No API key required."
+    inputs = {
+        "location": {
+            "type": "string",
+            "description": "The name of the city (e.g., 'Pune', 'New York', 'Tokyo')."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the OpenMeteo Weather tool.
+        """
+        super().__init__(**kwargs)
+
+    def forward(self, location: str) -> str:
+        """
+        Retrieves current weather data for a specific location using Open-Meteo API.
+        Returns Temperature, Wind Speed, and Humidity.
+        
+        Args:
+            location: The name of the city (e.g., 'Pune', 'New York', 'Tokyo').
+        """
+        try:
+            # 1. Geocoding (City -> Lat/Lon)
+            geo_url = f"https://geocoding-api.open-meteo.com/v1/search?name={location}&count=1&language=en&format=json"
+            geo_response = requests.get(geo_url, timeout=10)
+            geo_data = geo_response.json()
+
+            if not geo_data.get("results"):
+                return f"Error: Could not find coordinates for location '{location}'."
+
+            lat = geo_data["results"][0]["latitude"]
+            lon = geo_data["results"][0]["longitude"]
+            city_name = geo_data["results"][0]["name"]
+            country = geo_data["results"][0].get("country", "Unknown")
+
+            # 2. Fetch Weather
+            weather_url = (
+                f"https://api.open-meteo.com/v1/forecast"
+                f"?latitude={lat}&longitude={lon}"
+                f"&current=temperature_2m,relative_humidity_2m,wind_speed_10m"
+            )
+            w_response = requests.get(weather_url, timeout=10)
+            w_data = w_response.json()
+
+            current = w_data.get("current", {})
+            
+            # 3. Format Output
+            temp = current.get("temperature_2m", "N/A")
+            humid = current.get("relative_humidity_2m", "N/A")
+            wind = current.get("wind_speed_10m", "N/A")
+            units = w_data.get("current_units", {})
+
+            return (
+                f"🌤️ **Weather Report for {city_name}, {country}**\n"
+                f"🌡️ Temperature: {temp}{units.get('temperature_2m', '°C')}\n"
+                f"💧 Humidity: {humid}{units.get('relative_humidity_2m', '%')}\n"
+                f"💨 Wind Speed: {wind}{units.get('wind_speed_10m', 'km/h')}\n"
+                f"📍 Coordinates: {lat}, {lon}"
+            )
+
+        except Exception as e:
+            return f"Error fetching weather: {str(e)}"

--- a/tests/test_weather_tool.py
+++ b/tests/test_weather_tool.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from smolagents.weather_tool import OpenMeteoTool
+
+class TestWeatherTool(unittest.TestCase):
+    @patch('requests.get')
+    def test_weather_lookup(self, mock_get):
+        """
+        Test weather lookup with mocked API responses.
+        """
+        # 1. Mock Geocoding Response (Pune)
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = {
+            "results": [{"name": "Pune", "country": "India", "latitude": 18.5, "longitude": 73.8}]
+        }
+
+        # 2. Mock Weather Response
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {
+            "current": {
+                "temperature_2m": 28.5,
+                "relative_humidity_2m": 60,
+                "wind_speed_10m": 12.0
+            },
+            "current_units": {
+                "temperature_2m": "°C",
+                "relative_humidity_2m": "%",
+                "wind_speed_10m": "km/h"
+            }
+        }
+
+        # Configure the side_effect to return geo first, then weather
+        mock_get.side_effect = [mock_geo_resp, mock_weather_resp]
+
+        # 3. Run Tool
+        tool = OpenMeteoTool()
+        result = tool.forward("Pune")
+
+        # 4. Verify
+        self.assertIn("Pune, India", result)
+        self.assertIn("28.5°C", result)
+        self.assertIn("60%", result)
+
+    @patch('requests.get')
+    def test_city_not_found(self, mock_get):
+        """Test graceful failure for unknown cities."""
+        mock_get.return_value.json.return_value = {"results": []}
+        
+        tool = OpenMeteoTool()
+        result = tool.forward("Atlantis_Fake_City")
+        self.assertIn("Could not find coordinates", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Agents cannot access real-time physical world data like weather. This limits use cases for travel planning, logistics, or daily briefing agents.

### Solution
Added `OpenMeteoTool`, a zero-dependency (uses `requests`) interface for the Open-Meteo API.

**Features:**
- **Free & Open:** No API keys required.
- **Two-Step Logic:** Automatically geocodes city names (City -> Lat/Lon) before fetching weather.
- **Structured Output:** Returns Temperature, Humidity, and Wind Speed in a clear format.

### Verification
Added `tests/test_weather_tool.py` with full mocking of both Geocoding and Weather API endpoints.