### PR TITLE
fix: reset _print_outputs before ast.parse to prevent SyntaxError print leak

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1378,6 +1378,20 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_does_not_leak_previous_print_outputs(self):
+        """SyntaxError should reset _print_outputs so previous step output doesn't leak."""
+        state = {}
+        # Step 1: produce print output
+        evaluate_python_code("print('step1 output')", BASE_PYTHON_TOOLS, state=state)
+        assert "step1 output" in str(state["_print_outputs"])
+
+        # Step 2: SyntaxError — _print_outputs must be reset before the error is raised
+        with pytest.raises(InterpreterError, match="SyntaxError"):
+            evaluate_python_code("def bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        # The print outputs should be empty, not carrying over from step 1
+        assert str(state["_print_outputs"]).strip() == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Summary

Fixes #1998

When a `SyntaxError` occurs during code parsing in `evaluate_python_code`, the `_print_outputs` container was not reset because it was initialized **after** `ast.parse()`. This caused print outputs from the previous step to leak into the error step's execution logs.

## Root Cause

```python
# Before (buggy):
try:
    expression = ast.parse(code)      # ← SyntaxError here
except SyntaxError as e:
    raise InterpreterError(...)       # ← _print_outputs never reset

state["_print_outputs"] = PrintContainer()  # ← never reached on SyntaxError
```

## Fix

Move state initialization (including `_print_outputs = PrintContainer()`) **before** the `ast.parse()` call so that a fresh `PrintContainer` is always created regardless of whether parsing succeeds.

```python
# After (fixed):
state["_print_outputs"] = PrintContainer()  # ← always reset first
state["_operations_count"] = {"counter": 0}

try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)
```

## Tests

Added `test_syntax_error_does_not_leak_previous_print_outputs` regression test:
1. Step 1 prints output → `_print_outputs` contains it
2. Step 2 has SyntaxError → `_print_outputs` must be empty (not carry over from step 1)

```bash
pytest tests/test_local_python_executor.py -k 'test_syntax_error' -v
# 2 passed
```