### PR TITLE
fix: handle consecutive same-role messages with string content (fixes…

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,16 +373,28 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
-            if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
-            else:
-                for el in message.content:
-                    if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
-                        # Merge consecutive text messages rather than creating new ones
-                        output_message_list[-1]["content"][-1]["text"] += "\n" + el["text"]
-                    else:
-                        output_message_list[-1]["content"].append(el)
+            prev_content = output_message_list[-1]["content"]
+            curr_content = message.content
+            if isinstance(curr_content, str):
+                # Handle string content merging
+                if isinstance(prev_content, str):
+                    output_message_list[-1]["content"] = prev_content + "\n" + curr_content
+                else:
+                    # Previous was list, current is string — append as text element
+                    output_message_list[-1]["content"].append({"type": "text", "text": curr_content})
+            elif isinstance(curr_content, list):
+                if flatten_messages_as_text:
+                    output_message_list[-1]["content"] += "\n" + curr_content[0]["text"]
+                else:
+                    if isinstance(prev_content, str):
+                        # Previous was string, current is list — convert previous to list format
+                        output_message_list[-1]["content"] = [{"type": "text", "text": prev_content}]
+                    for el in curr_content:
+                        if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
+                            # Merge consecutive text messages rather than creating new ones
+                            output_message_list[-1]["content"][-1]["text"] += "\n" + el["text"]
+                        else:
+                            output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
                 content = message.content[0]["text"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,21 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_consecutive_string_messages():
+    """Test that consecutive same-role messages with string content are merged correctly (issue #1972)."""
+    messages = [
+        {"role": "system", "content": "When you say anything Start with 'FOO'"},
+        {"role": "system", "content": "When you say anything End with 'BAR'"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert result[0]["content"] == "When you say anything Start with 'FOO'\nWhen you say anything End with 'BAR'"
+    assert result[1]["role"] == "user"
+    assert result[1]["content"] == "Just say '.'"
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
… #1972)

get_clean_message_list() crashed with AssertionError when consecutive messages shared the same role and had string content (e.g. two system messages). The assertion expected list content for merging.

The fix handles string+string, string+list, and list+string content combinations when merging consecutive same-role messages.

## Summary

Fixes #1972

`get_clean_message_list()` crashes with `AssertionError` when consecutive messages share the same role and have string content (e.g., two system messages with plain text).

## Root Cause

Line 376 asserts `isinstance(message.content, list)` when merging consecutive same-role messages. But `ChatMessage.content` is typed as `str | list[dict] | None` — string content is perfectly valid.

## Changes

- **`src/smolagents/models.py`**: Replaced the assertion with branching logic that handles all content type combinations (string+string, string+list, list+string, list+list).
- **`tests/test_models.py`**: Added test reproducing the exact scenario from the bug report.

## Testing

- `pytest tests/test_models.py -k "get_clean_message_list"` — 8 passed ✅
