### PR TITLE
fix: handle consecutive system messages with string content in get_clean_message_list

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,16 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            # Normalize string content to list format for consistent merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             if flatten_messages_as_text:
+                # In flatten mode, the stored content is a plain string
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:
+                prev_content = output_message_list[-1]["content"]
+                if isinstance(prev_content, str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": prev_content}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
@@ -385,7 +391,10 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                if isinstance(message.content, str):
+                    content = message.content
+                else:
+                    content = message.content[0]["text"]
             else:
                 content = message.content
             output_message_list.append(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,29 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_consecutive_system_string_content():
+    """Regression test: consecutive system messages with plain string content
+    must be merged without crashing.
+    See https://github.com/huggingface/smolagents/issues/1972"""
+    messages = [
+        {"role": "system", "content": "Start with FOO"},
+        {"role": "system", "content": "End with BAR"},
+        {"role": "user", "content": "Just say ."},
+    ]
+    # flatten_messages_as_text=True path
+    result = get_clean_message_list(messages, flatten_messages_as_text=True)
+    assert len(result) == 2
+    assert "FOO" in result[0]["content"] and "BAR" in result[0]["content"]
+    assert result[1]["content"] == "Just say ."
+
+    # flatten_messages_as_text=False path
+    result2 = get_clean_message_list(messages, flatten_messages_as_text=False)
+    assert len(result2) == 2
+    merged = result2[0]["content"]
+    assert isinstance(merged, list)
+    assert "FOO" in merged[0]["text"] and "BAR" in merged[0]["text"]
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
## Problem

`get_clean_message_list` crashes with `AssertionError` when the message list contains multiple consecutive system messages with plain string content. System messages commonly carry a plain string (e.g. `{"role": "system", "content": "Be helpful"}`), but the merge path unconditionally asserted `isinstance(message.content, list)`.

This also affected the `flatten_messages_as_text=True` path, where `message.content[0]["text"]` fails with `TypeError` when content is a string.

Fixes #1972

## Solution

1. In the merge path: normalise string content to structured list form (`[{"type": "text", "text": ...}]`) before merging, only in non-flatten mode.
2. In the flatten merge path: extract text directly from string content.
3. In the initial output path: handle string content in `flatten_messages_as_text` mode.

## Testing

```python
msgs = [
    {"role": "system", "content": "Start with FOO"},
    {"role": "system", "content": "End with BAR"},
    {"role": "user", "content": "Say dot"},
]
# Both modes produce 2 messages with merged system content
get_clean_message_list(msgs)  # non-flatten ✅
get_clean_message_list(msgs, flatten_messages_as_text=True)  # flatten ✅
```

- All 7 `clean_message` tests pass — 2 consecutive clean runs
- No regressions in existing model tests (pre-existing failures are missing optional deps)