### PR TITLE
docs: Fix concurrent request handling in async_agent example

### DIFF
--- a/docs/source/en/examples/async_agent.md
+++ b/docs/source/en/examples/async_agent.md
@@ -38,14 +38,18 @@ from starlette.routing import Route
 
 from smolagents import CodeAgent, InferenceClientModel
 
-agent = CodeAgent(
-    model=InferenceClientModel(model_id="Qwen/Qwen3-Next-80B-A3B-Thinking"),
-    tools=[],
-)
+shared_inference_model = InferenceClientModel(model_id="Qwen/Qwen3-Next-80B-A3B-Thinking")
+def instantiate_agent():
+    return CodeAgent(
+        model=shared_inference_model,
+        tools=[],
+    )
 
 async def run_agent(request: Request):
     data = await request.json()
     task = data.get("task", "")
+    # Create agent instance to avoid sharing agent memory, state, step counter etc in case of concurrent tasks
+    agent = instantiate_agent()
     # Run the agent synchronously in a background thread
     result = await anyio.to_thread.run_sync(agent.run, task)
     return JSONResponse({"result": result})


### PR DESCRIPTION
The original example created a single global CodeAgent instance that was shared across all HTTP requests. This causes race conditions when multiple requests are processed concurrently, as CodeAgent maintains mutable instance state (step_number, memory, monitor) that gets corrupted when accessed from multiple threads.

This change demonstrates the correct pattern:
- Share thread-safe model instances (InferenceClientModel) at module level
- Create a fresh CodeAgent instance for each request via factory function
- Document why this pattern is necessary (avoid shared agent memory/state)

The fixed example helps prevent interleaved execution traces and state corruption in production deployments where the agent service handles concurrent request