### PR TITLE
feat: Add Human-in-the-Loop safety check for tools

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -134,7 +134,12 @@ class Tool(BaseTool):
     output_type: str
     output_schema: dict[str, Any] | None = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, requires_confirmation: bool = False, **kwargs):
+        """
+        Args:
+            requires_confirmation: If True, the agent must ask the user before running this tool.
+        """
+        self.requires_confirmation = requires_confirmation
         self.is_initialized = False
 
     def __init_subclass__(cls, **kwargs):
@@ -229,6 +234,13 @@ class Tool(BaseTool):
         raise NotImplementedError("Write this method in your subclass of `Tool`.")
 
     def __call__(self, *args, sanitize_inputs_outputs: bool = False, **kwargs):
+        if self.requires_confirmation:
+            print(f"\n⚠️  SECURITY ALERT: Agent wants to run tool '{self.name}'.")
+            print(f"   Arguments: {args} {kwargs}")
+            response = input("   Allow execution? (y/N): ").strip().lower()
+            if response != 'y':
+                raise ValueError(f"User denied execution of tool '{self.name}'.")
+
         if not self.is_initialized:
             self.setup()
 

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+from smolagents.tools import Tool
+
+class DangerousTool(Tool):
+    name = "nuke_database"
+    description = "Deletes everything."
+    inputs = {}
+    output_type = "string"
+
+    def forward(self):
+        return "BOOM"
+
+class TestSafety(unittest.TestCase):
+    def test_confirmation_accepted(self):
+        """Test that 'y' allows execution."""
+        tool = DangerousTool(requires_confirmation=True)
+        with patch('builtins.input', return_value='y'):
+            result = tool()
+            self.assertEqual(result, "BOOM")
+
+    def test_confirmation_denied(self):
+        """Test that 'n' raises an error."""
+        tool = DangerousTool(requires_confirmation=True)
+        with patch('builtins.input', return_value='n'):
+            with self.assertRaises(ValueError) as cm:
+                tool()
+            self.assertIn("User denied", str(cm.exception))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Agents are getting powerful (SQL, Shell access). Currently, they execute commands instantly. This is a major safety risk for production use, as a hallucinating agent could delete data without warning.

### Changes
Modified the core `Tool` class in `src/smolagents/tools.py` to accept a `requires_confirmation=True` flag.

**How it works:**
- When a sensitive tool is initialized with this flag, its `__call__` method intercepts the execution.
- It prompts the user (CLI) for a "y/N" confirmation.
- If denied, it raises a `ValueError` which the agent catches as feedback (e.g., "User denied execution").

This allows us to deploy "God Mode" tools (like the SQL tool we just built) safely. We can give the agent a bazooka, but keep the trigger finger human.

### Verification
Added `tests/test_safety.py` to verify that the prompt appears and correctly blocks/allows execution based on input.