### PR TITLE
fix: reset PrintContainer before ast.parse to prevent output leaking across steps

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,15 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    # Reset print outputs and operations counter BEFORE parsing so that
+    # a SyntaxError doesn't leak print outputs from the previous step.
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1622,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]


### PR DESCRIPTION
## Summary

Fixes #1998

When a `SyntaxError` occurs during `ast.parse()`, the `PrintContainer` from the previous execution step is not reset, causing stale print outputs to appear in subsequent steps' execution logs.

## Root Cause

In `evaluate_python_code()`, state initialization (including `_print_outputs = PrintContainer()`) happened **after** `ast.parse()`. When `ast.parse()` raises a `SyntaxError`, the function exits via `InterpreterError` before resetting `_print_outputs`, so the next step's error report includes the previous step's print output.

## Fix

Move state initialization (`_print_outputs` and `_operations_count` reset) **before** the `ast.parse()` call, ensuring the print container is always cleared at the start of each execution, regardless of whether parsing succeeds.

## Test

Added `test_syntax_error_does_not_leak_previous_print_output` that:
1. Executes code with `print()` in step 1
2. Triggers a `SyntaxError` in step 2
3. Verifies `_print_outputs` is empty after the error (not containing step 1's output)