### PR TITLE
fix: handle None content in parse_code_blobs and extract_code_from_text

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -171,8 +171,10 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
         )
 
 
-def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str | None:
+def extract_code_from_text(text: str | None, code_block_tags: tuple[str, str]) -> str | None:
     """Extract code from the LLM's output."""
+    if text is None:
+        return None
     pattern = rf"{code_block_tags[0]}(.*?){code_block_tags[1]}"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
@@ -180,7 +182,7 @@ def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str |
     return None
 
 
-def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
+def parse_code_blobs(text: str | None, code_block_tags: tuple[str, str]) -> str:
     """Extract code blocs from the LLM's output.
 
     If a valid code block is passed, it returns it directly.
@@ -194,6 +196,11 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     Raises:
         ValueError: If no valid code block is found in the text.
     """
+    if text is None:
+        raise ValueError(
+            "The model output is empty (content=None). The model may have been cut off by stop sequences "
+            "or produced no text. Please retry or adjust your model configuration."
+        )
     matches = extract_code_from_text(text, code_block_tags)
     if not matches:  # Fallback to markdown pattern
         matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,6 +142,17 @@ import numpy as np
         result = parse_code_blobs(test_input, ("<code>", "</code>"))
         assert result == "Foo\n\ncode_a\n\ncode_b"
 
+    def test_parse_code_blobs_none_content(self):
+        """parse_code_blobs should raise a clear error when text is None (empty model output)."""
+        with pytest.raises(ValueError, match="model output is empty"):
+            parse_code_blobs(None, ("<code>", "</code>"))
+
+    def test_extract_code_from_text_none_content(self):
+        """extract_code_from_text should return None when text is None."""
+        from smolagents.utils import extract_code_from_text
+
+        assert extract_code_from_text(None, ("<code>", "</code>")) is None
+
 
 @pytest.fixture(scope="function")
 def ipython_shell():


### PR DESCRIPTION
## Problem

When a model returns `content=None` (e.g., due to stop sequences truncating the response), `parse_code_blobs` crashes with:

```
expected string or bytes-like object, got 'NoneType'
```

This causes `CodeAgent` to output empty steps in a loop, consuming all max_steps without doing useful work.

### Reproduction

As described in #1896:
1. Use `CodeAgent` with vLLM OpenAI-compatible server
2. Send a simple prompt like `'hi'`
3. The model returns `content=None` after stop sequences truncate the output
4. All subsequent steps fail with the same cryptic regex error

## Fix

- **`extract_code_from_text`**: return `None` immediately when `text` is `None`
- **`parse_code_blobs`**: raise a clear `ValueError` explaining the model output is empty

The error message now reads:
> The model output is empty (content=None). The model may have been cut off by stop sequences or produced no text.

## Tests

Added:
- `test_parse_code_blobs_none_content`: verifies clear error message
- `test_extract_code_from_text_none_content`: verifies None → None

All tests pass (2 consecutive clean runs).

Fixes #1896