### PR TITLE
fix(models): Ensure post-init tool call is JSON-serializable

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -133,7 +133,14 @@ class ChatMessage:
             return
         self.tool_calls = [_coerce_tool_call(tool_call) for tool_call in self.tool_calls]
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "tool_calls" and value is not None:
+            value = [_coerce_tool_call(tool_call) for tool_call in value]
+        object.__setattr__(self, name, value)
+
     def model_dump_json(self):
+        if self.tool_calls is not None:
+            self.tool_calls = [_coerce_tool_call(tool_call) for tool_call in self.tool_calls]
         return json.dumps(get_dict_from_nested_dataclasses(self, ignore_key="raw"))
 
     @classmethod


### PR DESCRIPTION
The following issues were identified and fixed in this PR:

→ `tool_call` could remain non JSON-serializable when assigned or constructed outside the normal initialization path (e.g., post-init assignment or `__new__`), since coercion was skipped and `model_dump_json()` did not defensively normalize them, leading to `TypeError` during serialization (e.g., during telemetry instrumentation -- as demonstrated in the issue).
→ New tests are now added to cover post-initialization assignment and `__new__` constructed `ChatMessage` instances to prevent future regressions.

Closes #1929

cc: @albertvillanova @sayakpaul