### PR TITLE
feat: Add AgentState backbone with Pydantic schema and test

### DIFF
--- a/src/smolagents/state.py
+++ b/src/smolagents/state.py
@@ -1,0 +1,54 @@
+import uuid
+from datetime import datetime
+from typing import List, Dict, Any, Optional, Literal
+from pydantic import BaseModel, Field
+
+# 1. The Atomic Unit of Action
+class ToolCall(BaseModel):
+    """Represents the Agent's intent to use a tool."""
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    tool_name: str
+    arguments: Dict[str, Any]
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+class ToolResult(BaseModel):
+    """The result returned by the tool."""
+    call_id: str  # Links back to ToolCall.id
+    output: Any
+    error: Optional[str] = None
+    duration_ms: float
+
+# 2. The Step (One Cycle of Thought -> Action -> Result)
+class AgentStep(BaseModel):
+    """A discrete unit of the Agent's timeline."""
+    step_number: int
+    thought: str              # The LLM's reasoning
+    tool_calls: List[ToolCall]
+    tool_results: List[ToolResult]
+    
+    # Metadata for observability
+    token_usage: int = 0
+    latency_ms: float = 0.0
+
+# 3. The "God Object" (The State)
+class AgentState(BaseModel):
+    """
+    The Single Source of Truth.
+    This object alone is sufficient to pause, resume, or replay an agent.
+    """
+    session_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    status: Literal["idle", "running", "waiting_user", "done", "failed"] = "idle"
+    
+    # Goal Alignment
+    task: str
+    plan: List[str] = []      # High-level plan (optional)
+    
+    # Memory (The "Flight Recorder")
+    history: List[AgentStep] = []
+    
+    # Scratchpad (Variables the agent wants to keep)
+    working_memory: Dict[str, Any] = {}
+    
+    # Governance
+    total_tokens: int = 0
+    total_cost: float = 0.0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,43 @@
+import unittest
+from smolagents.state import AgentState, AgentStep, ToolCall, ToolResult
+import json
+from datetime import datetime
+
+class TestAgentState(unittest.TestCase):
+    def test_state_serialization(self):
+        # Create a ToolCall and ToolResult
+        call = ToolCall(tool_name="QRCodeTool", arguments={"data": "https://arxiv.org/pdf/1706.03762"})
+        result = ToolResult(call_id=call.id, output="/tmp/qrcode.png", duration_ms=12.5)
+
+        # Create an AgentStep
+        step = AgentStep(
+            step_number=1,
+            thought="Generate a QR code for the Arxiv paper.",
+            tool_calls=[call],
+            tool_results=[result],
+            token_usage=42,
+            latency_ms=100.0
+        )
+
+        # Create AgentState
+        state = AgentState(
+            task="Share Arxiv paper as QR code",
+            plan=["Find paper", "Generate QR code", "Share"],
+            history=[step],
+            working_memory={"last_url": "https://arxiv.org/pdf/1706.03762"},
+            total_tokens=42,
+            total_cost=0.01
+        )
+
+        # Serialize to JSON (Pydantic v2)
+        state_json = state.model_dump_json()
+        self.assertIn('Share Arxiv paper as QR code', state_json)
+        self.assertIn('Generate a QR code for the Arxiv paper.', state_json)
+        self.assertIn('QRCodeTool', state_json)
+        # Deserialize and check
+        loaded = AgentState.model_validate_json(state_json)
+        self.assertEqual(loaded.task, state.task)
+        self.assertEqual(loaded.history[0].thought, step.thought)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently, the agent's internal state is managed through loose dictionaries and mutable lists passed around the execution loop. This makes it impossible to reliably serialize the agent (for pause/resume) or debug complex failures, as we don't have a structured record of the execution path.

### Changes
Added `src/smolagents/state.py` to define a formal schema for the agent's lifecycle using Pydantic.

**Key Structures:**
- `AgentState`: Holds the session context, history, and memory. Acts as the single source of truth.
- `AgentStep`: Represents one full cycle (Thought → Tool Call → Result).
- `ToolCall` / `ToolResult`: Strictly typed records to track exactly what the agent tried to do and what happened.

This doesn't change the execution logic yet, but it provides the necessary backbone to implement:
1. **Replayability:** We can now save a failed run to JSON and reload it to debug.
2. **Persistence:** Enables pausing an agent and resuming it later.
3. **Observability:** Gives us a structured log of the agent's "chain of thought" instead of just raw text logs.

### Verification
Added `tests/test_state.py` to verify that state objects can be initialized, updated, and correctly serialized to/from JSON.