### PR TITLE
Isolate WasmExecutor Deno cache to per-instance temp directory

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -1108,10 +1108,11 @@ class WasmExecutor(RemotePythonExecutor):
         self.deno_path = deno_path
         self.timeout = timeout
 
+        # Create the Deno JavaScript runner file
+        self._create_deno_runner()
+
         # Default minimal permissions needed
         if deno_permissions is None:
-            # Use minimal permissions for Deno execution
-            home_dir = os.getenv("HOME")
             deno_permissions = [
                 "allow-net="
                 + ",".join(
@@ -1121,13 +1122,21 @@ class WasmExecutor(RemotePythonExecutor):
                         "pypi.org:443,files.pythonhosted.org:443",  # allow pyodide install packages from PyPI
                     ]
                 ),
-                f"allow-read={home_dir}/.cache/deno",
-                f"allow-write={home_dir}/.cache/deno",
+                # FS permissions are always scoped to deno_cache_dir (the per-instance temp dir
+                # that cleanup() removes). This replaces the original global ~/.cache/deno
+                # permissions, bounding any write from attacker code to a short-lived
+                # directory that never affects other Deno processes or persists past teardown.
+                # --allow-read: required for Deno to load npm package assets at runtime
+                #               (e.g. pyodide.asm.wasm is read via Deno file APIs).
+                # --allow-write: required for pyodide's loadPackage() to cache downloaded
+                #                Python packages (e.g. micropip) to the Deno-backed FS.
+                f"allow-read={self.deno_cache_dir}",
+                f"allow-write={self.deno_cache_dir}",
             ]
         self.deno_permissions = [f"--{perm}" for perm in deno_permissions]
 
-        # Create the Deno JavaScript runner file
-        self._create_deno_runner()
+        # Start the Deno server
+        self._start_deno_server()
 
         # Install additional packages
         self.installed_packages = self.install_packages(additional_imports)
@@ -1135,15 +1144,15 @@ class WasmExecutor(RemotePythonExecutor):
 
     def _create_deno_runner(self):
         """Create the Deno JavaScript file that will run Pyodide and execute Python code."""
+        # Create an isolated per-executor runtime directory to avoid sharing mutable Deno state
         self.runner_dir = tempfile.mkdtemp(prefix="pyodide_deno_")
         self.runner_path = os.path.join(self.runner_dir, "pyodide_runner.js")
-
         # Create the JavaScript runner file
         with open(self.runner_path, "w") as f:
             f.write(self.JS_CODE)
-
-        # Start the Deno server
-        self._start_deno_server()
+        # Isolate Deno's module cache inside the per-instance temp directory so it
+        # cannot affect other Deno processes and is removed when cleanup() runs.
+        self.deno_cache_dir = os.path.join(self.runner_dir, "deno_cache")
 
     def _start_deno_server(self):
         """Start the Deno server that will run our JavaScript code."""
@@ -1155,6 +1164,7 @@ class WasmExecutor(RemotePythonExecutor):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env={**os.environ, "DENO_DIR": self.deno_cache_dir},
         )
 
         # Wait for the server to start


### PR DESCRIPTION
Isolate WasmExecutor Deno cache to per-instance temp directory.

With this PR, each `WasmExecutor` instance gets its own isolated Deno cache directory. Module downloads, package caches, and all Deno runtime state are cleaned up together with the executor on `cleanup()`. No state leaks between instances or persists beyond the executor's lifetime.

### Problem

`WasmExecutor` previously pointed Deno's module cache at `~/.cache/deno`: a global directory shared across all Deno processes on the system. 

### Solution

This PR scopes the Deno runtime environment entirely to the per-instance temp directory (`runner_dir`) that `cleanup()` already manages, so module state is isolated between executor instances and automatically removed on teardown.

### Changes
- `DENO_DIR` isolation: sets `DENO_DIR=<runner_dir>/deno_cache` in the subprocess environment so Deno's module cache is contained within the executor instance's lifetime and never shared with other processes.
- FS permissions scoped to runner_dir: replaces `--allow-read/write=~/.cache/deno` with `--allow-read/write=<deno_runner_cache_dir>`. Pyodide requires read access to load npm assets (e.g. pyodide.asm.wasm) and write access for loadPackage() to cache downloaded Python packages; both are now bounded to the same temp dir that cleanup() removes.
- Removes hardcoded Linux path: `~/.cache/deno` is Linux-specific (macOS uses `~/Library/Caches/deno`, Windows differs). `runner_dir` is produced by `tempfile.mkdtemp()` and is portable across platforms.

Supersede and close #1952.