### PR TITLE
fix: typos and consistency in documentation and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ limitations under the License.
 Full documentation can be found [here](https://huggingface.co/docs/smolagents/index).
 
 > [!NOTE]
-> Check the our [launch blog post](https://huggingface.co/blog/smolagents) to learn more about `smolagents`!
+> Check our [launch blog post](https://huggingface.co/blog/smolagents) to learn more about `smolagents`!
 
 ## Quick demo
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -38,11 +38,11 @@ class PreTool:
 
 class PythonInterpreterTool(Tool):
     name = "python_interpreter"
-    description = "This is a tool that evaluates python code. It can be used to perform calculations."
+    description = "This is a tool that evaluates Python code. It can be used to perform calculations."
     inputs = {
         "code": {
             "type": "string",
-            "description": "The python code to run in interpreter",
+            "description": "The Python code to run in interpreter",
         }
     }
     output_type = "string"
@@ -57,7 +57,7 @@ class PythonInterpreterTool(Tool):
                 "type": "string",
                 "description": (
                     "The code snippet to evaluate. All variables used in this snippet must be defined in this same snippet, "
-                    f"else you will get an error. This code can only import the following python libraries: {self.authorized_imports}."
+                    f"else you will get an error. This code can only import the following Python libraries: {self.authorized_imports}."
                 ),
             }
         }

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -1283,7 +1283,7 @@ class WasmExecutor(RemotePythonExecutor):
         """
         # In Pyodide, we don't actually install packages here, but we keep track of them
         # to load them when executing code
-        # TODO: Install  here instead?
+        # TODO: Install here instead?
         self.logger.log(f"Adding packages to load: {', '.join(additional_imports)}", level=LogLevel.INFO)
         return additional_imports
 

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -244,7 +244,7 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
             Make sure to include code with the correct pattern, for instance:
             Thoughts: Your thoughts
             {code_block_tags[0]}
-            # Your python code here
+            # Your Python code here
             {code_block_tags[1]}
             """
         ).strip()


### PR DESCRIPTION
## Summary

This PR fixes several typos and consistency issues in the smolagents codebase:

### Changes Made

1. **README.md**: Fixed "Check the our" to "Check our"

2. **default_tools.py**: Fixed capitalization of "Python" in:
   - Tool description: "python code" -> "Python code"
   - Input description: "python code" -> "Python code"
   - Error message: "python libraries" -> "Python libraries"

3. **remote_executors.py**: Fixed double space in TODO comment "Install  here" -> "Install here"

4. **utils.py**: Fixed comment "python code" -> "Python code"

These are minor consistency fixes to ensure proper capitalization of "Python" throughout the codebase.