### PR TITLE
fix: preserve managed agent config during deserialization

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1032,6 +1032,8 @@ You have been provided with these additional arguments, that you can access dire
         for tool_info in agent_dict["tools"]:
             tools.append(Tool.from_code(tool_info["code"]))
         # Load managed agents
+        # Note: We don't pass **kwargs to managed agents because they should use their
+        # own serialized configuration, not inherit the parent's kwargs (fixes #1849)
         managed_agents = []
         for managed_agent_dict in agent_dict["managed_agents"]:
             agent_class = AGENT_REGISTRY.get(managed_agent_dict["class"])
@@ -1040,7 +1042,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {


### PR DESCRIPTION
## Summary

Fixes #1849

When deserializing an agent with managed agents via `from_dict()`, the parent agent's `**kwargs` were being incorrectly passed to child agents. This caused child agent configurations (especially `additional_authorized_imports`) to be overwritten by the parent's configuration.

## Root Cause

In `MultiStepAgent.from_dict()`, line 1043:
```python
managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
```

The `**kwargs` contains the parent agent's `code_agent_kwargs` (including `additional_authorized_imports`), which then overrides the child agent's own serialized configuration in `CodeAgent.from_dict()`.

## Fix

Remove `**kwargs` from the managed agent deserialization call:
```python
managed_agent = agent_class.from_dict(managed_agent_dict)
```

Each managed agent should use only its own serialized configuration, not inherit the parent's kwargs.

## Test Plan

- [x] Added `test_from_dict_preserves_managed_agent_authorized_imports` that:
  - Creates a managed agent with custom `additional_authorized_imports=["sympy"]`
  - Creates a parent agent WITHOUT sympy
  - Serializes and deserializes via `to_dict()`/`from_dict()`
  - Verifies the managed agent retains `sympy` in its authorized_imports
- [x] Test fails without the fix (NOP check verified)
- [x] All existing serialization tests pass
