### PR TITLE
Remove allow_origin from Docker and Modal executors

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -594,7 +594,7 @@ class DockerExecutor(RemotePythonExecutor):
             RUN pip install jupyter_kernel_gateway jupyter_client ipykernel
 
             EXPOSE 8888
-            CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip='0.0.0.0'", "--KernelGatewayApp.port=8888", "--KernelGatewayApp.allow_origin='*'"]
+            CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0", "--KernelGatewayApp.port=8888"]
             """
         )
 
@@ -778,9 +778,8 @@ class ModalExecutor(RemotePythonExecutor):
         entrypoint = [
             "jupyter",
             "kernelgateway",
-            "--KernelGatewayApp.ip='0.0.0.0'",
+            "--KernelGatewayApp.ip=0.0.0.0",
             f"--KernelGatewayApp.port={port}",
-            "--KernelGatewayApp.allow_origin='*'",
         ]
 
         self.logger.log("Starting Modal sandbox", level=LogLevel.INFO)

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -460,9 +460,8 @@ class TestModalExecutorUnit:
         assert create_call.args == (
             "jupyter",
             "kernelgateway",
-            "--KernelGatewayApp.ip='0.0.0.0'",
+            "--KernelGatewayApp.ip=0.0.0.0",
             f"--KernelGatewayApp.port={port}",
-            "--KernelGatewayApp.allow_origin='*'",
         )
         assert create_call.kwargs["timeout"] == 100
         assert create_call.kwargs["cpu"] == 2


### PR DESCRIPTION
Remove allow_origin from Docker and Modal executors.

Also fixed single-quotes issue to avoid passing a literal string to the process in exec/JSON form.