### PR TITLE
fix: use dict format for tool call arguments in few-shot examples

### DIFF
--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -46,7 +46,7 @@ system_prompt: |-
   Action:
   {
     "name": "final_answer",
-    "arguments": "image.png"
+    "arguments": {"answer": "image.png"}
   }
 
   ---
@@ -62,7 +62,7 @@ system_prompt: |-
   Action:
   {
     "name": "final_answer",
-    "arguments": "1302.678"
+    "arguments": {"answer": "1302.678"}
   }
 
   ---
@@ -71,7 +71,7 @@ system_prompt: |-
   Action:
   {
       "name": "web_search",
-      "arguments": "Population Guangzhou"
+      "arguments": {"query": "Population Guangzhou"}
   }
   Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
 
@@ -79,17 +79,17 @@ system_prompt: |-
   Action:
   {
       "name": "web_search",
-      "arguments": "Population Shanghai"
+      "arguments": {"query": "Population Shanghai"}
   }
   Observation: '26 million (2019)'
 
   Action:
   {
     "name": "final_answer",
-    "arguments": "Shanghai"
+    "arguments": {"answer": "Shanghai"}
   }
 
-  Above example were using notional tools that might not exist for you. You only have access to these tools:
+  Above examples were using notional tools that might not exist for you. You only have access to these tools:
   {%- for tool in tools.values() %}
   - {{ tool.to_tool_calling_prompt() }}
   {%- endfor %}


### PR DESCRIPTION
## Summary

The `TOOL_CALLING_SYSTEM_PROMPT` in `toolcalling_agent.yaml` contains contradictory format examples for tool call arguments:

- The **instruction block** (line 24) teaches dict format: `"arguments": {"answer": "insert your final answer here"}`
- The **worked examples** (lines 49, 65, 74, 82, 89) teach bare-string format: `"arguments": "Shanghai"`

This gives the LLM conflicting signals about expected output format within the same system prompt. The dict format is correct — it matches the declared tool input schemas (`FinalAnswerTool.inputs` declares `{"answer": {...}}`, `DuckDuckGoSearchTool.inputs` declares `{"query": {...}}`).

## Changes

Update all 5 bare-string `"arguments"` values to dict format matching each tool's declared input schema:

| Tool | Before | After |
|------|--------|-------|
| `final_answer` | `"image.png"` | `{"answer": "image.png"}` |
| `final_answer` | `"1302.678"` | `{"answer": "1302.678"}` |
| `final_answer` | `"Shanghai"` | `{"answer": "Shanghai"}` |
| `web_search` | `"Population Guangzhou"` | `{"query": "Population Guangzhou"}` |
| `web_search` | `"Population Shanghai"` | `{"query": "Population Shanghai"}` |

Also fixes a minor grammar typo: "Above example were" → "Above examples were"

## Why this is safe

The bare-string format currently works because of an undocumented single-input fallback in `execute_tool_call` (agents.py:1487-1488) and `validate_tool_arguments` (tools.py:1409-1412). That fallback remains in place, so models that still produce bare strings won't break. This change improves the few-shot signal so models are more likely to produce the canonical dict format from the start.

## Testing

281 agent/model/tool tests pass. No test changes needed — existing tests cover both dict and string argument paths.

Addresses #304