### PR TITLE
Fix TypeError crash when model returns None content in code parsing

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -173,6 +173,8 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
 
 def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str | None:
     """Extract code from the LLM's output."""
+    if text is None:
+        return None
     pattern = rf"{code_block_tags[0]}(.*?){code_block_tags[1]}"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
@@ -194,6 +196,8 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     Raises:
         ValueError: If no valid code block is found in the text.
     """
+    if text is None:
+        raise ValueError("The model returned an empty response (content=None). Cannot parse code from empty output.")
     matches = extract_code_from_text(text, code_block_tags)
     if not matches:  # Fallback to markdown pattern
         matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,11 @@ import numpy as np
         )
         assert output == "import numpy as np"
 
+    def test_parse_code_blobs_none_content(self):
+        """parse_code_blobs should raise ValueError with a clear message when content is None."""
+        with pytest.raises(ValueError, match="empty response"):
+            parse_code_blobs(None, ("<code>", "</code>"))
+
     def test_multiple_code_blobs(self):
         test_input = "<code>\nFoo\n</code>\n\n<code>\ncode_a\n</code>\n\n<code>\ncode_b\n</code>"
         result = parse_code_blobs(test_input, ("<code>", "</code>"))


### PR DESCRIPTION
## Summary

Fixes #1896

When an LLM returns a response with `content=None` (which can happen with certain model providers), `parse_code_blobs()` crashes with `TypeError: expected string or bytes-like object, got 'NoneType'` because `re.findall()` is called on `None`.

**Changes:**
- Added a `None` guard in `parse_code_blobs()` that raises a clear `ValueError` with a descriptive message instead of an opaque `TypeError`
- Added a `None` guard in `extract_code_from_text()` to return `None` early when input text is `None`
- Added test `test_parse_code_blobs_none_content` to verify the error message

## Test plan
- [x] `test_parse_code_blobs_none_content` passes — verifies `ValueError` with "empty response" message
- [x] All existing `AgentTextTests` pass (3/3)
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)