### PR TITLE
fix: reset print outputs before parsing to prevent leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1605,6 +1605,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1613,13 +1620,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1213,6 +1213,20 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_resets_print_outputs(self):
+        """Test that print outputs from a previous step don't leak into the next step when a SyntaxError occurs."""
+        state = {}
+        # Step 1: valid code with a print statement
+        evaluate_python_code('print("hello from step 1")', static_tools={"print": print}, state=state)
+        assert state["_print_outputs"].value == "hello from step 1\n"
+
+        # Step 2: code with a SyntaxError
+        with pytest.raises(InterpreterError):
+            evaluate_python_code("a = ;", static_tools={"print": print}, state=state)
+
+        # After the SyntaxError, _print_outputs should be reset (empty), not leaking step 1's output
+        assert state["_print_outputs"].value == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Summary

Fixes #1998

When a `SyntaxError` occurs during code parsing, print outputs from the previous execution step incorrectly leak into the current step's logs.

## Root Cause

In `evaluate_python_code()`, state initialization (including `PrintContainer` creation) happens **after** `ast.parse()`. When parsing fails with a `SyntaxError`, the `InterpreterError` is raised before `state["_print_outputs"]` is reset, so the old `PrintContainer` from the previous step persists.

```python
# Before (state init AFTER parsing):
try:
    expression = ast.parse(code)      # ← SyntaxError raised here
except SyntaxError as e:
    raise InterpreterError(...)        # ← Raised before reset!

state["_print_outputs"] = PrintContainer()  # ← Never reached on SyntaxError
```

## Fix

Move state initialization **before** `ast.parse()` so `_print_outputs` is always reset at the start of each call, regardless of whether parsing succeeds.

```python
# After (state init BEFORE parsing):
state["_print_outputs"] = PrintContainer()  # ← Always reset first

try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)
```

## Testing

- Added regression test `test_syntax_error_resets_print_outputs` that verifies print outputs don't leak across steps when `SyntaxError` occurs
- All 390 tests pass (2 skipped)