### PR TITLE
fix: propagate contextvars through timeout decorator for OTel span parenting

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -25,6 +25,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from contextvars import copy_context
 from dataclasses import dataclass
 from functools import wraps
 from importlib import import_module
@@ -304,9 +305,16 @@ def timeout(timeout_seconds: int):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            # Capture the current context so that contextvars (e.g. OpenTelemetry
+            # span context) are propagated into the worker thread.  Without this,
+            # ThreadPoolExecutor spawns a thread that starts with an empty context,
+            # causing tool spans created inside CodeAgent to become root spans
+            # instead of being nested under the agent span.  This mirrors the
+            # pattern already used in ToolCallingAgent (see agents.py).
+            ctx = copy_context()
             # Create a new ThreadPoolExecutor for each call to avoid threading issues
             with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(func, *args, **kwargs)
+                future = executor.submit(ctx.run, func, *args, **kwargs)
                 try:
                     result = future.result(timeout=timeout_seconds)
                     return result

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2313,6 +2313,57 @@ result = "completed"
         output = executor(code)
         assert output.output == "completed"
 
+    def test_timeout_decorator_propagates_contextvars(self):
+        """Test that the timeout decorator propagates contextvars to the worker thread.
+
+        This is critical for OpenTelemetry span context propagation: when
+        CodeAgent executes tool code inside the timeout-wrapped
+        evaluate_python_code, the OTel parent span stored in contextvars must
+        be visible in the worker thread so that tool spans are correctly
+        nested under the agent span.
+        """
+        import contextvars
+
+        test_var = contextvars.ContextVar("test_var", default=None)
+
+        @timeout(5)
+        def read_contextvar():
+            return test_var.get()
+
+        # Set a value in the current context
+        test_var.set("propagated_value")
+
+        # The timeout decorator should propagate it to the worker thread
+        result = read_contextvar()
+        assert result == "propagated_value"
+
+    def test_evaluate_python_code_propagates_contextvars(self):
+        """Test that evaluate_python_code propagates contextvars through the timeout mechanism.
+
+        This validates the full code path used by CodeAgent: a tool callable
+        is passed as a static_tool, and when the generated code invokes it
+        inside the timeout-wrapped evaluate_python_code, any contextvars set
+        in the caller (e.g. an OTel span context) must be visible to the tool.
+        """
+        import contextvars
+
+        test_var = contextvars.ContextVar("test_var", default=None)
+        captured = {}
+
+        def capture_contextvar():
+            captured["value"] = test_var.get()
+            return "ok"
+
+        test_var.set("agent_span_context")
+
+        evaluate_python_code(
+            "result = capture_contextvar()",
+            static_tools={"capture_contextvar": capture_contextvar},
+            timeout_seconds=5,
+        )
+
+        assert captured["value"] == "agent_span_context"
+
 
 @pytest.mark.parametrize(
     "module,authorized_imports,expected",


### PR DESCRIPTION
## Summary

Fixes #1961

When using `CodeAgent`, OpenTelemetry tool spans are missing their parent agent span. This happens because the `timeout` decorator in `local_python_executor.py` wraps code execution in a `ThreadPoolExecutor` worker thread that does **not** inherit `contextvars` by default.

Since the OpenTelemetry Python SDK stores span context in `contextvars`, tool invocations inside the executor thread lose their parent span, causing tool spans to become disconnected root spans instead of being nested under the agent span. `ToolCallingAgent` does not have this problem because it already uses `copy_context()` at `agents.py:1429`.

### Root Cause

The `timeout` decorator at `local_python_executor.py:307` uses:
```python
future = executor.submit(func, *args, **kwargs)
```

This does not propagate `contextvars` to the worker thread.

### Fix

Apply the same `copy_context()` pattern already used in `ToolCallingAgent`:
```python
ctx = copy_context()
future = executor.submit(ctx.run, func, *args, **kwargs)
```

This ensures that OpenTelemetry span context (and any other `contextvars`) is properly propagated into the timeout worker thread.

### Tests

Added two regression tests:
- **`test_timeout_decorator_propagates_contextvars`** — verifies that a `ContextVar` set before calling a timeout-wrapped function is readable inside the worker thread.
- **`test_evaluate_python_code_propagates_contextvars`** — validates the full code path used by `CodeAgent`: a tool callable passed as a `static_tool` can read the caller's `contextvars` when invoked inside the timeout-wrapped `evaluate_python_code`.

All 12 timeout tests pass.

> **Note:** This is an alternative to #2016 which addresses the same issue. This PR adds an additional integration-level test that validates contextvars propagation through the full `evaluate_python_code` → tool call path, and uses more precise comments (ThreadPoolExecutor does not propagate contextvars on any Python version, not just < 3.12).

## Test plan
- [x] All existing timeout tests pass (12/12)
- [x] New `test_timeout_decorator_propagates_contextvars` passes
- [x] New `test_evaluate_python_code_propagates_contextvars` passes
- [x] `ruff check` passes on changed files