### PR TITLE
Add ExaSearchTool as default web search provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ telemetry = [
 ]
 toolkit = [
   "ddgs>=9.0.0",  # DuckDuckGoSearchTool
+  "exa_py>=1.0.0",  # ExaSearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 transformers = [

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,10 +14,32 @@
 # limitations under the License.
 
 
-from smolagents import DuckDuckGoSearchTool
+from smolagents import DuckDuckGoSearchTool, ExaSearchTool
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
+
+
+class TestExaSearchTool(ToolTesterMixin):
+    def setup_method(self):
+        self.tool = ExaSearchTool()
+        self.tool.setup()
+
+    @require_run_all
+    def test_exact_match_arg(self):
+        result = self.tool("Agents")
+        assert isinstance(result, str)
+        assert "## Search Results" in result
+
+    @require_run_all
+    def test_filter_year(self):
+        result = self.tool("Hugging Face transformers", filter_year=2024)
+        assert isinstance(result, str)
+        assert "## Search Results" in result
+
+    @require_run_all
+    def test_agent_type_output(self):
+        super().test_agent_type_output()
 
 
 class TestDuckDuckGoSearchTool(ToolTesterMixin):


### PR DESCRIPTION
## Summary

- **Adds `ExaSearchTool`** — a new web search tool powered by the [Exa API](https://exa.ai), which uses neural search to find semantically relevant results (beyond simple keyword matching)
- **Replaces `DuckDuckGoSearchTool` as the default** in `TOOL_MAPPING`, so the CLI and `add_base_tools=True` now use Exa out of the box
- **All existing search tools are preserved** (`DuckDuckGoSearchTool`, `GoogleSearchTool`, `WebSearchTool`, `ApiWebSearchTool`) — users can still pass any of them explicitly

### Why Exa?

Exa's neural search understands query intent semantically rather than relying on keyword matching, which produces significantly higher quality results for agent use cases. Key features:

- **Auto search type** — intelligently routes each query to the best search method (neural, keyword, or hybrid)
- **Highlights** — returns extractive text snippets most relevant to the query, giving agents richer context without fetching full pages
- **Optional AI summaries** — can return Gemini Flash-generated summaries per result
- **Date filtering** — `filter_year` parameter for restricting results to a specific year
- **Simple setup** — just set `EXA_API_KEY` env var and `pip install exa_py`

### Usage

```python
from smolagents import ExaSearchTool

# Basic usage (reads EXA_API_KEY from environment)
tool = ExaSearchTool()

# With configuration
tool = ExaSearchTool(
    num_results=5,
    search_type="auto",  # "auto", "neural", or "keyword"
    highlights=True,
    summary=False,
)

# Use with an agent
from smolagents import CodeAgent, InferenceClientModel
agent = CodeAgent(tools=[ExaSearchTool()], model=InferenceClientModel())
```

## Changes

| File | Change |
|------|--------|
| `src/smolagents/default_tools.py` | Add `ExaSearchTool` class; update `TOOL_MAPPING` and `__all__` |
| `pyproject.toml` | Add `exa_py>=1.0.0` to `toolkit` optional dependencies |
| `tests/test_search.py` | Add `TestExaSearchTool` with query and year-filter tests |

## Test plan

- [ ] Verify `ExaSearchTool` returns formatted markdown results for basic queries
- [ ] Verify `filter_year` parameter correctly restricts results by date
- [ ] Verify CLI `smolagent` still works with default tools (now uses Exa)
- [ ] Verify existing search tools (`DuckDuckGoSearchTool`, etc.) still work unchanged
- [ ] Run `pytest tests/test_search.py` with `EXA_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)