### PR TITLE
Fix import of TokenUsage

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -57,7 +57,6 @@ from .memory import (
     SystemPromptStep,
     TaskStep,
     Timing,
-    TokenUsage,
     ToolCall,
 )
 from .models import (
@@ -75,6 +74,7 @@ from .monitoring import (
     AgentLogger,
     LogLevel,
     Monitor,
+    TokenUsage,
 )
 from .remote_executors import BlaxelExecutor, DockerExecutor, E2BExecutor, ModalExecutor, WasmExecutor
 from .tools import BaseTool, Tool, validate_tool_arguments

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -82,9 +82,9 @@ class TestModel:
             ChatMessageStreamDelta,
             ChatMessageToolCallFunction,
             ChatMessageToolCallStreamDelta,
-            TokenUsage,
             agglomerate_stream_deltas,
         )
+        from smolagents.monitoring import TokenUsage
 
         stream_deltas = [
             ChatMessageStreamDelta(

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -30,9 +30,8 @@ from smolagents.models import (
     ChatMessageToolCallFunction,
     MessageRole,
     Model,
-    TokenUsage,
 )
-from smolagents.monitoring import AgentLogger
+from smolagents.monitoring import AgentLogger, TokenUsage
 
 
 class FakeLLMModel(Model):


### PR DESCRIPTION
Fix import of TokenUsage.

This PR makes minor import adjustments to ensure that the `TokenUsage` class is imported from the correct module (`smolagents.monitoring`) throughout the codebase. No functional changes are introduced; the updates are strictly organizational for consistency and clarity.