### PR TITLE
feat(memory): add automatic memory consolidation via max_memory_steps (fixes #901)

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -289,6 +289,12 @@ class MultiStepAgent(ABC):
             - Take the final answer, the agent's memory, and the agent itself as arguments.
             - Return a boolean indicating whether the final answer is valid.
         return_full_result (`bool`, default `False`): Whether to return the full [`RunResult`] object or just the final answer output from the agent run.
+        max_memory_steps (`int` or `None`, default `None`):
+            Maximum number of interaction steps to keep in full detail in the
+            agent's memory.  When the number of ``ActionStep`` and
+            ``PlanningStep`` entries exceeds this value, older steps are
+            automatically consolidated into a summary using the agent's model.
+            ``None`` (the default) disables automatic memory consolidation.
     """
 
     def __init__(
@@ -309,6 +315,7 @@ class MultiStepAgent(ABC):
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
         logger: AgentLogger | None = None,
+        max_memory_steps: int | None = None,
     ):
         self.agent_name = self.__class__.__name__
         self.model = model
@@ -340,7 +347,7 @@ class MultiStepAgent(ABC):
         self._validate_tools_and_managed_agents(tools, managed_agents)
 
         self.task: str | None = None
-        self.memory = AgentMemory(self.system_prompt)
+        self.memory = AgentMemory(self.system_prompt, max_memory_steps=max_memory_steps)
 
         if logger is None:
             self.logger = AgentLogger(level=verbosity_level)
@@ -545,6 +552,13 @@ You have been provided with these additional arguments, that you can access dire
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
+
+            # Consolidate memory if it exceeds the configured threshold
+            if self.memory.consolidate(self.model):
+                self.logger.log(
+                    Text("Memory consolidated: older steps summarised.", style="dim"),
+                    level=LogLevel.DEBUG,
+                )
 
             # Run a planning step if scheduled
             if self.planning_interval is not None and (

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from smolagents.monitoring import AgentLogger
 
 
-__all__ = ["AgentMemory"]
+__all__ = ["AgentMemory", "MemorySummaryStep"]
 
 
 logger = getLogger(__name__)
@@ -207,6 +207,34 @@ class SystemPromptStep(MemoryStep):
 
 
 @dataclass
+class MemorySummaryStep(MemoryStep):
+    """A step that holds a consolidated summary of earlier memory steps.
+
+    When ``AgentMemory.consolidate`` is called the oldest interaction steps
+    are replaced by a single ``MemorySummaryStep`` so that the context sent
+    to the model stays bounded.
+
+    Args:
+        summary: The LLM-generated summary text.
+    """
+
+    summary: str
+
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
+        return [
+            ChatMessage(
+                role=MessageRole.USER,
+                content=[
+                    {
+                        "type": "text",
+                        "text": f"[Consolidated summary of earlier steps]\n{self.summary}",
+                    }
+                ],
+            )
+        ]
+
+
+@dataclass
 class FinalAnswerStep(MemoryStep):
     output: Any
 
@@ -219,19 +247,152 @@ class AgentMemory:
 
     Args:
         system_prompt (`str`): System prompt for the agent, which sets the context and instructions for the agent's behavior.
+        max_memory_steps (`int` or `None`, default `None`):
+            Maximum number of interaction steps (``ActionStep`` and ``PlanningStep``) to
+            keep in full detail.  When the number of such steps exceeds this
+            value, older steps are summarised into a single
+            ``MemorySummaryStep`` via :meth:`consolidate`.
+            ``None`` disables automatic consolidation.
 
     **Attributes**:
         - **system_prompt** (`SystemPromptStep`) -- System prompt step for the agent.
-        - **steps** (`list[TaskStep | ActionStep | PlanningStep]`) -- List of steps taken by the agent, which can include tasks, actions, and planning steps.
+        - **steps** (`list[TaskStep | ActionStep | PlanningStep | MemorySummaryStep]`) -- List of steps taken by the agent, which can include tasks, actions, planning steps, and memory summary steps.
     """
 
-    def __init__(self, system_prompt: str):
+    def __init__(self, system_prompt: str, max_memory_steps: int | None = None):
         self.system_prompt: SystemPromptStep = SystemPromptStep(system_prompt=system_prompt)
-        self.steps: list[TaskStep | ActionStep | PlanningStep] = []
+        self.steps: list[TaskStep | ActionStep | PlanningStep | MemorySummaryStep] = []
+        self.max_memory_steps = max_memory_steps
 
     def reset(self):
         """Reset the agent's memory, clearing all steps and keeping the system prompt."""
         self.steps = []
+
+    def consolidate(self, model) -> bool:
+        """Summarise the oldest interaction steps to keep memory bounded.
+
+        When the number of ``ActionStep`` / ``PlanningStep`` entries exceeds
+        ``max_memory_steps``, older steps are summarised by *model* into a
+        single ``MemorySummaryStep``.  The ``TaskStep`` at the beginning of
+        the conversation is preserved.  Any existing ``MemorySummaryStep``
+        entries are folded into the new summary to prevent unbounded growth.
+
+        Args:
+            model: A model instance with a ``generate`` method (the same model
+                used by the agent).
+
+        Returns:
+            ``True`` if consolidation was performed, ``False`` otherwise.
+        """
+        if self.max_memory_steps is None:
+            return False
+
+        interaction_indices = [
+            i for i, s in enumerate(self.steps) if isinstance(s, (ActionStep, PlanningStep))
+        ]
+        if len(interaction_indices) <= self.max_memory_steps:
+            return False
+
+        # Keep the most recent `max_memory_steps` interaction steps untouched.
+        n_to_summarise = len(interaction_indices) - self.max_memory_steps
+        indices_to_summarise = interaction_indices[:n_to_summarise]
+
+        # Also fold any existing MemorySummaryStep entries into the new summary
+        # to prevent unbounded growth of summary steps.
+        existing_summary_indices = [
+            i for i, s in enumerate(self.steps) if isinstance(s, MemorySummaryStep)
+        ]
+
+        # Build text from the steps that will be consolidated.
+        summary_parts: list[str] = []
+
+        # Include existing summaries first for context continuity.
+        for idx in existing_summary_indices:
+            step = self.steps[idx]
+            summary_parts.append(f"[Previous summary] {step.summary}")
+
+        for idx in indices_to_summarise:
+            step = self.steps[idx]
+            if isinstance(step, ActionStep):
+                part = f"[Step {step.step_number}]"
+                if step.model_output:
+                    part += f" Thought: {step.model_output}"
+                if step.tool_calls:
+                    part += f" | Tool calls: {[tc.name for tc in step.tool_calls]}"
+                if step.observations:
+                    obs_trunc = step.observations[:500]
+                    part += f" | Observation: {obs_trunc}"
+                if step.error:
+                    part += f" | Error: {step.error}"
+                summary_parts.append(part)
+            elif isinstance(step, PlanningStep):
+                summary_parts.append(f"[Planning] {step.plan[:500]}")
+
+        text_to_summarise = "\n".join(summary_parts)
+
+        prompt_messages = [
+            ChatMessage(
+                role=MessageRole.SYSTEM,
+                content=[
+                    {
+                        "type": "text",
+                        "text": (
+                            "You are a memory consolidation assistant. "
+                            "Summarise the following agent interaction history into a concise but "
+                            "information-preserving summary. Keep key facts, tool results, errors, "
+                            "and decisions. Be concise."
+                        ),
+                    }
+                ],
+            ),
+            ChatMessage(
+                role=MessageRole.USER,
+                content=[
+                    {
+                        "type": "text",
+                        "text": f"Summarise these agent steps:\n\n{text_to_summarise}",
+                    }
+                ],
+            ),
+        ]
+
+        try:
+            response = model.generate(prompt_messages)
+            # Prefer a normalized text representation of the response (e.g. markdown),
+            # and fall back to truncation when no usable text is available.
+            if hasattr(response, "render_as_markdown"):
+                rendered = response.render_as_markdown()
+            elif isinstance(response.content, str):
+                rendered = response.content
+            elif isinstance(response.content, list):
+                # Extract text from structured content blocks (e.g. [{"type": "text", "text": "..."}])
+                rendered = " ".join(
+                    block.get("text", "") for block in response.content if isinstance(block, dict) and block.get("type") == "text"
+                )
+            else:
+                rendered = ""
+            rendered = (rendered or "").strip()
+            summary_text = rendered or text_to_summarise[:2000]
+        except Exception as e:
+            logger.warning("Memory consolidation LLM call failed (%s); falling back to truncation.", e)
+            summary_text = text_to_summarise[:2000]
+
+        summary_step = MemorySummaryStep(summary=summary_text)
+
+        # Remove summarised steps and old summary steps; insert new summary in their place.
+        indices_set = set(indices_to_summarise) | set(existing_summary_indices)
+        new_steps: list = []
+        inserted = False
+        for i, step in enumerate(self.steps):
+            if i in indices_set:
+                if not inserted:
+                    new_steps.append(summary_step)
+                    inserted = True
+                # skip this old step
+            else:
+                new_steps.append(step)
+        self.steps = new_steps
+        return True
 
     def get_succinct_steps(self) -> list[dict]:
         """Return a succinct representation of the agent's steps, excluding model input messages."""
@@ -269,6 +430,9 @@ class AgentMemory:
                 if detailed and step.model_input_messages is not None:
                     logger.log_messages(step.model_input_messages, level=LogLevel.ERROR)
                 logger.log_markdown(title="Agent output:", content=step.plan, level=LogLevel.ERROR)
+            elif isinstance(step, MemorySummaryStep):
+                logger.log_rule("Memory summary", level=LogLevel.ERROR)
+                logger.log_markdown(title="Consolidated memory:", content=step.summary, level=LogLevel.ERROR)
 
     def return_full_code(self) -> str:
         """Returns all code actions from the agent's steps, concatenated as a single script."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -9,6 +9,7 @@ from smolagents.memory import (
     AgentMemory,
     ChatMessage,
     MemoryStep,
+    MemorySummaryStep,
     MessageRole,
     PlanningStep,
     SystemPromptStep,
@@ -271,3 +272,189 @@ def test_memory_step_json_serialization():
     # Raw field should be present but serializable
     assert "raw" in json_str
     assert "MockChatCompletion" in json_str
+
+
+# ---------------------------------------------------------------------------
+# Tests for MemorySummaryStep and AgentMemory.consolidate
+# ---------------------------------------------------------------------------
+
+
+def _make_action_step(step_number: int, output: str = "thought", observation: str = "obs") -> ActionStep:
+    """Helper to build a minimal ActionStep."""
+    return ActionStep(
+        step_number=step_number,
+        timing=Timing(start_time=0.0, end_time=1.0),
+        model_output=output,
+        observations=observation,
+    )
+
+
+class _FakeModel:
+    """Minimal model stub whose ``generate`` returns a canned summary."""
+
+    def __init__(self, summary_text: str = "consolidated summary"):
+        self.summary_text = summary_text
+        self.call_count = 0
+
+    def generate(self, messages, **kwargs):
+        self.call_count += 1
+        return ChatMessage(role=MessageRole.ASSISTANT, content=self.summary_text)
+
+
+class TestMemorySummaryStep:
+    def test_to_messages(self):
+        step = MemorySummaryStep(summary="A summary of earlier steps.")
+        messages = step.to_messages()
+        assert len(messages) == 1
+        assert messages[0].role == MessageRole.USER
+        assert "Consolidated summary" in messages[0].content[0]["text"]
+        assert "A summary of earlier steps." in messages[0].content[0]["text"]
+
+    def test_to_messages_summary_mode(self):
+        step = MemorySummaryStep(summary="summary")
+        # summary_mode should not suppress this step
+        messages = step.to_messages(summary_mode=True)
+        assert len(messages) == 1
+
+
+class TestAgentMemoryConsolidate:
+    def test_no_consolidation_when_disabled(self):
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=None)
+        for i in range(10):
+            memory.steps.append(_make_action_step(i))
+        assert memory.consolidate(_FakeModel()) is False
+        assert len(memory.steps) == 10
+
+    def test_no_consolidation_when_under_threshold(self):
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=5)
+        for i in range(5):
+            memory.steps.append(_make_action_step(i))
+        assert memory.consolidate(_FakeModel()) is False
+        assert len(memory.steps) == 5
+
+    def test_consolidation_replaces_old_steps(self):
+        model = _FakeModel("short summary")
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=3)
+        # Add a task step + 5 action steps
+        memory.steps.append(TaskStep(task="do something"))
+        for i in range(5):
+            memory.steps.append(_make_action_step(i, output=f"thought_{i}", observation=f"obs_{i}"))
+
+        assert memory.consolidate(model) is True
+        assert model.call_count == 1
+
+        # We should now have: TaskStep, MemorySummaryStep, and 3 remaining ActionSteps
+        assert isinstance(memory.steps[0], TaskStep)
+        assert isinstance(memory.steps[1], MemorySummaryStep)
+        assert memory.steps[1].summary == "short summary"
+        action_steps = [s for s in memory.steps if isinstance(s, ActionStep)]
+        assert len(action_steps) == 3
+
+    def test_consolidation_preserves_planning_steps_in_recent(self):
+        model = _FakeModel("summary")
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=2)
+        memory.steps.append(TaskStep(task="task"))
+        for i in range(3):
+            memory.steps.append(_make_action_step(i))
+        memory.steps.append(
+            PlanningStep(
+                model_input_messages=[],
+                model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content="plan"),
+                plan="plan text",
+                timing=Timing(start_time=0.0, end_time=1.0),
+            )
+        )
+        # 3 ActionSteps + 1 PlanningStep = 4 interaction steps; keep 2 → summarise 2
+        result = memory.consolidate(model)
+        assert result is True
+        interaction_remaining = [s for s in memory.steps if isinstance(s, (ActionStep, PlanningStep))]
+        assert len(interaction_remaining) == 2
+
+    def test_consolidation_fallback_on_model_error(self):
+        class _FailingModel:
+            def generate(self, messages, **kwargs):
+                raise RuntimeError("model unavailable")
+
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=2)
+        for i in range(4):
+            memory.steps.append(_make_action_step(i, output=f"t{i}"))
+
+        # Should not raise, should fall back to truncation
+        assert memory.consolidate(_FailingModel()) is True
+        summary_steps = [s for s in memory.steps if isinstance(s, MemorySummaryStep)]
+        assert len(summary_steps) == 1
+        # Fallback produces raw text, not empty
+        assert len(summary_steps[0].summary) > 0
+
+    def test_repeated_consolidation(self):
+        """After consolidation, adding more steps and consolidating again merges the summary."""
+        model = _FakeModel("summary_v1")
+        memory = AgentMemory(system_prompt="sys", max_memory_steps=2)
+        for i in range(4):
+            memory.steps.append(_make_action_step(i))
+        memory.consolidate(model)
+
+        # Add more steps
+        model.summary_text = "summary_v2"
+        for i in range(4, 7):
+            memory.steps.append(_make_action_step(i))
+        memory.consolidate(model)
+
+        summary_steps = [s for s in memory.steps if isinstance(s, MemorySummaryStep)]
+        # Only one summary step should remain (old one gets consolidated into new)
+        assert len(summary_steps) == 1
+        action_steps = [s for s in memory.steps if isinstance(s, ActionStep)]
+        assert len(action_steps) == 2
+
+
+class TestMaxMemoryStepsPropagation:
+    """Integration test: max_memory_steps is accepted by agent constructors and triggers consolidation."""
+
+    def test_code_agent_accepts_max_memory_steps(self):
+        """CodeAgent constructor propagates max_memory_steps to AgentMemory."""
+        from unittest.mock import MagicMock
+
+        from smolagents.agents import CodeAgent
+        from smolagents.models import Model
+
+        model = MagicMock(spec=Model)
+        model.model_id = "fake"
+        agent = CodeAgent(tools=[], model=model, max_memory_steps=5)
+        assert agent.memory.max_memory_steps == 5
+
+    def test_tool_calling_agent_accepts_max_memory_steps(self):
+        """ToolCallingAgent constructor propagates max_memory_steps to AgentMemory."""
+        from unittest.mock import MagicMock
+
+        from smolagents.agents import ToolCallingAgent
+        from smolagents.models import Model
+
+        model = MagicMock(spec=Model)
+        model.model_id = "fake"
+        agent = ToolCallingAgent(tools=[], model=model, max_memory_steps=3)
+        assert agent.memory.max_memory_steps == 3
+
+    def test_consolidation_triggered_when_threshold_exceeded(self):
+        """Memory consolidation is triggered during agent run when steps exceed threshold."""
+        from unittest.mock import MagicMock
+
+        from smolagents.agents import CodeAgent
+        from smolagents.models import Model
+
+        model = MagicMock(spec=Model)
+        model.model_id = "fake"
+        agent = CodeAgent(tools=[], model=model, max_memory_steps=2)
+
+        # Manually populate memory to simulate steps added during a run
+        for i in range(5):
+            agent.memory.steps.append(_make_action_step(i))
+
+        # Consolidation should trigger and reduce steps
+        fake_model = _FakeModel("integration summary")
+        result = agent.memory.consolidate(fake_model)
+        assert result is True
+
+        summary_steps = [s for s in agent.memory.steps if isinstance(s, MemorySummaryStep)]
+        assert len(summary_steps) == 1
+        action_steps = [s for s in agent.memory.steps if isinstance(s, ActionStep)]
+        assert len(action_steps) == 2


### PR DESCRIPTION
## Summary
Fixes #901 — Adds automatic memory/history consolidation after a configurable number of interaction steps.

## Root Cause
Long-running agents accumulate unbounded conversation history, eventually hitting context window limits or degrading response quality.

## Changes
- `MemorySummaryStep` dataclass in `memory.py` for summary representation
- `max_memory_steps` parameter on `AgentMemory` (default: None = disabled)
- `consolidate()` method summarizes older steps via LLM, with truncation fallback
- `MultiStepAgent` accepts `max_memory_steps` and consolidates each iteration

## Usage
```python
agent = CodeAgent(tools=[], model=my_model, max_memory_steps=10)
# After 10+ steps, older ones are automatically summarized
```

## Tests
8 tests covering: summary step messages, no-op when disabled/under threshold, consolidation, preservation of recent steps, fallback on model error, repeated consolidation.

Fixes #901