### PR TITLE
Clearer Chinese Tutorial

### DIFF
--- a/docs/source/zh/_toctree.yml
+++ b/docs/source/zh/_toctree.yml
@@ -32,11 +32,13 @@
     title: 编排 multi-agent 系统
   - local: examples/web_browser
     title: 基于视觉模型构建能够浏览网页的agent
+  - local: examples/async_agent
+    title: 使用Agent的异步应用
 - title: Reference
   sections:
   - local: reference/agents
-    title: Agent-related objects
+    title: Agent 相关对象
   - local: reference/models
-    title: Model-related objects
+    title: 模型相关对象
   - local: reference/tools
-    title: Tool-related objects
+    title: 工具相关对象

--- a/docs/source/zh/examples/async_agent.md
+++ b/docs/source/zh/examples/async_agent.md
@@ -1,0 +1,82 @@
+# 使用Agent的异步应用
+
+本指南演示了如何将 `smolagents` 库中的同步agent集成到使用 Starlette 构建的异步 Python Web 应用程序中。此示例旨在帮助初次接触异步 Python 和agent集成的用户理解将同步智能体逻辑与异步 Web 服务器结合的最佳实践。
+
+## 概述
+
+- **Starlette**：一个轻量级的 ASGI 框架，用于在 Python 中构建异步 Web 应用程序。
+- **anyio.to_thread.run_sync**：一个实用工具，用于在后台线程中运行阻塞（同步）代码，防止其阻塞异步事件循环。
+- **CodeAgent**：来自 `smolagents` 库的一个agent，能够通过编程方式解决任务。
+
+## 为何使用后台线程？
+
+`CodeAgent.run()` 是同步执行 Python 代码的。如果在异步端点中直接调用，它会阻塞 Starlette 的事件循环，从而降低性能和可扩展性。通过使用 `anyio.to_thread.run_sync` 将此操作卸载到后台线程，即使在高并发下，也能保持应用程序的响应性和高效性。
+
+## 工作流程示例
+
+- Starlette 应用暴露一个 `/run-agent` 端点，该端点接收包含 `task` 字符串的 JSON 负载。
+- 收到请求时，使用 `anyio.to_thread.run_sync` 在后台线程中运行agent。
+- 结果以 JSON 响应的形式返回。
+
+## 使用 CodeAgent 构建 Starlette 应用
+
+### 1. 安装依赖
+
+```bash
+pip install smolagents starlette anyio uvicorn
+```
+
+### 2. 应用程序代码 (`main.py`)
+
+```python
+import anyio.to_thread
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from smolagents import CodeAgent, InferenceClientModel
+
+agent = CodeAgent(
+    model=InferenceClientModel(model_id="Qwen/Qwen3-Next-80B-A3B-Thinking"),
+    tools=[],
+)
+
+async def run_agent(request: Request):
+    data = await request.json()
+    task = data.get("task", "")
+    # 在后台线程中同步运行智能体
+    result = await anyio.to_thread.run_sync(agent.run, task)
+    return JSONResponse({"result": result})
+
+app = Starlette(routes=[
+    Route("/run-agent", run_agent, methods=["POST"]),
+])
+```
+
+### 3. 运行应用
+
+```bash
+uvicorn async_agent.main:app --reload
+```
+
+### 4. 测试端点
+
+```bash
+curl -X POST http://localhost:8000/run-agent -H 'Content-Type: application/json' -d '{"task": "What is 2+2?"}'
+```
+
+**预期响应：**
+
+```json
+{"result": "4"}
+```
+
+## 扩展阅读
+
+- [Starlette 文档](https://www.starlette.io/)
+- [anyio 文档](https://anyio.readthedocs.io/)
+
+---
+
+完整代码请参见 [`examples/async_agent`](https://github.com/huggingface/smolagents/tree/main/examples/async_agent)。

--- a/docs/source/zh/reference/agents.md
+++ b/docs/source/zh/reference/agents.md
@@ -10,7 +10,7 @@ Smolagents 是一个实验性的 API，可能会随时发生变化。由于 API 
 
 ## 智能体（Agents）
 
-我们的智能体继承自 [`MultiStepAgent`]，这意味着它们可以执行多步操作，每一步包含一个思考（thought），然后是一个工具调用和执行。请阅读[概念指南](../conceptual_guides/react)以了解更多信息。
+我们的agent继承自 [`MultiStepAgent`]，这意味着它们可以执行多步操作，每一步包含一个思考（thought），然后是一个工具调用和执行。请阅读[概念指南](../conceptual_guides/react)以了解更多信息。
 
 我们提供两种类型的代理，它们基于主要的 [`Agent`] 类：
   - [`CodeAgent`] 是默认代理，它以 Python 代码编写工具调用。
@@ -18,7 +18,7 @@ Smolagents 是一个实验性的 API，可能会随时发生变化。由于 API 
 
 两者在初始化时都需要提供参数 `model` 和工具列表 `tools`。
 
-### 智能体类
+### Agent类
 
 [[autodoc]] MultiStepAgent
 

--- a/docs/source/zh/reference/models.md
+++ b/docs/source/zh/reference/models.md
@@ -6,11 +6,11 @@ Smolagents 是一个实验性 API，其可能会随时发生更改。由于 API 
 
 </Tip>
 
-要了解有关智能体和工具的更多信息，请务必阅读[入门指南](../index)。此页面包含底层类的 API 文档。
+要了解有关agent和工具的更多信息，请务必阅读[入门指南](../index)。此页面包含底层类的 API 文档。
 
 ## 模型
 
-您可以自由创建和使用自己的模型为智能体提供支持。
+您可以自由创建和使用自己的模型为agent提供支持。
 
 您可以使用任何 `model` 可调用对象作为智能体的模型，只要满足以下条件：
 1. 它遵循[消息格式](./chat_templating)（`List[Dict[str, str]]`），将其作为输入 `messages`，并返回一个 `str`。
@@ -145,6 +145,6 @@ print(model([{"role": "user", "content": "Ok!"}], stop_sequences=["great"]))
 ```
 
 > [!TIP]
-> 您必须在机器上安装 `mlx-lm`。如果尚未安装，请运行 `pip install 'smolagents[mlx-lm]'`。
+> 您必须在设备上安装 `mlx-lm`。如果尚未安装，请运行 `pip install 'smolagents[mlx-lm]'`。
 
 [[autodoc]] MLXModel

--- a/docs/source/zh/reference/tools.md
+++ b/docs/source/zh/reference/tools.md
@@ -6,7 +6,7 @@ Smolagents 是一个实验性 API，可能会随时更改。由于 API 或底层
 
 </Tip>
 
-要了解更多关于智能体和工具的信息，请务必阅读[入门指南](../index)。本页面包含底层类的 API 文档。
+要了解更多关于agent和工具的信息，请务必阅读[入门指南](../index)。本页面包含底层类的 API 文档。
 
 ## 工具
 
@@ -27,6 +27,28 @@ Smolagents 是一个实验性 API，可能会随时更改。由于 API 或底层
 [[autodoc]] launch_gradio_demo
 
 ## 默认工具
+
+这些默认工具是 [`Tool`] 基类的具体实现，每个工具都设计用于特定任务，例如网络搜索、Python代码执行、网页抓取和用户交互。
+您可以直接在您的agent中使用这些工具，而无需自己实现底层功能。
+每个工具处理一项特定能力，并遵循一致的接口，这使得将它们组合成强大的agent工作流变得很容易。
+
+默认工具可按其主要功能分类：
+*   **信息检索**：从网络和特定知识源搜索和获取信息。
+    *   [`ApiWebSearchTool`]
+    *   [`DuckDuckGoSearchTool`]
+    *   [`GoogleSearchTool`]
+    *   [`WebSearchTool`]
+    *   [`WikipediaSearchTool`]
+*   **网络交互**：获取并处理特定网页的内容。
+    *   [`VisitWebpageTool`]
+*   **代码执行**：为计算任务动态执行 Python 代码。
+    *   [`PythonInterpreterTool`]
+*   **用户交互**：实现智能体与用户之间的人机协同。
+    *   [`UserInputTool`]：收集用户输入。
+*   **语音处理**：将音频转换为文本数据。
+    *   [`SpeechToTextTool`]
+*   **工作流控制**：管理和指导智能体操作的流程。
+    *   [`FinalAnswerTool`]：用最终响应结束智能体工作流
 
 ### PythonInterpreterTool
 


### PR DESCRIPTION
- The translation for `agent` is now consistent over the tutorial. 
- Adding the tutorial for building the async agent application. 
- Clearer information for the tutorial on built-in tools. 
- Translate the titles for the `reference` part. 