### PR TITLE
fix: align few-shot observation examples with runtime format

### DIFF
--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -18,7 +18,11 @@ system_prompt: |-
   answer = document_qa(document=document, question="Who is the oldest person mentioned?")
   print(answer)
   {{code_block_closing_tag}}
-  Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
+  Observation:
+  Execution logs:
+  The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland.
+  Last output from code snippet:
+  None
 
   Thought: I will now generate an image showcasing the oldest person.
   {{code_block_opening_tag}}
@@ -60,7 +64,10 @@ system_prompt: |-
   print(pages)
   {{code_block_closing_tag}}
   Observation:
+  Execution logs:
   No result found for query "1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein".
+  Last output from code snippet:
+  None
 
   Thought: The query was maybe too restrictive and did not find any results. Let's try again with a broader query.
   {{code_block_opening_tag}}
@@ -68,12 +75,15 @@ system_prompt: |-
   print(pages)
   {{code_block_closing_tag}}
   Observation:
+  Execution logs:
   Found 6 pages:
   [Stanislaus Ulam 1979 interview](https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/)
 
   [Ulam discusses Manhattan Project](https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/)
 
   (truncated)
+  Last output from code snippet:
+  None
 
   Thought: I will read the first 2 pages to know more.
   {{code_block_opening_tag}}
@@ -83,10 +93,13 @@ system_prompt: |-
       print("\n" + "="*80 + "\n")  # Print separator between pages
   {{code_block_closing_tag}}
   Observation:
+  Execution logs:
   Manhattan Project Locations:
   Los Alamos, NM
   Stanislaus Ulam was a Polish-American mathematician. He worked on the Manhattan Project at Los Alamos and later helped design the hydrogen bomb. In this interview, he discusses his work at
   (truncated)
+  Last output from code snippet:
+  None
 
   Thought: I now have the final answer: from the webpages visited, Stanislaus Ulam says of Einstein: "He learned too much mathematics and sort of diminished, it seems to me personally, it seems to me his purely physics creativity." Let's answer in one word.
   {{code_block_opening_tag}}
@@ -102,8 +115,11 @@ system_prompt: |-
       print(f"Population {city}:", web_search(f"{city} population"))
   {{code_block_closing_tag}}
   Observation:
+  Execution logs:
   Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
   Population Shanghai: '26 million (2019)'
+  Last output from code snippet:
+  None
 
   Thought: Now I know that Shanghai has the highest population.
   {{code_block_opening_tag}}
@@ -121,7 +137,11 @@ system_prompt: |-
   print("Pope age as per google search:", pope_age_search)
   {{code_block_closing_tag}}
   Observation:
-  Pope age: "The pope Francis is currently 88 years old."
+  Execution logs:
+  Pope age as per wikipedia: "The pope Francis is currently 88 years old."
+  Pope age as per google search: "The pope Francis is currently 88 years old."
+  Last output from code snippet:
+  None
 
   Thought: I know that the pope is 88 years old. Let's compute the result using Python code.
   {{code_block_opening_tag}}

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -20,7 +20,11 @@ system_prompt: |-
   Task: "Generate an image of the oldest person in this document."
 
   {"thought": "I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.", "code": "answer = document_qa(document=document, question=\"Who is the oldest person mentioned?\")\nprint(answer)\n"}
-  Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
+  Observation:
+  Execution logs:
+  The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland.
+  Last output from code snippet:
+  None
 
   {"thought": "I will now generate an image showcasing the oldest person.", "code": "image = image_generator(\"A portrait of John Doe, a 55-year-old man living in Canada.\")\nfinal_answer(image)\n"}
   ---
@@ -35,24 +39,33 @@ system_prompt: |-
 
   {"thought": "I need to find and read the 1979 interview of Stanislaus Ulam with Martin Sherwin.", "code": "pages = web_search(query=\"1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein\")\nprint(pages)\n"}
   Observation:
+  Execution logs:
   No result found for query "1979 interview Stanislaus Ulam Martin Sherwin physicists Einstein".
+  Last output from code snippet:
+  None
 
   {"thought": "The query was maybe too restrictive and did not find any results. Let's try again with a broader query.", "code": "pages = web_search(query=\"1979 interview Stanislaus Ulam\")\nprint(pages)\n"}
   Observation:
+  Execution logs:
   Found 6 pages:
   [Stanislaus Ulam 1979 interview](https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/)
 
   [Ulam discusses Manhattan Project](https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/)
 
   (truncated)
+  Last output from code snippet:
+  None
 
   {"thought": "I will read the first 2 pages to know more.", "code": "for url in [\"https://ahf.nuclearmuseum.org/voices/oral-histories/stanislaus-ulams-interview-1979/\", \"https://ahf.nuclearmuseum.org/manhattan-project/ulam-manhattan-project/\"]:\n      whole_page = visit_webpage(url)\n      print(whole_page)\n      print(\"\n\" + \"=\"*80 + \"\n\")  # Print separator between pages"}
 
   Observation:
+  Execution logs:
   Manhattan Project Locations:
   Los Alamos, NM
   Stanislaus Ulam was a Polish-American mathematician. He worked on the Manhattan Project at Los Alamos and later helped design the hydrogen bomb. In this interview, he discusses his work at
   (truncated)
+  Last output from code snippet:
+  None
 
   {"thought": "I now have the final answer: from the webpages visited, Stanislaus Ulam says of Einstein: \"He learned too much mathematics and sort of diminished, it seems to me personally, it seems to me his purely physics creativity.\" Let's answer in one word.", "code": "final_answer(\"diminished\")"}
 
@@ -61,8 +74,11 @@ system_prompt: |-
 
   {"thought": "I need to get the populations for both cities and compare them: I will use the tool `web_search` to get the population of both cities.", "code": "for city in [\"Guangzhou\", \"Shanghai\"]:\n      print(f\"Population {city}:\", web_search(f\"{city} population\")"}
   Observation:
+  Execution logs:
   Population Guangzhou: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
   Population Shanghai: '26 million (2019)'
+  Last output from code snippet:
+  None
 
   {"thought": "Now I know that Shanghai has the highest population.", "code": "final_answer(\"Shanghai\")"}
 
@@ -71,7 +87,11 @@ system_prompt: |-
 
   {"thought": "I will use the tool `wikipedia_search` to get the age of the pope, and confirm that with a web search.", "code": "pope_age_wiki = wikipedia_search(query=\"current pope age\")\nprint(\"Pope age as per wikipedia:\", pope_age_wiki)\npope_age_search = web_search(query=\"current pope age\")\nprint(\"Pope age as per google search:\", pope_age_search)"}
   Observation:
-  Pope age: "The pope Francis is currently 88 years old."
+  Execution logs:
+  Pope age as per wikipedia: "The pope Francis is currently 88 years old."
+  Pope age as per google search: "The pope Francis is currently 88 years old."
+  Last output from code snippet:
+  None
 
   {"thought": "I know that the pope is 88 years old. Let's compute the result using python code.", "code": "pope_current_age = 88 ** 0.36\nfinal_answer(pope_current_age)"}
 


### PR DESCRIPTION
## Summary

Updates few-shot observation examples in `code_agent.yaml` and `structured_code_agent.yaml` to match the actual runtime observation format produced by the agent.

The system prompt's few-shot examples currently show flat observations:
```
Observation: "The oldest person is John Doe, a 55 year old lumberjack."
```

But the runtime (constructed in `agents.py` and `memory.py`) produces structured observations:
```
Observation:
Execution logs:
The oldest person is John Doe, a 55 year old lumberjack.
Last output from code snippet:
None
```

This format mismatch means the LLM is taught one observation pattern via examples but sees a different one at runtime, undermining format grounding.

## Changes

- **`prompts/code_agent.yaml`** — Update ~6 observation examples to use `Execution logs:` / `Last output from code snippet:` structure
- **`prompts/structured_code_agent.yaml`** — Same updates for the structured agent variant

## Notes

- Pure YAML edits — no Python code changes
- Fix direction is examples → runtime (align teaching to reality), not the reverse, to avoid breaking downstream behavior
- The `ToolCallingAgent` uses a simpler `str(result)` format for observations, which is closer to the current flat examples. This fix targets `CodeAgent` and `StructuredCodeAgent` specifically, which is where the format divergence exists.

## Testing

All existing tests pass identically on the fix branch and main.

Fixes #830