### PR TITLE
Add Camb.ai tool suite for TTS, translation, transcription, and audio processing

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -52,3 +52,5 @@
       local: reference/tools
     - title: Built-in Tools
       local: reference/default_tools
+    - title: Camb AI Tools
+      local: reference/camb_tools

--- a/docs/source/en/reference/camb_tools.md
+++ b/docs/source/en/reference/camb_tools.md
@@ -1,0 +1,53 @@
+# Camb AI Tools
+
+Tools for text-to-speech, translation, transcription, voice cloning, sound generation, and audio separation using the [Camb.ai](https://camb.ai) API.
+
+These tools require a Camb.ai API key, which can be passed directly via the `api_key` parameter or set as the `CAMB_API_KEY` environment variable. All tools depend only on `requests` (a core smolagents dependency).
+
+The Camb AI tools can be grouped by their primary functions:
+- **Text-to-Speech**: Convert text into spoken audio.
+  - [`CambTextToSpeechTool`]
+  - [`CambTranslatedTTSTool`]
+- **Translation**: Translate text between 140+ languages.
+  - [`CambTranslationTool`]
+- **Transcription**: Convert spoken audio to text with speaker detection.
+  - [`CambTranscriptionTool`]
+- **Voice Cloning & Management**: Clone voices and browse available voices.
+  - [`CambVoiceCloneTool`]
+  - [`CambVoiceListTool`]
+- **Sound Generation**: Generate sounds and music from text prompts.
+  - [`CambTextToSoundTool`]
+- **Audio Separation**: Split audio into vocal and background stems.
+  - [`CambAudioSeparationTool`]
+
+## CambTextToSpeechTool
+
+[[autodoc]] smolagents.camb_tools.CambTextToSpeechTool
+
+## CambTranslationTool
+
+[[autodoc]] smolagents.camb_tools.CambTranslationTool
+
+## CambTranscriptionTool
+
+[[autodoc]] smolagents.camb_tools.CambTranscriptionTool
+
+## CambTranslatedTTSTool
+
+[[autodoc]] smolagents.camb_tools.CambTranslatedTTSTool
+
+## CambVoiceCloneTool
+
+[[autodoc]] smolagents.camb_tools.CambVoiceCloneTool
+
+## CambVoiceListTool
+
+[[autodoc]] smolagents.camb_tools.CambVoiceListTool
+
+## CambTextToSoundTool
+
+[[autodoc]] smolagents.camb_tools.CambTextToSoundTool
+
+## CambAudioSeparationTool
+
+[[autodoc]] smolagents.camb_tools.CambAudioSeparationTool

--- a/examples/camb_tools.py
+++ b/examples/camb_tools.py
@@ -1,0 +1,144 @@
+"""Example usage of Camb.ai tools with smolagents.
+
+Requires:
+    - CAMB_API_KEY in .env file or environment
+    - Sabrina Carpenter audio clip at ../yt-dlp/voices/original/sabrina-original-clip.mp3
+
+Usage:
+    .venv/bin/python examples/camb_tools.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from smolagents import (
+    CambAudioSeparationTool,
+    CambTextToSoundTool,
+    CambTextToSpeechTool,
+    CambTranscriptionTool,
+    CambTranslatedTTSTool,
+    CambTranslationTool,
+    CambVoiceCloneTool,
+    CambVoiceListTool,
+)
+
+API_KEY = os.environ.get("CAMB_API_KEY")
+if not API_KEY:
+    raise RuntimeError("Set CAMB_API_KEY in .env or environment")
+
+_DEFAULT_SAMPLE = Path(__file__).resolve().parents[2] / "yt-dlp" / "voices" / "original" / "sabrina-original-clip.mp3"
+AUDIO_SAMPLE = os.environ.get("CAMB_AUDIO_SAMPLE", str(_DEFAULT_SAMPLE))
+if not Path(AUDIO_SAMPLE).exists():
+    raise RuntimeError(f"Audio sample not found at {AUDIO_SAMPLE}")
+
+
+def play(path: str) -> None:
+    """Play audio with afplay (macOS)."""
+    if sys.platform == "darwin":
+        print(f"  Playing: {path}")
+        subprocess.run(["afplay", path], check=False)
+    else:
+        print(f"  Audio at: {path}")
+
+
+def example_tts():
+    """1. Text-to-Speech: convert text to audio."""
+    tool = CambTextToSpeechTool(api_key=API_KEY)
+    path = tool("Hello from Camb AI and smolagents! This is a text to speech test.")
+    print(f"  Audio saved to: {path}")
+    play(path)
+
+
+def example_list_voices():
+    """2. List Voices: show available voices."""
+    tool = CambVoiceListTool(api_key=API_KEY)
+    result = tool(language_filter=None)
+    voices = json.loads(result)
+    print(f"  Found {len(voices)} voices")
+    for v in voices[:3]:
+        print(f"    - {v['name']} (id={v['id']}, gender={v['gender']})")
+
+
+def example_translation():
+    """3. Translation: translate text between languages."""
+    tool = CambTranslationTool(api_key=API_KEY)
+    result = tool("Hello, how are you?", source_language=1, target_language=2)
+    print(f"  Translated: {result}")
+
+
+def example_transcription():
+    """4. Transcription: transcribe the Sabrina clip."""
+    tool = CambTranscriptionTool(api_key=API_KEY)
+    result = tool(audio_file_path=AUDIO_SAMPLE, language=1)
+    parsed = json.loads(result)
+    print(f"  Text: {parsed.get('text', result[:200])}")
+    segments = parsed.get("segments", [])
+    print(f"  Segments: {len(segments)}")
+
+
+def example_translated_tts():
+    """5. Translated TTS: translate and speak in one step."""
+    tool = CambTranslatedTTSTool(api_key=API_KEY)
+    path = tool("Hello, how are you?", source_language=1, target_language=2)
+    print(f"  Audio saved to: {path}")
+    play(path)
+
+
+def example_text_to_sound():
+    """6. Text-to-Sound: generate sound effects from a prompt."""
+    tool = CambTextToSoundTool(api_key=API_KEY)
+    path = tool("gentle rain on a rooftop")
+    print(f"  Audio saved to: {path}")
+    play(path)
+
+
+def example_voice_clone():
+    """7. Voice Clone: clone Sabrina's voice and speak with it."""
+    tool = CambVoiceCloneTool(api_key=API_KEY)
+    result = tool(voice_name="smolagents_sabrina", audio_file_path=AUDIO_SAMPLE, gender=2)
+    data = json.loads(result)
+    voice_id = data["voice_id"]
+    print(f"  Cloned voice ID: {voice_id}")
+
+    # Now speak with the cloned voice
+    tts = CambTextToSpeechTool(api_key=API_KEY, voice_id=voice_id)
+    path = tts("Hello! This is Sabrina, cloned with Camb AI and smolagents.")
+    print(f"  Speaking with cloned voice...")
+    play(path)
+
+
+def example_audio_separation():
+    """8. Audio Separation: separate vocals from background."""
+    tool = CambAudioSeparationTool(api_key=API_KEY)
+    result = tool(audio_file_path=AUDIO_SAMPLE)
+    parsed = json.loads(result)
+    print(f"  Status: {parsed['status']}")
+    print(f"  Foreground: {parsed['vocals']}")
+    print(f"  Background: {parsed['background']}")
+
+
+if __name__ == "__main__":
+    examples = [
+        example_tts,
+        example_list_voices,
+        example_translation,
+        example_transcription,
+        example_translated_tts,
+        example_text_to_sound,
+        example_voice_clone,
+        example_audio_separation,
+    ]
+    for fn in examples:
+        print(f"\n--- {fn.__doc__} ---")
+        try:
+            fn()
+            print("  PASSED")
+        except Exception as e:
+            print(f"  FAILED: {e}")

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -18,6 +18,7 @@ __version__ = "1.25.0.dev0"
 
 from .agent_types import *  # noqa: I001
 from .agents import *  # Above noqa avoids a circular dependency due to cli.py
+from .camb_tools import *
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *

--- a/src/smolagents/camb_tools.py
+++ b/src/smolagents/camb_tools.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import tempfile
+import time
+
+from .tools import Tool
+
+
+class _CambToolBase:
+    """Shared mixin providing Camb.ai API helpers for all camb tools."""
+
+    def _camb_init(
+        self,
+        api_key: str | None = None,
+        base_url: str = "https://client.camb.ai/apis",
+        timeout: float = 60.0,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ):
+        self.api_key = api_key or os.environ.get("CAMB_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Camb.ai API key is required. Set it via 'api_key' parameter or CAMB_API_KEY environment variable."
+            )
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_poll_attempts = max_poll_attempts
+        self.poll_interval = poll_interval
+
+    def _get_headers(self) -> dict[str, str]:
+        return {
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+    def _poll_task(self, task_endpoint: str, task_id: str | int) -> dict:
+        """Poll until an async task completes. Returns the status dict."""
+        import requests
+
+        for _ in range(self.max_poll_attempts):
+            resp = requests.get(
+                f"{self.base_url}/{task_endpoint}/{task_id}",
+                headers=self._get_headers(),
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            status = resp.json()
+            status_value = status.get("status", "")
+            if status_value in ("completed", "SUCCESS"):
+                return status
+            if status_value in ("failed", "FAILED", "error"):
+                raise RuntimeError(f"Camb.ai task failed: {status}")
+            time.sleep(self.poll_interval)
+        raise TimeoutError(
+            f"Camb.ai task {task_id} did not complete within {self.max_poll_attempts * self.poll_interval} seconds"
+        )
+
+    @staticmethod
+    def _detect_audio_suffix(audio_data: bytes) -> str:
+        """Detect audio format from magic bytes."""
+        if audio_data[:4] == b"RIFF":
+            return ".wav"
+        if audio_data[:3] == b"ID3" or audio_data[:2] == b"\xff\xfb":
+            return ".mp3"
+        if audio_data[:4] == b"fLaC":
+            return ".flac"
+        if audio_data[:4] == b"OggS":
+            return ".ogg"
+        return ".wav"
+
+    @staticmethod
+    def _save_audio_to_temp(audio_data: bytes, suffix: str = ".wav") -> str:
+        """Save audio bytes to a temporary file and return the path."""
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+            f.write(audio_data)
+            return f.name
+
+
+class CambTextToSpeechTool(_CambToolBase, Tool):
+    """Text-to-speech tool that converts text to audio using the Camb.ai API.
+
+    Generates speech from text input and saves it to a temporary WAV file.
+    Supports configurable voice, language, and speech model.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+        voice_id (`int`, default `147320`): Numeric ID of the voice to use. Use `CambVoiceListTool` to discover available voices.
+        language (`str`, default `"en-us"`): Language code for speech synthesis (e.g. `"en-us"`, `"fr-fr"`).
+        speech_model (`str`, default `"mars-flash"`): Speech model identifier.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambTextToSpeechTool
+        >>> tts = CambTextToSpeechTool()
+        >>> audio_path = tts("Hello, how are you?")
+        >>> print(audio_path)  # /tmp/...wav
+        ```
+    """
+
+    name = "camb_text_to_speech"
+    description = "Converts text to speech using Camb.ai. Returns the file path to the generated audio WAV file."
+    inputs = {
+        "text": {
+            "type": "string",
+            "description": "The text to convert to speech (3-3000 characters).",
+        }
+    }
+    output_type = "string"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        voice_id: int = 147320,
+        language: str = "en-us",
+        speech_model: str = "mars-flash",
+        **kwargs,
+    ):
+        self.voice_id = voice_id
+        self.language = language
+        self.speech_model = speech_model
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, text: str) -> str:
+        import requests
+
+        payload = {
+            "text": text,
+            "voice_id": self.voice_id,
+            "language": self.language,
+            "speech_model": self.speech_model,
+            "output_configuration": {"format": "wav"},
+        }
+        response = requests.post(
+            f"{self.base_url}/tts-stream",
+            json=payload,
+            headers=self._get_headers(),
+            stream=True,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        audio_data = b"".join(response.iter_content(chunk_size=8192))
+        suffix = self._detect_audio_suffix(audio_data)
+        return self._save_audio_to_temp(audio_data, suffix=suffix)
+
+
+class CambTranslationTool(_CambToolBase, Tool):
+    """Text translation tool that translates between 140+ languages using the Camb.ai API.
+
+    Translates text from a source language to a target language. Languages are specified
+    as integer codes (e.g. 1 for English, 2 for Spanish).
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambTranslationTool
+        >>> translator = CambTranslationTool()
+        >>> result = translator("Hello, how are you?", source_language=1, target_language=2)
+        >>> print(result)
+        ```
+    """
+
+    name = "camb_translation"
+    description = (
+        "Translates text between 140+ languages using Camb.ai. "
+        "Source and target languages are specified as integer language codes "
+        "(e.g. 1 for English)."
+    )
+    inputs = {
+        "text": {
+            "type": "string",
+            "description": "The text to translate.",
+        },
+        "source_language": {
+            "type": "integer",
+            "description": "Source language code (integer, e.g. 1 for English).",
+        },
+        "target_language": {
+            "type": "integer",
+            "description": "Target language code (integer, e.g. 2 for Spanish).",
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, text: str, source_language: int, target_language: int) -> str:
+        import requests
+
+        payload = {
+            "text": text,
+            "source_language": source_language,
+            "target_language": target_language,
+        }
+        response = requests.post(
+            f"{self.base_url}/translation/stream",
+            json=payload,
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        # API returns plain text (not JSON)
+        return response.text
+
+
+class CambTranscriptionTool(_CambToolBase, Tool):
+    """Audio transcription tool that converts speech to text using the Camb.ai API.
+
+    Transcribes audio files to text with speaker detection and timestamped segments.
+    Returns the result as a JSON string.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambTranscriptionTool
+        >>> transcriber = CambTranscriptionTool()
+        >>> result = transcriber("recording.wav", language=1)
+        >>> print(result)  # JSON with text, segments, and speakers
+        ```
+    """
+
+    name = "camb_transcription"
+    description = (
+        "Transcribes audio files to text with speaker detection using Camb.ai. "
+        "Returns JSON with transcribed text, segments, and speakers."
+    )
+    inputs = {
+        "audio_file_path": {
+            "type": "string",
+            "description": "Path to the audio file to transcribe.",
+        },
+        "language": {
+            "type": "integer",
+            "description": "Language code (integer, e.g. 1 for English).",
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, audio_file_path: str, language: int) -> str:
+        import requests
+
+        with open(audio_file_path, "rb") as f:
+            resp = requests.post(
+                f"{self.base_url}/transcribe",
+                headers={"x-api-key": self.api_key},
+                files={"media_file": f},
+                data={"language": str(language)},
+                timeout=self.timeout,
+            )
+        resp.raise_for_status()
+        task_data = resp.json()
+        task_id = task_data.get("task_id") or task_data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Camb.ai API did not return a task ID: {task_data}")
+
+        status = self._poll_task("transcribe", task_id)
+        run_id = status.get("run_id")
+        if not run_id:
+            raise RuntimeError(f"Camb.ai task completed but no run_id returned: {status}")
+
+        result_resp = requests.get(
+            f"{self.base_url}/transcription-result/{run_id}",
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        result_resp.raise_for_status()
+        return json.dumps(result_resp.json(), indent=2)
+
+
+class CambTranslatedTTSTool(_CambToolBase, Tool):
+    """Combined translation and text-to-speech tool using the Camb.ai API.
+
+    Translates text from a source language to a target language and synthesizes
+    speech from the translated text in one step. Returns the path to the generated audio file.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+        voice_id (`int`, default `147320`): Numeric ID of the voice to use for speech synthesis.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambTranslatedTTSTool
+        >>> translated_tts = CambTranslatedTTSTool()
+        >>> audio_path = translated_tts("Hello!", source_language=1, target_language=2)
+        >>> print(audio_path)  # /tmp/...wav
+        ```
+    """
+
+    name = "camb_translated_tts"
+    description = (
+        "Translates text and converts it to speech in one step using Camb.ai. "
+        "Returns the file path to the generated audio."
+    )
+    inputs = {
+        "text": {
+            "type": "string",
+            "description": "The text to translate and convert to speech.",
+        },
+        "source_language": {
+            "type": "integer",
+            "description": "Source language code (integer).",
+        },
+        "target_language": {
+            "type": "integer",
+            "description": "Target language code (integer).",
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, voice_id: int = 147320, **kwargs):
+        self.voice_id = voice_id
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, text: str, source_language: int, target_language: int) -> str:
+        import requests
+
+        payload = {
+            "text": text,
+            "voice_id": self.voice_id,
+            "source_language": source_language,
+            "target_language": target_language,
+        }
+        resp = requests.post(
+            f"{self.base_url}/translated-tts",
+            json=payload,
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        task_data = resp.json()
+        task_id = task_data.get("task_id") or task_data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Camb.ai API did not return a task ID: {task_data}")
+
+        status = self._poll_task("translated-tts", task_id)
+        run_id = status.get("run_id")
+        if not run_id:
+            raise RuntimeError(f"Camb.ai task completed but no run_id returned: {status}")
+
+        audio_resp = requests.get(
+            f"{self.base_url}/tts-result/{run_id}",
+            headers={"x-api-key": self.api_key},
+            stream=True,
+            timeout=self.timeout,
+        )
+        audio_resp.raise_for_status()
+        audio_data = b"".join(audio_resp.iter_content(chunk_size=8192))
+        suffix = self._detect_audio_suffix(audio_data)
+        return self._save_audio_to_temp(audio_data, suffix=suffix)
+
+
+class CambVoiceCloneTool(_CambToolBase, Tool):
+    """Voice cloning tool that creates a custom voice from an audio sample using the Camb.ai API.
+
+    Creates a new voice profile from a 2+ second audio recording. Returns JSON with the
+    created voice ID, which can then be used with `CambTextToSpeechTool` or `CambTranslatedTTSTool`.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambVoiceCloneTool
+        >>> cloner = CambVoiceCloneTool()
+        >>> result = cloner("my_voice", "sample.wav", gender=1)
+        >>> print(result)  # JSON with voice_id
+        ```
+    """
+
+    name = "camb_voice_clone"
+    description = "Clones a voice from a 2+ second audio sample using Camb.ai. Returns JSON with the created voice_id."
+    inputs = {
+        "voice_name": {
+            "type": "string",
+            "description": "Name for the cloned voice.",
+        },
+        "audio_file_path": {
+            "type": "string",
+            "description": "Path to the audio file (2+ seconds) to clone the voice from.",
+        },
+        "gender": {
+            "type": "integer",
+            "description": "Gender code: 0=not specified, 1=male, 2=female, 9=not applicable.",
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, voice_name: str, audio_file_path: str, gender: int) -> str:
+        import requests
+
+        with open(audio_file_path, "rb") as f:
+            resp = requests.post(
+                f"{self.base_url}/create-custom-voice",
+                headers={"x-api-key": self.api_key},
+                files={"file": f},
+                data={"voice_name": voice_name, "gender": str(gender)},
+                timeout=self.timeout,
+            )
+        resp.raise_for_status()
+        return json.dumps(resp.json(), indent=2)
+
+
+class CambVoiceListTool(_CambToolBase, Tool):
+    """Voice listing tool that retrieves all available voices from the Camb.ai API.
+
+    Returns a JSON array of voices with their IDs, names, genders, and languages.
+    Useful for discovering voice IDs to use with TTS tools.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambVoiceListTool
+        >>> voices = CambVoiceListTool()
+        >>> result = voices(language_filter="en-us")
+        >>> print(result)  # JSON array of matching voices
+        ```
+    """
+
+    name = "camb_voice_list"
+    description = (
+        "Lists all available voices from Camb.ai with ID, name, gender, and language. "
+        "Use this to find the right voice_id for TTS tools."
+    )
+    inputs = {
+        "language_filter": {
+            "type": "string",
+            "description": "Optional language to filter voices by (e.g. 'en-us'). Pass null to list all.",
+            "nullable": True,
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, language_filter: str | None = None) -> str:
+        import requests
+
+        resp = requests.get(
+            f"{self.base_url}/list-voices",
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        voices = resp.json()
+
+        voice_list = []
+        for voice in voices:
+            entry = {
+                "id": voice.get("id"),
+                "name": voice.get("voice_name", voice.get("name", "Unknown")),
+                "gender": self._gender_to_string(voice.get("gender", 0)),
+                "age": voice.get("age"),
+                "language": voice.get("language"),
+            }
+            if language_filter and entry.get("language") != language_filter:
+                continue
+            voice_list.append(entry)
+
+        return json.dumps(voice_list, indent=2)
+
+    @staticmethod
+    def _gender_to_string(gender: int) -> str:
+        gender_map = {
+            0: "not_specified",
+            1: "male",
+            2: "female",
+            9: "not_applicable",
+        }
+        return gender_map.get(gender, "unknown")
+
+
+class CambTextToSoundTool(_CambToolBase, Tool):
+    """Sound generation tool that creates audio from text descriptions using the Camb.ai API.
+
+    Generates sounds, music, or soundscapes from natural-language prompts.
+    Returns the path to the generated audio file.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambTextToSoundTool
+        >>> sound_gen = CambTextToSoundTool()
+        >>> audio_path = sound_gen("rain falling on a tin roof")
+        >>> print(audio_path)  # /tmp/...wav
+        ```
+    """
+
+    name = "camb_text_to_sound"
+    description = (
+        "Generates sounds, music, or soundscapes from text descriptions using Camb.ai. "
+        "Returns the file path to the generated audio."
+    )
+    inputs = {
+        "prompt": {
+            "type": "string",
+            "description": "Description of the sound or music to generate.",
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, prompt: str) -> str:
+        import requests
+
+        payload = {"prompt": prompt}
+        resp = requests.post(
+            f"{self.base_url}/text-to-sound",
+            json=payload,
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        task_data = resp.json()
+        task_id = task_data.get("task_id") or task_data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Camb.ai API did not return a task ID: {task_data}")
+
+        status = self._poll_task("text-to-sound", task_id)
+        run_id = status.get("run_id")
+        if not run_id:
+            raise RuntimeError(f"Camb.ai task completed but no run_id returned: {status}")
+
+        audio_resp = requests.get(
+            f"{self.base_url}/text-to-sound-result/{run_id}",
+            headers={"x-api-key": self.api_key},
+            stream=True,
+            timeout=self.timeout,
+        )
+        audio_resp.raise_for_status()
+        audio_data = b"".join(audio_resp.iter_content(chunk_size=8192))
+        suffix = self._detect_audio_suffix(audio_data)
+        return self._save_audio_to_temp(audio_data, suffix=suffix)
+
+
+class CambAudioSeparationTool(_CambToolBase, Tool):
+    """Audio separation tool that splits vocals from background audio using the Camb.ai API.
+
+    Separates an audio file into foreground (vocals/speech) and background tracks.
+    Returns JSON with URLs to download the separated audio stems.
+
+    Args:
+        api_key (`str`, *optional*): Camb.ai API key. Falls back to the `CAMB_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import CambAudioSeparationTool
+        >>> separator = CambAudioSeparationTool()
+        >>> result = separator("song.mp3")
+        >>> print(result)  # JSON with vocals and background URLs
+        ```
+    """
+
+    name = "camb_audio_separation"
+    description = (
+        "Separates vocals/speech from background audio using Camb.ai. "
+        "Returns JSON with URLs for the separated vocals and background tracks."
+    )
+    inputs = {
+        "audio_file_path": {
+            "type": "string",
+            "description": "Path to the audio file to separate.",
+        }
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        self._camb_init(
+            api_key=api_key,
+            **{k: v for k, v in kwargs.items() if k in ("base_url", "timeout", "max_poll_attempts", "poll_interval")},
+        )
+        super().__init__()
+
+    def forward(self, audio_file_path: str) -> str:
+        import requests
+
+        with open(audio_file_path, "rb") as f:
+            resp = requests.post(
+                f"{self.base_url}/audio-separation",
+                headers={"x-api-key": self.api_key},
+                files={"media_file": f},
+                timeout=self.timeout,
+            )
+        resp.raise_for_status()
+        task_data = resp.json()
+        task_id = task_data.get("task_id") or task_data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Camb.ai API did not return a task ID: {task_data}")
+
+        status = self._poll_task("audio-separation", task_id)
+        run_id = status.get("run_id")
+        if not run_id:
+            raise RuntimeError(f"Camb.ai task completed but no run_id returned: {status}")
+
+        result_resp = requests.get(
+            f"{self.base_url}/audio-separation-result/{run_id}",
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        result_resp.raise_for_status()
+        result = result_resp.json()
+
+        output = {
+            "vocals": result.get("foreground_audio_url"),
+            "background": result.get("background_audio_url"),
+            "status": "completed",
+        }
+        return json.dumps(output, indent=2)
+
+
+__all__ = [
+    "CambTextToSpeechTool",
+    "CambTranslationTool",
+    "CambTranscriptionTool",
+    "CambTranslatedTTSTool",
+    "CambVoiceCloneTool",
+    "CambVoiceListTool",
+    "CambTextToSoundTool",
+    "CambAudioSeparationTool",
+]

--- a/tests/test_camb_tools.py
+++ b/tests/test_camb_tools.py
@@ -1,0 +1,436 @@
+"""Tests for Camb.ai tools."""
+
+import json
+import os
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from smolagents.camb_tools import (
+    CambAudioSeparationTool,
+    CambTextToSoundTool,
+    CambTextToSpeechTool,
+    CambTranscriptionTool,
+    CambTranslatedTTSTool,
+    CambTranslationTool,
+    CambVoiceCloneTool,
+    CambVoiceListTool,
+    _CambToolBase,
+)
+
+TEST_API_KEY = "test-api-key-12345"
+
+
+# --- Instantiation tests ---
+
+
+class TestInstantiation:
+    """Test that each tool can be instantiated with an explicit API key."""
+
+    def test_tts_tool(self):
+        tool = CambTextToSpeechTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_text_to_speech"
+        assert tool.api_key == TEST_API_KEY
+        assert tool.voice_id == 147320
+        assert tool.language == "en-us"
+        assert tool.speech_model == "mars-flash"
+
+    def test_translation_tool(self):
+        tool = CambTranslationTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_translation"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_transcription_tool(self):
+        tool = CambTranscriptionTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_transcription"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_translated_tts_tool(self):
+        tool = CambTranslatedTTSTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_translated_tts"
+        assert tool.api_key == TEST_API_KEY
+        assert tool.voice_id == 147320
+
+    def test_voice_clone_tool(self):
+        tool = CambVoiceCloneTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_voice_clone"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_voice_list_tool(self):
+        tool = CambVoiceListTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_voice_list"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_text_to_sound_tool(self):
+        tool = CambTextToSoundTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_text_to_sound"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_audio_separation_tool(self):
+        tool = CambAudioSeparationTool(api_key=TEST_API_KEY)
+        assert tool.name == "camb_audio_separation"
+        assert tool.api_key == TEST_API_KEY
+
+    def test_env_var_fallback(self):
+        with patch.dict(os.environ, {"CAMB_API_KEY": "env-key-123"}):
+            tool = CambTextToSpeechTool()
+            assert tool.api_key == "env-key-123"
+
+    def test_custom_config(self):
+        tool = CambTextToSpeechTool(
+            api_key=TEST_API_KEY,
+            voice_id=999,
+            language="fr-fr",
+            speech_model="mars-pro",
+        )
+        assert tool.voice_id == 999
+        assert tool.language == "fr-fr"
+        assert tool.speech_model == "mars-pro"
+
+
+class TestMissingApiKey:
+    """Test that missing API key raises ValueError."""
+
+    def test_tts_missing_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("CAMB_API_KEY", None)
+            with pytest.raises(ValueError, match="API key is required"):
+                CambTextToSpeechTool()
+
+    def test_translation_missing_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("CAMB_API_KEY", None)
+            with pytest.raises(ValueError, match="API key is required"):
+                CambTranslationTool()
+
+
+# --- Forward method tests with mocked HTTP ---
+
+
+class TestTextToSpeechForward:
+    @patch("requests.post")
+    def test_forward_streams_audio(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        # WAV magic bytes (RIFF header)
+        wav_data = b"RIFF" + b"\x00" * 100
+        mock_response.iter_content.return_value = [wav_data]
+        mock_post.return_value = mock_response
+
+        tool = CambTextToSpeechTool(api_key=TEST_API_KEY)
+        result = tool.forward("Hello world")
+
+        assert result.endswith(".wav")
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert "tts-stream" in call_kwargs[0][0] or "tts-stream" in str(call_kwargs)
+
+
+class TestTranslationForward:
+    @patch("requests.post")
+    def test_forward_returns_text(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = "Hola mundo"
+        mock_post.return_value = mock_response
+
+        tool = CambTranslationTool(api_key=TEST_API_KEY)
+        result = tool.forward("Hello world", source_language=1, target_language=2)
+
+        assert result == "Hola mundo"
+
+
+class TestTranscriptionForward:
+    @patch("requests.get")
+    @patch("requests.post")
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_forward_returns_json(self, mock_post, mock_get):
+        # Mock POST for creating transcription task
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 200
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_post_resp.json.return_value = {"task_id": "task-123"}
+        mock_post.return_value = mock_post_resp
+
+        # Mock GET for polling (completed) and result
+        mock_poll_resp = MagicMock()
+        mock_poll_resp.status_code = 200
+        mock_poll_resp.raise_for_status = MagicMock()
+        mock_poll_resp.json.return_value = {"status": "completed", "run_id": "run-456"}
+
+        mock_result_resp = MagicMock()
+        mock_result_resp.status_code = 200
+        mock_result_resp.raise_for_status = MagicMock()
+        mock_result_resp.json.return_value = {
+            "text": "Hello world",
+            "segments": [{"start": 0, "end": 2, "text": "Hello world"}],
+            "speakers": ["SPEAKER_00"],
+        }
+
+        mock_get.side_effect = [mock_poll_resp, mock_result_resp]
+
+        tool = CambTranscriptionTool(api_key=TEST_API_KEY)
+        result = tool.forward("/path/to/audio.wav", language=1)
+
+        parsed = json.loads(result)
+        assert parsed["text"] == "Hello world"
+        assert "segments" in parsed
+
+
+class TestTranslatedTTSForward:
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_forward_returns_file_path(self, mock_post, mock_get):
+        # Mock POST for creating task
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 200
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_post_resp.json.return_value = {"task_id": "task-789"}
+        mock_post.return_value = mock_post_resp
+
+        # Mock GET for polling and audio result
+        mock_poll_resp = MagicMock()
+        mock_poll_resp.status_code = 200
+        mock_poll_resp.raise_for_status = MagicMock()
+        mock_poll_resp.json.return_value = {"status": "completed", "run_id": "run-101"}
+
+        mock_audio_resp = MagicMock()
+        mock_audio_resp.status_code = 200
+        mock_audio_resp.raise_for_status = MagicMock()
+        mock_audio_resp.iter_content.return_value = [b"RIFF" + b"\x00" * 100]
+
+        mock_get.side_effect = [mock_poll_resp, mock_audio_resp]
+
+        tool = CambTranslatedTTSTool(api_key=TEST_API_KEY)
+        result = tool.forward("Hello", source_language=1, target_language=2)
+
+        assert result.endswith(".wav")
+
+
+class TestVoiceCloneForward:
+    @patch("requests.post")
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_forward_returns_json(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "voice_id": 12345,
+            "voice_name": "TestVoice",
+            "status": "created",
+        }
+        mock_post.return_value = mock_response
+
+        tool = CambVoiceCloneTool(api_key=TEST_API_KEY)
+        result = tool.forward("TestVoice", "/path/to/sample.wav", gender=1)
+
+        parsed = json.loads(result)
+        assert parsed["voice_id"] == 12345
+        assert parsed["voice_name"] == "TestVoice"
+
+
+class TestVoiceListForward:
+    @patch("requests.get")
+    def test_forward_returns_voice_list(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = [
+            {"id": 1, "voice_name": "Alice", "gender": 2, "age": 30, "language": "en-us"},
+            {"id": 2, "voice_name": "Bob", "gender": 1, "age": 40, "language": "en-us"},
+            {"id": 3, "voice_name": "Carlos", "gender": 1, "age": 35, "language": "es-es"},
+        ]
+        mock_get.return_value = mock_response
+
+        tool = CambVoiceListTool(api_key=TEST_API_KEY)
+        result = tool.forward(language_filter=None)
+
+        parsed = json.loads(result)
+        assert len(parsed) == 3
+        assert parsed[0]["name"] == "Alice"
+        assert parsed[0]["gender"] == "female"
+
+    @patch("requests.get")
+    def test_forward_filters_by_language(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = [
+            {"id": 1, "voice_name": "Alice", "gender": 2, "age": 30, "language": "en-us"},
+            {"id": 3, "voice_name": "Carlos", "gender": 1, "age": 35, "language": "es-es"},
+        ]
+        mock_get.return_value = mock_response
+
+        tool = CambVoiceListTool(api_key=TEST_API_KEY)
+        result = tool.forward(language_filter="en-us")
+
+        parsed = json.loads(result)
+        assert len(parsed) == 1
+        assert parsed[0]["name"] == "Alice"
+
+
+class TestTextToSoundForward:
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_forward_returns_file_path(self, mock_post, mock_get):
+        # Mock POST for creating task
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 200
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_post_resp.json.return_value = {"task_id": "task-sound"}
+        mock_post.return_value = mock_post_resp
+
+        # Mock GET for polling and audio result
+        mock_poll_resp = MagicMock()
+        mock_poll_resp.status_code = 200
+        mock_poll_resp.raise_for_status = MagicMock()
+        mock_poll_resp.json.return_value = {"status": "completed", "run_id": "run-sound"}
+
+        mock_audio_resp = MagicMock()
+        mock_audio_resp.status_code = 200
+        mock_audio_resp.raise_for_status = MagicMock()
+        mock_audio_resp.iter_content.return_value = [b"RIFF" + b"\x00" * 100]
+
+        mock_get.side_effect = [mock_poll_resp, mock_audio_resp]
+
+        tool = CambTextToSoundTool(api_key=TEST_API_KEY)
+        result = tool.forward("Birds chirping in a forest")
+
+        assert result.endswith(".wav")
+
+
+class TestAudioSeparationForward:
+    @patch("requests.get")
+    @patch("requests.post")
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_forward_returns_json(self, mock_post, mock_get):
+        # Mock POST for creating task
+        mock_post_resp = MagicMock()
+        mock_post_resp.status_code = 200
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_post_resp.json.return_value = {"task_id": "task-sep"}
+        mock_post.return_value = mock_post_resp
+
+        # Mock GET for polling and result
+        mock_poll_resp = MagicMock()
+        mock_poll_resp.status_code = 200
+        mock_poll_resp.raise_for_status = MagicMock()
+        mock_poll_resp.json.return_value = {"status": "completed", "run_id": "run-sep"}
+
+        mock_result_resp = MagicMock()
+        mock_result_resp.status_code = 200
+        mock_result_resp.raise_for_status = MagicMock()
+        mock_result_resp.json.return_value = {
+            "foreground_audio_url": "https://example.com/vocals.wav",
+            "background_audio_url": "https://example.com/background.wav",
+        }
+
+        mock_get.side_effect = [mock_poll_resp, mock_result_resp]
+
+        tool = CambAudioSeparationTool(api_key=TEST_API_KEY)
+        result = tool.forward("/path/to/mixed.wav")
+
+        parsed = json.loads(result)
+        assert parsed["vocals"] == "https://example.com/vocals.wav"
+        assert parsed["background"] == "https://example.com/background.wav"
+        assert parsed["status"] == "completed"
+
+
+# --- Polling logic tests ---
+
+
+class TestPollingLogic:
+    @patch("requests.get")
+    @patch("time.sleep")
+    def test_poll_completes_after_retries(self, mock_sleep, mock_get):
+        pending_resp = MagicMock()
+        pending_resp.status_code = 200
+        pending_resp.raise_for_status = MagicMock()
+        pending_resp.json.return_value = {"status": "pending"}
+
+        completed_resp = MagicMock()
+        completed_resp.status_code = 200
+        completed_resp.raise_for_status = MagicMock()
+        completed_resp.json.return_value = {"status": "completed", "run_id": "run-123"}
+
+        mock_get.side_effect = [pending_resp, pending_resp, completed_resp]
+
+        tool = CambTextToSpeechTool(api_key=TEST_API_KEY)
+        result = tool._poll_task("test-endpoint", "task-1")
+
+        assert result["status"] == "completed"
+        assert result["run_id"] == "run-123"
+        assert mock_sleep.call_count == 2
+
+    @patch("requests.get")
+    @patch("time.sleep")
+    def test_poll_raises_on_failure(self, mock_sleep, mock_get):
+        failed_resp = MagicMock()
+        failed_resp.status_code = 200
+        failed_resp.raise_for_status = MagicMock()
+        failed_resp.json.return_value = {"status": "failed", "error": "Something went wrong"}
+
+        mock_get.return_value = failed_resp
+
+        tool = CambTextToSpeechTool(api_key=TEST_API_KEY)
+        with pytest.raises(RuntimeError, match="task failed"):
+            tool._poll_task("test-endpoint", "task-1")
+
+    @patch("requests.get")
+    @patch("time.sleep")
+    def test_poll_raises_on_timeout(self, mock_sleep, mock_get):
+        pending_resp = MagicMock()
+        pending_resp.status_code = 200
+        pending_resp.raise_for_status = MagicMock()
+        pending_resp.json.return_value = {"status": "pending"}
+
+        mock_get.return_value = pending_resp
+
+        tool = CambTextToSpeechTool(api_key=TEST_API_KEY, max_poll_attempts=3, poll_interval=0.01)
+        with pytest.raises(TimeoutError, match="did not complete"):
+            tool._poll_task("test-endpoint", "task-1")
+
+
+# --- Audio format detection tests ---
+
+
+class TestAudioFormatDetection:
+    def test_detect_wav(self):
+        assert _CambToolBase._detect_audio_suffix(b"RIFF" + b"\x00" * 10) == ".wav"
+
+    def test_detect_mp3_id3(self):
+        assert _CambToolBase._detect_audio_suffix(b"ID3" + b"\x00" * 10) == ".mp3"
+
+    def test_detect_mp3_sync(self):
+        assert _CambToolBase._detect_audio_suffix(b"\xff\xfb" + b"\x00" * 10) == ".mp3"
+
+    def test_detect_flac(self):
+        assert _CambToolBase._detect_audio_suffix(b"fLaC" + b"\x00" * 10) == ".flac"
+
+    def test_detect_ogg(self):
+        assert _CambToolBase._detect_audio_suffix(b"OggS" + b"\x00" * 10) == ".ogg"
+
+    def test_detect_unknown_defaults_wav(self):
+        assert _CambToolBase._detect_audio_suffix(b"\x00\x00\x00\x00") == ".wav"
+
+
+# --- Gender string conversion ---
+
+
+class TestGenderConversion:
+    def test_male(self):
+        assert CambVoiceListTool._gender_to_string(1) == "male"
+
+    def test_female(self):
+        assert CambVoiceListTool._gender_to_string(2) == "female"
+
+    def test_not_specified(self):
+        assert CambVoiceListTool._gender_to_string(0) == "not_specified"
+
+    def test_not_applicable(self):
+        assert CambVoiceListTool._gender_to_string(9) == "not_applicable"
+
+    def test_unknown(self):
+        assert CambVoiceListTool._gender_to_string(99) == "unknown"


### PR DESCRIPTION
## Summary
- Adds 8 new tools powered by the Camb.ai API: `CambTextToSpeechTool`, `CambTranslationTool`, `CambTranscriptionTool`, `CambTranslatedTTSTool`, `CambVoiceCloneTool`, `CambVoiceListTool`, `CambTextToSoundTool`, `CambAudioSeparationTool`
- Tools only depend on `requests` (already a core dependency) — no new extras needed
- Includes documentation reference page with `[[autodoc]]` entries and toctree integration

## Test plan
- [x] `pytest tests/test_camb_tools.py` — 35 unit tests passing
- [x] `ruff check` and `ruff format` pass
- [x] `uv run examples/camb_tools.py` — live integration test verified
- [ ] Doc build: `make docs` to verify `[[autodoc]]` renders correctly