### PR TITLE
Fix Bedrock tool_calls parsing

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],


### PR DESCRIPTION
## Summary
Bedrock sometimes returns only text and no tool calls, which caused a KeyError. This change uses `.get("tool_calls")` so text‑only responses don’t crash.

Fixes #1941

## Test plan
- ruff check examples src tests
- ruff format --check examples src tests
- python -m pytest ./tests (ran on Windows; several tests require optional deps/services not available locally)