### PR TITLE
Add timeout protection to GitHub Actions workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   check_code_quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       UV_HTTP_TIMEOUT: 600 # max 10min to install deps
 

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Added `timeout-minutes` to all workflow jobs to prevent runaway processes
- Quality check (linting/formatting): 10 minutes timeout
- Python tests across multiple versions: 20 minutes timeout
- Secret scanning: 10 minutes timeout

## Test plan
- Workflows will continue to run as before
- Added protection against hanging processes
- Timeouts are appropriate for each job type

Generated with [Claude Code](https://claude.com/claude-code)