### PR TITLE
fix(bedrock): use .get() for tool_calls to prevent KeyError on text-only responses

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],


### PR DESCRIPTION
## Summary

Fixes #1941

`AmazonBedrockModel.generate()` accesses `response["output"]["message"]["tool_calls"]` with bracket notation, which raises a `KeyError` when the Bedrock model returns a text-only response without any tool calls.

## Fix

Use `.get("tool_calls")` instead of `["tool_calls"]` so that `None` is returned when the key is absent. This matches the `ChatMessage.tool_calls` field default of `None`.

```diff
- tool_calls=response["output"]["message"]["tool_calls"],
+ tool_calls=response["output"]["message"].get("tool_calls"),
```

## Testing

All 74 applicable model tests pass (2 consecutive clean runs; pre-existing failures from missing `boto3`/`mlx-lm`/`transformers` modules are unrelated).