### PR TITLE
fix: reset PrintContainer before ast.parse to prevent output leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1620,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1213,6 +1213,20 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_clears_previous_print_outputs(self):
+        """Print outputs from a previous step should not leak into a step with a SyntaxError."""
+        state = {}
+        # Step 1: code that prints something
+        evaluate_python_code("print('step1 output')", BASE_PYTHON_TOOLS, state=state)
+        assert "step1 output" in str(state["_print_outputs"])
+
+        # Step 2: code with a SyntaxError — should reset _print_outputs before raising
+        with pytest.raises(InterpreterError):
+            evaluate_python_code("def bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        # The print container should have been reset, not carry over step 1 output
+        assert "step1 output" not in str(state["_print_outputs"])
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Summary

Fixes #1998

When a `SyntaxError` occurs during code parsing in `evaluate_python_code`, the `InterpreterError` is raised *before* `state["_print_outputs"]` is reset with a fresh `PrintContainer`. This causes print outputs from the previous execution step to leak into the error step's reported output.

## Root Cause

```python
# BEFORE (buggy order):
try:
    expression = ast.parse(code)     # ← raises SyntaxError
except SyntaxError as e:
    raise InterpreterError(...)      # ← _print_outputs never reset

state["_print_outputs"] = PrintContainer()  # ← never reached
```

## Fix

Move state initialization (including `PrintContainer` reset) before the `ast.parse()` call:

```python
# AFTER (fixed order):
state["_print_outputs"] = PrintContainer()  # ← always reset first

try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)
```

## Testing

- Added `test_syntax_error_clears_previous_print_outputs` — verifies that print outputs from step N do not appear in step N+1 when step N+1 has a `SyntaxError`
- 388/388 tests pass (2 consecutive clean runs; 2 pre-existing failures from missing scipy/sklearn are unrelated)