### PR TITLE
Add LangChainModel wrapper to fix TypeError with LangChain models (#1…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ e2b = [
 gradio = [
   "gradio>=5.14.0",  # Sidebar component GH-797
 ]
+langchain = [
+  "langchain-core>=0.3.0",
+]
 litellm = [
   "litellm>=1.60.2",
 ]
@@ -90,7 +93,7 @@ vllm = [
   "torch"
 ]
 all = [
-  "smolagents[audio,blaxel,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
+  "smolagents[audio,blaxel,docker,e2b,gradio,langchain,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
 ]
 quality = [
   "ruff>=0.9.0",

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2099,21 +2099,42 @@ class LangChainModel(Model):
                 f"Expected a LangChain BaseChatModel instance, got {type(model).__name__}"
             )
         self.langchain_model = model
-        model_id = getattr(model, "model_name", None) or getattr(model, "model", None) or type(model).__name__
+        # Try common attribute names used by LangChain providers; fall back to the class name
+        # but warn the caller so the surprising id is observable.
+        model_id = getattr(model, "model_name", None) or getattr(model, "model", None)
+        if not model_id:
+            model_id = type(model).__name__
+            logger.warning(
+                "LangChainModel: could not find `model_name` or `model` attribute on %s; "
+                "falling back to class name `%s` as model_id. Pass `model_id=...` to "
+                "LangChainModel(...) to override.",
+                type(model).__name__,
+                model_id,
+            )
         super().__init__(model_id=model_id, **kwargs)
 
-    def _convert_to_langchain_messages(self, messages: list) -> list:
-        """Convert smolagents ChatMessage objects to LangChain BaseMessage objects."""
-        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    def _convert_to_langchain_messages(self, messages: list) -> "list[BaseMessage]":
+        """Convert smolagents ChatMessage objects to LangChain BaseMessage objects.
 
-        lc_messages = []
+        Mapping:
+            - role=system           -> SystemMessage
+            - role=assistant or tool-call -> AIMessage
+            - role=tool-response    -> ToolMessage (with tool_call_id from message)
+            - role=user (and others) -> HumanMessage
+        """
+        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+        lc_messages: list[BaseMessage] = []
         for msg in messages:
+            tool_call_id = None
             if isinstance(msg, dict):
                 role = msg.get("role", "user")
                 content = msg.get("content", "")
+                tool_call_id = msg.get("tool_call_id")
             else:
                 role = msg.role.value if isinstance(msg.role, MessageRole) else str(msg.role)
                 content = msg.content
+                tool_call_id = getattr(msg, "tool_call_id", None)
 
             # Flatten list content to string
             if isinstance(content, list):
@@ -2128,12 +2149,17 @@ class LangChainModel(Model):
             if content is None:
                 content = ""
 
-            if role in ("system",):
+            if role == "system":
                 lc_messages.append(SystemMessage(content=content))
             elif role in ("assistant", "tool-call"):
                 lc_messages.append(AIMessage(content=content))
+            elif role in ("tool-response", "tool"):
+                # LangChain requires tool_call_id to associate the result with the originating call.
+                # If the smolagents message lacks one, we still construct a ToolMessage with an empty
+                # id rather than dropping to HumanMessage, since the role semantics differ.
+                lc_messages.append(ToolMessage(content=content, tool_call_id=tool_call_id or ""))
             else:
-                # user, tool-response, and any other roles map to HumanMessage
+                # user and any unrecognised role
                 lc_messages.append(HumanMessage(content=content))
 
         return lc_messages

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1127,6 +1127,70 @@ class TestLangChainModel:
         assert isinstance(lc_messages[2], AIMessage)
         assert lc_messages[2].content == "Hi there!"
 
+    def test_convert_tool_response_to_tool_message(self):
+        """ToolMessage role should map to LangChain ToolMessage carrying tool_call_id."""
+        try:
+            from langchain_core.messages import ToolMessage
+        except ImportError:
+            pytest.skip("langchain-core not installed")
+
+        model = self._make_model()
+
+        # smolagents uses dict-form for tool-response messages with a tool_call_id field
+        messages = [
+            {
+                "role": "tool-response",
+                "content": "Tool returned: 42",
+                "tool_call_id": "call_abc123",
+            }
+        ]
+
+        lc_messages = model._convert_to_langchain_messages(messages)
+
+        assert len(lc_messages) == 1
+        assert isinstance(lc_messages[0], ToolMessage)
+        assert lc_messages[0].content == "Tool returned: 42"
+        assert lc_messages[0].tool_call_id == "call_abc123"
+
+    def test_convert_tool_response_without_tool_call_id(self):
+        """ToolMessage without explicit tool_call_id should still be a ToolMessage (empty id)."""
+        try:
+            from langchain_core.messages import ToolMessage
+        except ImportError:
+            pytest.skip("langchain-core not installed")
+
+        model = self._make_model()
+
+        messages = [{"role": "tool", "content": "result"}]
+        lc_messages = model._convert_to_langchain_messages(messages)
+
+        assert len(lc_messages) == 1
+        assert isinstance(lc_messages[0], ToolMessage)
+        assert lc_messages[0].content == "result"
+        assert lc_messages[0].tool_call_id == ""
+
+    def test_init_logs_warning_when_falling_back_to_class_name(self, caplog):
+        """When neither model_name nor model attribute is present, a warning is logged."""
+        try:
+            from langchain_core.language_models import BaseChatModel
+        except ImportError:
+            pytest.skip("langchain-core not installed")
+
+        mock_lc_model = MagicMock(spec=BaseChatModel)
+        # Force both lookups to be falsy so the fallback path triggers
+        mock_lc_model.model_name = None
+        mock_lc_model.model = None
+
+        with caplog.at_level("WARNING", logger="smolagents.models"):
+            model = LangChainModel(mock_lc_model)
+
+        assert any(
+            "falling back to class name" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        ), f"Expected fallback warning, got records: {[r.message for r in caplog.records]}"
+        # model_id should still be set to the class name
+        assert model.model_id == type(mock_lc_model).__name__
+
     def test_convert_handles_string_content(self):
         """Test conversion when content is a plain string instead of list."""
         try:


### PR DESCRIPTION
## Summary

Fixes #1968

Passing a LangChain `BaseChatModel` (e.g. `ChatOpenAI`) directly to `CodeAgent` causes `TypeError: 'ChatMessage' object is not iterable` because smolagents' `ChatMessage` objects are incompatible with LangChain's expected message format.

This PR adds a `LangChainModel` wrapper class that bridges the two formats, following the same pattern as `LiteLLMModel` and `OpenAIModel`.

### Usage

```python
from langchain_openai import ChatOpenAI
from smolagents import CodeAgent, LangChainModel

llm = ChatOpenAI(model_name="gpt-4o")
model = LangChainModel(llm)
agent = CodeAgent(model=model, tools=[])
agent.run("Hello!")
