### PR TITLE
Handle no-op streaming chunks in API model adapters

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1356,8 +1356,9 @@ class LiteLLMModel(ApiModel):
                         else None,
                     )
                 else:
-                    if not getattr(choice, "finish_reason", None):
-                        raise ValueError(f"No content or tool calls in event: {event}")
+                    # Some providers can emit no-op chunks (no delta, no finish_reason).
+                    # These chunks are harmless and should not abort the whole stream.
+                    continue
 
 
 class LiteLLMRouterModel(LiteLLMModel):
@@ -1639,8 +1640,9 @@ class InferenceClientModel(ApiModel):
                         else None,
                     )
                 else:
-                    if not getattr(choice, "finish_reason", None):
-                        raise ValueError(f"No content or tool calls in event: {event}")
+                    # Some providers can emit no-op chunks (no delta, no finish_reason).
+                    # These chunks are harmless and should not abort the whole stream.
+                    continue
 
 
 class OpenAIModel(ApiModel):
@@ -1755,8 +1757,9 @@ class OpenAIModel(ApiModel):
                         else None,
                     )
                 else:
-                    if not getattr(choice, "finish_reason", None):
-                        raise ValueError(f"No content or tool calls in event: {event}")
+                    # Some providers can emit no-op chunks (no delta, no finish_reason).
+                    # These chunks are harmless and should not abort the whole stream.
+                    continue
 
     def generate(
         self,


### PR DESCRIPTION
### PR Description

This PR improves streaming robustness in API model adapters by handling no-op stream events gracefully.

A **no-op stream event** is a streaming chunk that carries no `delta` content/tool-call updates and no `finish_reason`. Some providers may emit these harmless intermediate events. Previously, these chunks could raise an error and interrupt streaming.

### What changed
- Updated streaming handlers in:
  - `LiteLLMModel.generate_stream`
  - `InferenceClientModel.generate_stream`
  - `OpenAIModel.generate_stream`
- No-op chunks are now ignored (`continue`) instead of raising `ValueError`.

### Why
This makes streaming more reliable across provider-specific event shapes and avoids unnecessary runtime failures from benign empty chunks.

### Tests
- Added `test_generate_stream_ignores_noop_events` in [tests/test_models.py](C:/Users/elmar/Desktop/OSS/smolagents/tests/test_models.py).
- Test covers all three adapters above and verifies:
  - no-op events do not crash streaming
  - later valid chunks are still emitted correctly.