### PR TITLE
fix: handle None content in parse_code_blobs (fixes #1896)

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -207,8 +207,14 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
         `str`: Extracted code block.
 
     Raises:
-        ValueError: If no valid code block is found in the text.
+        ValueError: If no valid code block is found in the text or if the
+            model output is None.
     """
+    if text is None:
+        raise ValueError(
+            "The model output is empty (None). The LLM did not generate any text content. "
+            "Please retry or check your model configuration."
+        )
     matches = extract_code_from_text(text, code_block_tags)
     if not matches:  # Fallback to markdown pattern
         matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,10 @@ class AgentTextTests(unittest.TestCase):
         with pytest.raises(ValueError):
             parse_code_blobs("Wrong blob!", ("<code>", "</code>"))
 
+        # None input should raise ValueError with a clear message (issue #1896)
+        with pytest.raises(ValueError, match="model output is empty"):
+            parse_code_blobs(None, ("<code>", "</code>"))
+
         # Parsing mardkwon with code blobs should work
         output = parse_code_blobs(
             """


### PR DESCRIPTION
When the model returns content=None (e.g., empty ChatCompletionMessage), parse_code_blobs now raises a clear ValueError instead of crashing with TypeError: expected string or bytes-like object, got NoneType.

This prevents the agent from entering an error loop with unhelpful error messages and gives the retry logic a proper exception to handle.

## Summary

Fixes #1896 

When the model returns `content=None` (e.g., empty `ChatCompletionMessage`), `parse_code_blobs()` crashes with:


## Changes

- **`src/smolagents/utils.py`**: Added a `None` guard at the top of `parse_code_blobs()` that raises a clear `ValueError` with an actionable message.
- **`tests/test_utils.py`**: Added test case verifying that `parse_code_blobs(None, ...)` raises `ValueError`.

## Root Cause

In `agents.py` line 1709, `output_text = chat_message.content` can be `None` when the model returns an empty response. This `None` propagates to `re.findall()` which crashes with the unhelpful `TypeError`.

## Testing

- `pytest tests/test_utils.py::AgentTextTests::test_parse_code_blobs` — ✅ passes
