### PR TITLE
fix: reset PrintContainer before ast.parse to prevent output leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1620,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]


### PR DESCRIPTION
## Summary

Fixes #1998 — When a `SyntaxError` occurs during code parsing, print outputs from the previous step leak into the current step's output.

## Root Cause

In `evaluate_python_code()`, the `PrintContainer` reset (`state["_print_outputs"] = PrintContainer()`) happened **after** `ast.parse()`. When `ast.parse()` raises a `SyntaxError`, the `PrintContainer` from the previous step is never cleared.

## Fix

Move state initialization (including `PrintContainer` and `_operations_count` reset) **before** the `ast.parse()` call so the state is always clean regardless of whether parsing succeeds.

## Changes

- **`src/smolagents/local_python_executor.py`**: Reordered 6 lines of state initialization to execute before `ast.parse()`
- **`tests/test_local_python_executor.py`**: Added regression test `test_syntax_error_clears_print_outputs`

## Testing

- New regression test passes ✅
- All 390 existing executor tests pass ✅ (2 skipped, pre-existing)