### PR TITLE
fix: reset PrintContainer before ast.parse to prevent print output le…

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -830,6 +830,20 @@ def function():
         evaluate_python_code(code, {"print": print, "range": range}, state=state)
         assert state["_print_outputs"].value == "1\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n"
 
+    def test_print_outputs_reset_on_syntax_error(self):
+        """Test that print outputs from previous step don't leak when SyntaxError occurs (issue #1998)."""
+        state = {}
+        # Step 1: print something
+        evaluate_python_code("print('step 1 output')", BASE_PYTHON_TOOLS, state=state)
+        assert state["_print_outputs"].value == "step 1 output\n"
+
+        # Step 2: code with SyntaxError — should reset print outputs before raising
+        with pytest.raises(InterpreterError, match="SyntaxError"):
+            evaluate_python_code("def bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        # Print outputs should be empty (reset), NOT "step 1 output\n"
+        assert state["_print_outputs"].value == ""
+
     def test_tuple_target_in_iterator(self):
         code = "for a, b in [('Ralf Weikert', 'Austria'), ('Samuel Seungwon Lee', 'South Korea')]:res = a.split()[0]"
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})


### PR DESCRIPTION
Fixes #1998 — print outputs from step N leak into step N+1 when a SyntaxError occurs,
because PrintContainer() was reset after ast.parse(). Moved state initialization before parsing.
