### PR TITLE
fix: handle string content in consecutive same-role message merging

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,14 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            # Normalize string content to list format for consistent merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
@@ -385,7 +389,7 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = message.content if isinstance(message.content, str) else message.content[0]["text"]
             else:
                 content = message.content
             output_message_list.append(


### PR DESCRIPTION
## Summary

- Fixes `AssertionError` crash in `get_clean_message_list()` when consecutive messages with the same role have plain string content
- Also fixes the `flatten_messages_as_text` path which had the same string-vs-list assumption

Closes #1972

## Root Cause

`ChatMessage.content` can be either `str` or `list[dict]`. When merging consecutive same-role messages, `get_clean_message_list()` asserted that content was always a `list`, which fails when users pass messages as plain dicts with string content — a perfectly normal API usage pattern.

## Changes

| File | Change |
|------|--------|
| `src/smolagents/models.py` | Normalize string content to list format at merge point; fix initial storage for flatten path |
| `tests/test_models.py` | 3 new tests: consecutive string content, mixed string+list, consecutive string with flatten |

## Reproduction (from #1972)

```python
messages = [
    {"role": "system", "content": "Start with 'FOO'"},
    {"role": "system", "content": "End with 'BAR'"},
    {"role": "user", "content": "Just say '.'"},
]
result = get_clean_message_list(messages)  # Was: AssertionError, Now: works correctly
```

## Test plan

- [x] All 3 new tests pass
- [x] All 7 existing `get_clean_message_list` tests pass
- [x] Full `test_models.py` suite: 88 passed (27 skipped due to optional deps)
- [x] `ruff check` + `ruff format` clean