### PR TITLE
fix: reset PrintContainer before ast.parse to prevent SyntaxError leaking previous output

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1620,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1213,6 +1213,19 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_resets_print_outputs(self):
+        """Print outputs from a previous step must not leak when the next step has a SyntaxError."""
+        state = {}
+        # Step 1: a successful execution that prints something
+        evaluate_python_code("print('step1')", BASE_PYTHON_TOOLS, state=state)
+        assert "step1" in str(state["_print_outputs"])
+
+        # Step 2: a SyntaxError — _print_outputs should be reset, not carry over
+        with pytest.raises(InterpreterError):
+            evaluate_python_code("def bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        assert "step1" not in str(state["_print_outputs"])
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Problem

When a `SyntaxError` occurs during code parsing in `evaluate_python_code()`, the `InterpreterError` is raised **before** `state['_print_outputs']` is reset with a fresh `PrintContainer`. This causes print output from a previous step to appear in the current step's execution logs.

### Reproduction

1. Step 1: `print('Step 1 output')` — prints normally
2. Step 2: Code with a `SyntaxError` — execution logs show **"Step 1 output"** again

This happens because `ast.parse()` runs before the `PrintContainer` is reset, so when parsing fails, the old `PrintContainer` (still containing step 1's output) is read.

## Solution

Move the state initialization block (including `state['_print_outputs'] = PrintContainer()`) **before** `ast.parse()`. This ensures the print buffer is always clean, regardless of whether parsing succeeds or fails.

## Changes

| File | Change |
|------|--------|
| `src/smolagents/local_python_executor.py` | Moved state init block before `ast.parse()` |

## Verification

```python
state = {}
evaluate_python_code('print("Step 1")', state=state, static_tools={'print': print})
assert state['_print_outputs'].value == 'Step 1\n'

try:
    evaluate_python_code('def bad(\n    pass', state=state, static_tools={'print': print})
except InterpreterError:
    pass

# Before fix: 'Step 1\n' (leaked)
# After fix: '' (clean)
assert state['_print_outputs'].value == ''
```

All 389 existing tests pass (2 skipped).

Fixes #1998