### PR TITLE
fix: remove duplicate action_step yield when max_steps is reached

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -605,7 +605,6 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -519,6 +519,17 @@ class TestAgent:
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
+    def test_max_steps_stream_no_duplicate_yield(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=2,
+        )
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+        action_steps = [s for s in steps if isinstance(s, ActionStep)]
+        # Each action step should appear exactly once in the stream
+        assert len(action_steps) == len(set(id(s) for s in action_steps))
+
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"


### PR DESCRIPTION
## Summary

- Removes a duplicate `yield action_step` in `_run_stream()` that caused the final action step to be yielded twice when the agent hit `max_steps`
- This also prevents a `NameError` if `_run_stream` were called with `max_steps=0` (the loop never executes, so `action_step` is undefined)

Closes #1816

## Root Cause

When max_steps is reached, the last `action_step` is already yielded in the `finally` block (line 603). The extra `yield action_step` after `_handle_max_steps_reached()` (line 608) re-yields the same stale step. Meanwhile, `_handle_max_steps_reached` creates its own `ActionStep` and appends it to memory independently.

## Changes

| File | Change |
|------|--------|
| `src/smolagents/agents.py` | Remove duplicate `yield action_step` (1 line) |
| `tests/test_agents.py` | Add test verifying no duplicate ActionSteps in stream when max_steps is hit |

## Test plan

- [x] New test `test_max_steps_stream_no_duplicate_yield` passes
- [x] Existing `test_fails_max_steps` still passes
- [x] `ruff check` + `ruff format` clean