### PR TITLE
fix: register weakref finalizer in DockerExecutor to prevent orphaned containers

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -25,6 +25,7 @@ import subprocess
 import tempfile
 import time
 import uuid
+import weakref
 from contextlib import closing
 from io import BytesIO
 from textwrap import dedent
@@ -577,6 +578,7 @@ class DockerExecutor(RemotePythonExecutor):
         dockerfile_content: str | None = None,
     ):
         super().__init__(additional_imports, logger, allow_pickle)
+        self._cleaned_up = False
         try:
             import docker
         except ModuleNotFoundError:
@@ -666,6 +668,7 @@ class DockerExecutor(RemotePythonExecutor):
             self.logger.log(
                 f"Container {self.container.short_id} is running with kernel {self.kernel_id}", level=LogLevel.INFO
             )
+            self._finalizer = weakref.finalize(self, DockerExecutor._stop_and_remove, self.container, self.logger)
 
         except Exception as e:
             self.cleanup()
@@ -686,14 +689,31 @@ class DockerExecutor(RemotePythonExecutor):
         with closing(create_connection(self.ws_url)) as ws:
             return _websocket_run_code_raise_errors(code, ws, self.logger, self.allow_pickle)
 
+    @staticmethod
+    def _stop_and_remove(container, logger):
+        """Stop and remove a Docker container. Safe to call from weakref.finalize context."""
+        logger.log(f"Stopping and removing container {container.short_id}...", level=LogLevel.INFO)
+        try:
+            container.stop()
+        except Exception as e:
+            logger.log_error(f"Error stopping container: {e}")
+        try:
+            container.remove(force=True)
+        except Exception as e:
+            logger.log_error(f"Error removing container: {e}")
+            raise
+        logger.log("Container cleanup completed", level=LogLevel.INFO)
+
     def cleanup(self):
         """Clean up the Docker container and resources."""
+        if self._cleaned_up:
+            return
         try:
             if hasattr(self, "container"):
-                self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)
-                self.container.stop()
-                self.container.remove()
-                self.logger.log("Container cleanup completed", level=LogLevel.INFO)
+                DockerExecutor._stop_and_remove(self.container, self.logger)
+                self._cleaned_up = True
+                if hasattr(self, "_finalizer"):
+                    self._finalizer.detach()
                 del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -230,16 +230,18 @@ class TestE2BExecutorIntegration:
 
 
 class TestDockerExecutorUnit:
-    def test_cleanup(self):
-        """Test that cleanup properly stops and removes the container"""
-        logger = MagicMock()
+    """Unit tests for DockerExecutor lifecycle (cleanup, finalizer, idempotency)."""
+
+    @staticmethod
+    def _make_executor(logger=None):
+        """Create a DockerExecutor with mocked dependencies, returning (executor, mock_container)."""
+        logger = logger or MagicMock()
         with (
             patch("docker.from_env") as mock_docker_client,
             patch("requests.get") as mock_get,
             patch("requests.post") as mock_post,
             patch("websocket.create_connection"),
         ):
-            # Setup mocks
             mock_container = MagicMock()
             mock_container.status = "running"
             mock_container.short_id = "test123"
@@ -251,15 +253,117 @@ class TestDockerExecutorUnit:
             mock_post.return_value.status_code = 201
             mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
 
-            # Create executor
             executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+        return executor, mock_container
 
-            # Call cleanup
-            executor.cleanup()
+    def test_cleanup(self):
+        """Test that cleanup properly stops and removes the container."""
+        executor, mock_container = self._make_executor()
 
-            # Verify container was stopped and removed
+        executor.cleanup()
+
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once_with(force=True)
+        assert executor._cleaned_up is True
+
+    def test_cleanup_is_idempotent(self):
+        """Test that calling cleanup twice only stops/removes the container once."""
+        executor, mock_container = self._make_executor()
+
+        executor.cleanup()
+        executor.cleanup()
+
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once_with(force=True)
+
+    def test_finalizer_registered_on_init(self):
+        """Test that a weakref.finalize finalizer is registered during init."""
+        executor, _ = self._make_executor()
+
+        assert hasattr(executor, "_finalizer")
+        assert executor._finalizer.alive
+
+    def test_cleanup_detaches_finalizer(self):
+        """Test that cleanup detaches the finalizer so it won't fire again."""
+        executor, _ = self._make_executor()
+
+        executor.cleanup()
+
+        assert not executor._finalizer.alive
+
+    def test_finalizer_cleans_up_on_gc(self):
+        """Test that dropping the executor triggers container cleanup via the finalizer."""
+        import weakref
+
+        executor, mock_container = self._make_executor()
+        # Detach the finalizer to call it manually (simulating GC)
+        finalizer = executor._finalizer
+        # Prevent explicit cleanup from running first
+        executor._cleaned_up = True
+        # Simulate what GC would do
+        finalizer()
+
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once_with(force=True)
+
+    def test_cleanup_removes_even_if_stop_fails(self):
+        """Test that container.remove(force=True) is called even if stop() raises."""
+        executor, mock_container = self._make_executor()
+        mock_container.stop.side_effect = Exception("stop failed")
+
+        executor.cleanup()
+
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once_with(force=True)
+
+    def test_cleanup_not_marked_done_if_remove_fails(self):
+        """Test that _cleaned_up stays False if remove(force=True) raises, allowing retry."""
+        executor, mock_container = self._make_executor()
+        mock_container.remove.side_effect = Exception("remove failed")
+
+        executor.cleanup()
+
+        assert executor._cleaned_up is False
+        assert hasattr(executor, "container")
+        # Detach finalizer to avoid noisy stderr during test process exit
+        executor._finalizer.detach()
+
+    def test_finalizer_alive_after_failed_cleanup(self):
+        """Test that finalizer remains alive if remove() fails, so GC/exit can retry."""
+        executor, mock_container = self._make_executor()
+        mock_container.remove.side_effect = Exception("remove failed")
+
+        executor.cleanup()
+
+        assert executor._finalizer.alive
+        executor._finalizer.detach()
+
+    def test_init_failure_cleans_up_container(self):
+        """Test that if init fails after container creation, the container is cleaned up."""
+        logger = MagicMock()
+        with (
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+        ):
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            # Simulate kernel creation failure
+            mock_post.return_value.status_code = 500
+            mock_post.return_value.json.return_value = {}
+
+            with pytest.raises(RuntimeError, match="Failed to initialize Jupyter kernel"):
+                DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+
             mock_container.stop.assert_called_once()
-            mock_container.remove.assert_called_once()
+            mock_container.remove.assert_called_once_with(force=True)
 
 
 class CommonDockerExecutorIntegration:


### PR DESCRIPTION
## Summary

- Fixes #2050 — `DockerExecutor` leaves orphaned containers when the Python process terminates unexpectedly (KeyboardInterrupt, crash, unhandled exception), blocking port 8888 on restart.
- Registers a `weakref.finalize` callback on successful init that automatically stops and removes the container on GC or interpreter shutdown.
- Makes `cleanup()` idempotent with a `_cleaned_up` guard and resilient to `stop()` failures (`remove(force=True)` still runs).
- If `remove()` fails, `_cleaned_up` stays `False` and the finalizer remains alive, allowing retry on process exit.

## Test plan

- [x] `ruff check src/smolagents/remote_executors.py` — no errors
- [x] 9 unit tests in `TestDockerExecutorUnit` — all pass:
  - Basic cleanup (stop + remove with force=True)
  - Idempotency (double cleanup → single stop/remove)
  - Finalizer registered on init
  - Finalizer detached after successful cleanup
  - Finalizer triggers cleanup on GC
  - `remove(force=True)` called even if `stop()` fails
  - `_cleaned_up` stays False if `remove()` fails (retry possible)
  - Finalizer remains alive after failed cleanup
  - Init failure cleans up container
- [x] Manual test with Docker (integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)