### PR TITLE
fix: stop kwargs propagation to managed agents in from_dict (fixes #1…

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1594,6 +1594,40 @@ class TestMultiStepAgent:
         assert recreated_managed_agent.description == "A managed agent for testing"
         assert recreated_managed_agent.max_steps == 5
 
+    def test_from_dict_kwargs_not_propagated_to_managed_agents(self):
+        """Test that parent kwargs are not passed to managed agents during from_dict (issue #1849)."""
+        # Create a managed agent with specific max_steps
+        managed_agent = CodeAgent(
+            tools=[], model=MagicMock(), name="child_agent", description="Child agent", max_steps=5
+        )
+
+        # Create main agent
+        main_agent = CodeAgent(
+            tools=[],
+            managed_agents=[managed_agent],
+            model=MagicMock(),
+            name="parent_agent",
+            description="Parent agent",
+            max_steps=10,
+        )
+
+        agent_dict = main_agent.to_dict()
+
+        mock_model_class = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_model_class.from_dict.return_value = mock_model_instance
+
+        # Pass max_steps=30 as kwarg override — this should only affect the parent
+        with patch.dict("smolagents.models.MODEL_REGISTRY", {"MagicMock": mock_model_class}):
+            recreated_agent = CodeAgent.from_dict(agent_dict, max_steps=30)
+
+        # Parent should use the kwarg override
+        assert recreated_agent.max_steps == 30
+
+        # Child should keep its own serialized value, NOT the parent's kwarg
+        recreated_child = list(recreated_agent.managed_agents.values())[0]
+        assert recreated_child.max_steps == 5
+
     def test_from_dict_invalid_model_class(self):
         """Test that from_dict raises ValueError with helpful message for invalid model class."""
         agent_dict = {


### PR DESCRIPTION
## Summary

Fixes #1849

`MultiStepAgent.from_dict()` passes parent `**kwargs` to child managed agents during deserialization, overriding their serialized configs (e.g., `additional_authorized_imports`).

## Fix

One-line change — remove `**kwargs` from managed agent deserialization:

- managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+ managed_agent = agent_class.from_dict(managed_agent_dict)

## Testing

- Added `test_from_dict_kwargs_not_propagated_to_managed_agents`
- All 3 related tests pass ✅
