### PR TITLE
fix: handle consecutive messages with string content in get_clean_message_list

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,21 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_consecutive_string_content():
+    """Test that consecutive messages with string content are merged without assertion error."""
+    messages = [
+        {"role": "system", "content": "When you say anything Start with 'FOO'"},
+        {"role": "system", "content": "When you say anything End with 'BAR'"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert result[0]["content"] == "When you say anything Start with 'FOO'\nWhen you say anything End with 'BAR'"
+    assert result[1]["role"] == "user"
+    assert result[1]["content"] == "Just say '.'"
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
## Summary

`LiteLLMModel` (and other model backends) crashes with an `AssertionError` when the input message list contains multiple consecutive system messages with string content.

## Root Cause

`get_clean_message_list()` assumes `message.content` is always a `list` when merging consecutive same-role messages (line 376):

```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

But when messages are provided as dicts with string content (e.g. `{"role": "system", "content": "text"}`), `ChatMessage.from_dict()` preserves the string type, causing the assertion to fail.

## Fix

Handle string `content` by concatenating with newline, consistent with the existing flattened-text merge behavior. The assertion is removed and replaced with type-aware merging logic.

## Test

Added `test_get_clean_message_list_consecutive_string_content` that reproduces the exact scenario from #1972.

```
8 passed in 0.04s
```

Fixes #1972