### PR TITLE
fix: handle string content when merging consecutive same-role messages

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,43 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_consecutive_string_content():
+    """Consecutive same-role messages with string content should be merged (not crash)."""
+    messages = [
+        ChatMessage(role=MessageRole.SYSTEM, content="Start with FOO"),
+        ChatMessage(role=MessageRole.SYSTEM, content="End with BAR"),
+        ChatMessage(role=MessageRole.USER, content="Just say '.'"),
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert result[0]["content"] == "Start with FOO\nEnd with BAR"
+    assert result[1]["role"] == "user"
+    assert result[1]["content"] == "Just say '.'"
+
+
+def test_get_clean_message_list_string_content_flatten():
+    """String content should work in flatten mode too."""
+    messages = [
+        ChatMessage(role=MessageRole.SYSTEM, content="First system"),
+        ChatMessage(role=MessageRole.SYSTEM, content="Second system"),
+    ]
+    result = get_clean_message_list(messages, flatten_messages_as_text=True)
+    assert len(result) == 1
+    assert result[0]["content"] == "First system\nSecond system"
+
+
+def test_get_clean_message_list_string_into_list_content():
+    """String content merged into a previous list-content message."""
+    messages = [
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello!"}]),
+        ChatMessage(role=MessageRole.USER, content="How are you?"),
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 1
+    assert result[0]["content"][-1]["text"] == "Hello!\nHow are you?"
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
## Problem

`get_clean_message_list()` crashes with `AssertionError: Error: wrong content:...` when two consecutive messages share the same role and carry plain-string content (e.g. multiple system messages).

```python
messages = [
    {"role": "system", "content": "Start with FOO"},
    {"role": "system", "content": "End with BAR"},
    {"role": "user", "content": "Say ."},
]
model(messages)  # AssertionError
```

## Root Cause

Line 376 asserts `isinstance(message.content, list)` but `ChatMessage.content` is typed as `str | list[dict] | None`. Plain system messages typically have string content.

## Fix

Handle all four content-type merge combinations:
- **str → str**: concatenate with newline
- **str → list**: merge text into last text element (or append)
- **list → str**: promote previous string to list, then merge elements
- **list → list**: existing behavior (unchanged)

Also fix the first-message path in `flatten_messages_as_text` mode for string content.

## Tests

Added 3 new tests covering:
- Consecutive string-content system messages
- String content with `flatten_messages_as_text=True`
- String content merged into a previous list-content message

All 10 `get_clean_message_list` tests pass.

Fixes #1972