### PR TITLE
fix: reset PrintContainer before ast.parse to prevent output leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1620,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1213,6 +1213,20 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_resets_print_container(self):
+        """Print outputs from a previous step must not leak when the next step has a SyntaxError."""
+        state: dict = {}
+        # Step 1: produces print output
+        evaluate_python_code("print('step1')", BASE_PYTHON_TOOLS, state=state)
+        assert "step1" in str(state["_print_outputs"])
+
+        # Step 2: has a SyntaxError — PrintContainer should still be reset
+        with pytest.raises(InterpreterError, match="SyntaxError"):
+            evaluate_python_code("def bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        # The print container must be fresh (no step1 content)
+        assert str(state["_print_outputs"]) == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Problem

When a `SyntaxError` occurs during code parsing in `evaluate_python_code`, print outputs from the **previous** step leak into the current step's execution logs.

This happens because `ast.parse(code)` is called **before** state initialization (including `state['_print_outputs'] = PrintContainer()`). When parsing fails, the `InterpreterError` is raised immediately, and the `PrintContainer` from the previous step is never reset.

### Reproduction

As described in #1998:
1. Step 1: `print('step1 text')` → logs show `step1 text`
2. Step 2: code with `SyntaxError` → logs incorrectly show `step1 text` again

## Fix

Move state initialization (`PrintContainer` reset, `_operations_count` reset, `static_tools` copy) **before** `ast.parse()` so the container is always fresh regardless of whether parsing succeeds.

## Test

Added `test_syntax_error_resets_print_container` that verifies print outputs from a previous step do not leak when the next step has a SyntaxError.

## Checklist

- [x] 388/388 executor tests pass (2 consecutive clean runs)
- [x] Only pre-existing failures excluded (missing scipy/sklearn modules)

Fixes #1998