### PR TITLE
feat: Add QRCodeTool for visual link sharing

### DIFF
--- a/src/smolagents/qrcode_tool.py
+++ b/src/smolagents/qrcode_tool.py
@@ -1,0 +1,57 @@
+import os
+from .tools import Tool
+
+class QRCodeTool(Tool):
+    name = "QRCodeTool"
+    description = "Generate a QR code image from any text or URL. Useful for sharing links to mobile devices."
+    inputs = {
+        "data": {
+            "type": "string",
+            "description": "The text or URL to encode (e.g., 'https://arxiv.org/pdf/1706.03762')."
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        """
+        Initialize the QR Code Generator tool.
+        """
+        super().__init__(**kwargs)
+
+    def forward(self, data: str) -> str:
+        """
+        Generates a QR Code for the given text or URL and saves it as an image.
+        Useful for sharing links to mobile devices.
+        
+        Args:
+            data: The text or URL to encode (e.g., 'https://arxiv.org/pdf/1706.03762').
+        """
+        try:
+            # Lazy Import
+            import qrcode
+        except ImportError:
+            return "Error: Please install 'qrcode[pil]' to use this tool."
+
+        try:
+            # 1. Create QR Code
+            qr = qrcode.QRCode(
+                version=1,
+                error_correction=qrcode.constants.ERROR_CORRECT_L,
+                box_size=10,
+                border=4,
+            )
+            qr.add_data(data)
+            qr.make(fit=True)
+
+            # 2. Generate Image
+            img = qr.make_image(fill_color="black", back_color="white")
+            
+            # 3. Save to temporary path (or current directory)
+            filename = "qrcode_output.png"
+            img.save(filename)
+            
+            # 4. Return the path (The Agent UI will often render local image paths)
+            return f"✅ QR Code generated successfully! Saved to: {os.path.abspath(filename)}"
+
+        except Exception as e:
+            return f"Error generating QR code: {str(e)}"

--- a/tests/test_qrcode_tool.py
+++ b/tests/test_qrcode_tool.py
@@ -1,0 +1,47 @@
+import sys
+import unittest
+import os
+from unittest.mock import MagicMock, patch
+from smolagents.qrcode_tool import QRCodeTool
+
+class TestQRCodeTool(unittest.TestCase):
+    def test_qr_generation(self):
+        """
+        Test QR code generation logic with mocked library.
+        """
+        # 1. Mock the Image Object
+        mock_img = MagicMock()
+        mock_img.save = MagicMock()
+
+        # 2. Mock the QRCode Object
+        mock_qr_instance = MagicMock()
+        mock_qr_instance.make_image.return_value = mock_img
+
+        # 3. Mock the Library
+        mock_qrcode = MagicMock()
+        mock_qrcode.QRCode.return_value = mock_qr_instance
+        mock_qrcode.constants.ERROR_CORRECT_L = 1
+
+        # 4. Patch and Run
+        with patch.dict(sys.modules, {'qrcode': mock_qrcode}):
+            tool = QRCodeTool()
+            result = tool.forward("https://srijan.ai")
+            
+            # 5. Verify
+            self.assertIn("QR Code generated successfully", result)
+            self.assertIn("qrcode_output.png", result)
+            mock_qr_instance.add_data.assert_called_with("https://srijan.ai")
+            mock_img.save.assert_called_once()
+
+    def test_missing_dependency(self):
+        """Test graceful failure."""
+        with patch.dict(sys.modules):
+            if 'qrcode' in sys.modules:
+                del sys.modules['qrcode']
+            
+            tool = QRCodeTool()
+            result = tool.forward("test")
+            self.assertIn("Please install 'qrcode[pil]'", result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Agents are text-only. When they find a resource (URL, Paper, Video), transferring that to a mobile device requires manual copy-pasting.

### Solution
Added `QRCodeTool`, which generates scan-able images from text/URLs.

**Features:**
- **Instant Handoff:** Allows users to scan a result and take it with them.
- **Lazy Loading:** `qrcode` library is optional.
- **Zero API Keys:** Fully offline generation.

### Verification
Added `tests/test_qrcode_tool.py` with mocked image saving to ensure CI stability.