### PR TITLE
fix: clear print outputs before syntax check to prevent stale output leaking

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,10 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    state["_print_outputs"] = PrintContainer()
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1614,11 +1618,8 @@ def evaluate_python_code(
             f"{' ' * (e.offset or 0)}^"
         )
 
-    if state is None:
-        state = {}
     static_tools = static_tools.copy() if static_tools is not None else {}
     custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
     state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:


### PR DESCRIPTION
## Summary

Fixes #1998

When a `SyntaxError` occurs in step N, the execution logs incorrectly show print outputs from step N-1.

## Root Cause

In `evaluate_python_code()`, the `state['_print_outputs']` is reset **after** the `ast.parse()` call (line 1621). When `ast.parse()` raises a `SyntaxError`, the function raises `InterpreterError` before reaching the reset line. The `PrintContainer` from the previous step persists in `state`, so the caller (`LocalPythonExecutor.__call__`) reads stale output at line 1751.

## Fix

Move `state` initialization (including `PrintContainer` reset) **before** the `ast.parse()` call. This ensures that print outputs are always cleared at the start of each step evaluation, regardless of whether the code parses successfully.

### Before
```python
try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)  # state['_print_outputs'] still has previous step's output

if state is None:
    state = {}
state['_print_outputs'] = PrintContainer()  # never reached on SyntaxError
```

### After
```python
if state is None:
    state = {}
state['_print_outputs'] = PrintContainer()  # always reset before parsing

try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)  # state['_print_outputs'] is now clean
```

## Testing

- All 387 executor tests pass (2 consecutive clean runs)
- Pre-existing scipy/sklearn import failures are unrelated