### PR TITLE
docs: update quickstart examples to use Llama 3 models

### DIFF
--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -84,7 +84,7 @@ You can use various models with your agent:
 
 ```python
 # Using a specific model from Hugging Face
-model = InferenceClientModel(model_id="meta-llama/Llama-2-70b-chat-hf")
+model = InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct")
 
 # Using OpenAI/Anthropic (requires 'smolagents[litellm]')
 from smolagents import LiteLLMModel
@@ -92,7 +92,7 @@ model = LiteLLMModel(model_id="gpt-4")
 
 # Using local models (requires 'smolagents[transformers]')
 from smolagents import TransformersModel
-model = TransformersModel(model_id="meta-llama/Llama-2-7b-chat-hf")
+model = TransformersModel(model_id="meta-llama/Llama-3.2-3B-Instruct")
 ```
 
 ## Next Steps

--- a/docs/source/es/index.md
+++ b/docs/source/es/index.md
@@ -84,7 +84,7 @@ Puedes usar diferentes modelos con los agentes:
 
 ```python
 # Usar un modelo específico de Hugging Face
-model = InferenceClientModel(model_id="meta-llama/Llama-2-70b-chat-hf")
+model = InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct")
 
 # Usar la API de OpenAI/Anthropic (requiere smolagents[litellm])
 from smolagents import LiteLLMModel
@@ -92,7 +92,7 @@ model = LiteLLMModel(model_id="gpt-4")
 
 # Utilizar modelos locales (requiere smolagents[transformers])
 from smolagents import TransformersModel
-model = TransformersModel(model_id="meta-llama/Llama-2-7b-chat-hf")
+model = TransformersModel(model_id="meta-llama/Llama-3.2-3B-Instruct")
 ```
 
 ## Próximos Pasos

--- a/docs/source/ko/index.md
+++ b/docs/source/ko/index.md
@@ -84,7 +84,7 @@ print(result)
 
 ```python
 # Hugging Face의 특정 모델 사용
-model = InferenceClientModel(model_id="meta-llama/Llama-2-70b-chat-hf")
+model = InferenceClientModel(model_id="meta-llama/Llama-3.3-70B-Instruct")
 
 # OpenAI/Anthropic 사용 ('smolagents[litellm]' 필요)
 from smolagents import LiteLLMModel
@@ -92,7 +92,7 @@ model = LiteLLMModel(model_id="gpt-4")
 
 # 로컬 모델 사용 ('smolagents[transformers]' 필요)
 from smolagents import TransformersModel
-model = TransformersModel(model_id="meta-llama/Llama-2-7b-chat-hf")
+model = TransformersModel(model_id="meta-llama/Llama-3.2-3B-Instruct")
 ```
 
 ## 다음 단계[[next-steps]]


### PR DESCRIPTION
## Summary
Updates outdated Llama 2 model IDs in the Quickstart section across all language versions (en, es, ko).

## Changes
| Before | After |
|--------|-------|
| `meta-llama/Llama-2-70b-chat-hf` | `meta-llama/Llama-3.3-70B-Instruct` |
| `meta-llama/Llama-2-7b-chat-hf` | `meta-llama/Llama-3.2-3B-Instruct` |

## Motivation
The Quickstart examples used Llama 2 models while the rest of the docs (guided_tour.md, tutorials) use Llama 3. This aligns the quickstart with other documentation and gives new users better-performing models out of the box.