### PR TITLE
feat: Add HubSearchTool for finding HF models and datasets

### DIFF
--- a/src/smolagents/hub_tool.py
+++ b/src/smolagents/hub_tool.py
@@ -1,0 +1,81 @@
+from .tools import Tool
+
+class HubSearchTool(Tool):
+    name = "HubSearchTool"
+    description = "Search Hugging Face Hub for models and datasets by query. Returns top results by downloads."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "The search term or task (e.g., 'text-to-image', 'bert', 'finance dataset')."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the Hugging Face Hub Search tool.
+        """
+        super().__init__(**kwargs)
+
+    def forward(self, query: str) -> str:
+        """
+        Searches the Hugging Face Hub for Models and Datasets.
+        Useful for finding state-of-the-art models for specific tasks (e.g., 'text-classification', 'llama').
+        
+        Args:
+            query: The search term or task (e.g., 'text-to-image', 'bert', 'finance dataset').
+        """
+        try:
+            # Lazy Import (Standard HF library)
+            from huggingface_hub import HfApi
+            api = HfApi()
+            
+            # 1. Search Models (Top 3 by Downloads)
+            models = api.list_models(
+                search=query,
+                sort="downloads",
+                direction=-1,
+                limit=3
+            )
+            
+            # 2. Search Datasets (Top 3 by Downloads)
+            datasets = api.list_datasets(
+                search=query,
+                sort="downloads", 
+                direction=-1,
+                limit=3
+            )
+            
+            results = []
+            
+            # Format Models
+            if models:
+                results.append("🤖 **Top Models:**")
+                for m in models:
+                    likes = getattr(m, 'likes', 0)
+                    downloads = getattr(m, 'downloads', 0)
+                    results.append(
+                        f"- ID: {m.modelId}\n"
+                        f"  ❤️ Likes: {likes} | ⬇️ Downloads: {downloads}\n"
+                        f"  🔗 https://huggingface.co/{m.modelId}"
+                    )
+            
+            # Format Datasets
+            if datasets:
+                results.append("\n📊 **Top Datasets:**")
+                for d in datasets:
+                    likes = getattr(d, 'likes', 0)
+                    downloads = getattr(d, 'downloads', 0)
+                    results.append(
+                        f"- ID: {d.id}\n"
+                        f"  ❤️ Likes: {likes} | ⬇️ Downloads: {downloads}\n"
+                        f"  🔗 https://huggingface.co/datasets/{d.id}"
+                    )
+
+            if not results:
+                return f"No models or datasets found on the Hub for '{query}'."
+
+            return "\n".join(results)
+
+        except Exception as e:
+            return f"Error searching HF Hub: {str(e)}"

--- a/tests/test_hub_tool.py
+++ b/tests/test_hub_tool.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from smolagents.hub_tool import HubSearchTool
+
+class TestHubTool(unittest.TestCase):
+    def test_hub_search(self):
+        """
+        Test Hub search with mocked HfApi response.
+        """
+        # 1. Mock Model Object
+        mock_model = MagicMock()
+        mock_model.modelId = "meta-llama/Llama-3-8b"
+        mock_model.likes = 10000
+        mock_model.downloads = 500000
+
+        # 2. Mock Dataset Object
+        mock_dataset = MagicMock()
+        mock_dataset.id = "common_voice"
+        mock_dataset.likes = 500
+        mock_dataset.downloads = 20000
+
+        # 3. Mock the API
+        mock_api = MagicMock()
+        mock_api.list_models.return_value = [mock_model]
+        mock_api.list_datasets.return_value = [mock_dataset]
+
+        # 4. Patch and Run
+        with patch("huggingface_hub.HfApi", return_value=mock_api):
+            tool = HubSearchTool()
+            result = tool.forward("llama")
+            
+            # 5. Verify
+            self.assertIn("meta-llama/Llama-3-8b", result)
+            self.assertIn("common_voice", result)
+            self.assertIn("https://huggingface.co/", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The agent operates within the Hugging Face ecosystem but has no way to discover resources on the Hub. Users cannot ask "What is the best model for depth estimation?" or "Find me a finance dataset."

### Solution
Added `HubSearchTool`, which leverages the existing `huggingface_hub` dependency.

**Features:**
- **Zero New Dependencies:** Uses the core `HfApi` that is already part of the environment.
- **Dual Search:** Returns both Models and Datasets sorted by popularity (Downloads).
- **Navigation:** Provides direct links to the model cards.

### Verification
Added `tests/test_hub_tool.py` with mocked API responses.