### PR TITLE
Implement autonomy harness defaults and prompts for smolagent CLI

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -91,6 +91,7 @@ from .utils import (
     extract_code_from_text,
     is_valid_name,
     make_init_file,
+    make_json_serializable,
     parse_code_blobs,
     truncate_content,
 )
@@ -253,6 +254,24 @@ class RunResult:
         }
 
 
+@dataclass
+class RunStateSnapshot:
+    step_number: int
+    completed_action_steps: int
+    pending_task: str | None
+    last_plan: str | None
+    memory_summary: list[dict[str, Any]]
+
+    def dict(self) -> dict[str, Any]:
+        return {
+            "step_number": self.step_number,
+            "completed_action_steps": self.completed_action_steps,
+            "pending_task": self.pending_task,
+            "last_plan": self.last_plan,
+            "memory_summary": self.memory_summary,
+        }
+
+
 StreamEvent: TypeAlias = Union[
     ChatMessageStreamDelta,
     ChatMessageToolCall,
@@ -289,6 +308,8 @@ class MultiStepAgent(ABC):
             - Take the final answer, the agent's memory, and the agent itself as arguments.
             - Return a boolean indicating whether the final answer is valid.
         return_full_result (`bool`, default `False`): Whether to return the full [`RunResult`] object or just the final answer output from the agent run.
+        tool_retry_limit (`int`, default `0`): Number of retries to allow for recoverable step errors.
+        stagnation_window (`int`, default `0`): Trigger an unscheduled planning step after this many repeated non-progress steps.
     """
 
     def __init__(
@@ -308,6 +329,8 @@ class MultiStepAgent(ABC):
         provide_run_summary: bool = False,
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
+        tool_retry_limit: int = 0,
+        stagnation_window: int = 0,
         logger: AgentLogger | None = None,
     ):
         self.agent_name = self.__class__.__name__
@@ -334,6 +357,12 @@ class MultiStepAgent(ABC):
         self.provide_run_summary = provide_run_summary
         self.final_answer_checks = final_answer_checks if final_answer_checks is not None else []
         self.return_full_result = return_full_result
+        if tool_retry_limit < 0:
+            raise ValueError(f"tool_retry_limit must be >= 0, got {tool_retry_limit}")
+        if stagnation_window < 0:
+            raise ValueError(f"stagnation_window must be >= 0, got {stagnation_window}")
+        self.tool_retry_limit = tool_retry_limit
+        self.stagnation_window = stagnation_window
         self.instructions = instructions
         self._setup_managed_agents(managed_agents)
         self._setup_tools(tools, add_base_tools)
@@ -350,6 +379,7 @@ class MultiStepAgent(ABC):
         self.monitor = Monitor(self.model, self.logger)
         self._setup_step_callbacks(step_callbacks)
         self.stream_outputs = False
+        self._reset_autonomy_state()
 
     @property
     def system_prompt(self) -> str:
@@ -433,6 +463,55 @@ class MultiStepAgent(ABC):
         # Register monitor update_metrics only for ActionStep for backward compatibility
         self.step_callbacks.register(ActionStep, self.monitor.update_metrics)
 
+    def _reset_autonomy_state(self):
+        self._force_plan_step = False
+        self._stagnant_step_count = 0
+        self._last_progress_signature: str | None = None
+
+    def _is_retryable_error(self, error: AgentError) -> bool:
+        return not isinstance(error, (AgentGenerationError, AgentMaxStepsError))
+
+    def _build_progress_signature(self, action_step: ActionStep) -> str:
+        if action_step.error is not None:
+            return f"error:{type(action_step.error).__name__}:{action_step.error.message}"
+        signature = {
+            "tool_calls": (
+                [
+                    {"name": tool_call.name, "arguments": make_json_serializable(tool_call.arguments)}
+                    for tool_call in action_step.tool_calls
+                ]
+                if action_step.tool_calls
+                else []
+            ),
+            "observations": action_step.observations,
+            "action_output": make_json_serializable(action_step.action_output),
+            "model_output": make_json_serializable(action_step.model_output),
+        }
+        return json.dumps(make_json_serializable(signature), sort_keys=True)
+
+    def _update_stagnation_tracking(self, action_step: ActionStep):
+        if self.stagnation_window <= 0:
+            return
+        if action_step.is_final_answer:
+            self._stagnant_step_count = 0
+            self._last_progress_signature = None
+            return
+
+        signature = self._build_progress_signature(action_step)
+        if self._last_progress_signature == signature:
+            self._stagnant_step_count += 1
+        else:
+            self._stagnant_step_count = 0
+        self._last_progress_signature = signature
+
+        if self._stagnant_step_count >= self.stagnation_window:
+            self._force_plan_step = True
+            self._stagnant_step_count = 0
+            self.logger.log(
+                "Detected repeated non-progress steps. Triggering an unscheduled planning step.",
+                level=LogLevel.INFO,
+            )
+
     def run(
         self,
         task: str,
@@ -468,6 +547,7 @@ class MultiStepAgent(ABC):
         max_steps = max_steps or self.max_steps
         self.task = task
         self.interrupt_switch = False
+        self._reset_autonomy_state()
         if additional_args:
             self.state.update(additional_args)
             self.task += f"""
@@ -542,14 +622,17 @@ You have been provided with these additional arguments, that you can access dire
     ) -> Generator[ActionStep | PlanningStep | FinalAnswerStep | ChatMessageStreamDelta]:
         self.step_number = 1
         returned_final_answer = False
+        final_answer = None
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
 
             # Run a planning step if scheduled
-            if self.planning_interval is not None and (
-                self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0
-            ):
+            should_plan = self._force_plan_step or (
+                self.planning_interval is not None
+                and (self.step_number == 1 or (self.step_number - 1) % self.planning_interval == 0)
+            )
+            if should_plan:
                 planning_start_time = time.time()
                 planning_step = None
                 for element in self._generate_planning_step(
@@ -565,47 +648,67 @@ You have been provided with these additional arguments, that you can access dire
                 )
                 self._finalize_step(planning_step)
                 self.memory.steps.append(planning_step)
+                self._force_plan_step = False
 
-            # Start action step!
-            action_step_start_time = time.time()
-            action_step = ActionStep(
-                step_number=self.step_number,
-                timing=Timing(start_time=action_step_start_time),
-                observations_images=images,
-            )
-            self.logger.log_rule(f"Step {self.step_number}", level=LogLevel.INFO)
-            try:
-                for output in self._step_stream(action_step):
-                    # Yield all
-                    yield output
+            retries_left = self.tool_retry_limit
+            while True:
+                action_step_start_time = time.time()
+                action_step = ActionStep(
+                    step_number=self.step_number,
+                    timing=Timing(start_time=action_step_start_time),
+                    observations_images=images,
+                )
+                self.logger.log_rule(f"Step {self.step_number}", level=LogLevel.INFO)
 
-                    if isinstance(output, ActionOutput) and output.is_final_answer:
-                        final_answer = output.output
+                retry_attempted = False
+                try:
+                    for output in self._step_stream(action_step):
+                        # Yield all
+                        yield output
+
+                        if isinstance(output, ActionOutput) and output.is_final_answer:
+                            final_answer = output.output
+                            self.logger.log(
+                                Text(f"Final answer: {final_answer}", style=f"bold {YELLOW_HEX}"),
+                                level=LogLevel.INFO,
+                            )
+
+                            if self.final_answer_checks:
+                                self._validate_final_answer(final_answer)
+                            returned_final_answer = True
+                            action_step.is_final_answer = True
+                except AgentGenerationError as e:
+                    # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
+                    action_step.error = e
+                    self._finalize_step(action_step)
+                    self.memory.steps.append(action_step)
+                    self._update_stagnation_tracking(action_step)
+                    yield action_step
+                    raise e
+                except AgentError as e:
+                    # Other AgentError types are typically recoverable and can be retried when configured.
+                    action_step.error = e
+                    retry_attempted = retries_left > 0 and self._is_retryable_error(e)
+                    if retry_attempted:
+                        retries_left -= 1
                         self.logger.log(
-                            Text(f"Final answer: {final_answer}", style=f"bold {YELLOW_HEX}"),
+                            f"Retrying step {self.step_number} after recoverable error ({retries_left} retries left).",
                             level=LogLevel.INFO,
                         )
 
-                        if self.final_answer_checks:
-                            self._validate_final_answer(final_answer)
-                        returned_final_answer = True
-                        action_step.is_final_answer = True
-
-            except AgentGenerationError as e:
-                # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
-                raise e
-            except AgentError as e:
-                # Other AgentError types are caused by the Model, so we should log them and iterate.
-                action_step.error = e
-            finally:
                 self._finalize_step(action_step)
                 self.memory.steps.append(action_step)
+                self._update_stagnation_tracking(action_step)
                 yield action_step
+
+                if retry_attempted:
+                    continue
+
                 self.step_number += 1
+                break
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step
@@ -865,6 +968,32 @@ You have been provided with these additional arguments, that you can access dire
         """
         self.memory.replay(self.logger, detailed=detailed)
 
+    def get_run_state_snapshot(self) -> dict[str, Any]:
+        """Return a compact, serializable snapshot of the current run state."""
+        action_steps = [step for step in self.memory.steps if isinstance(step, ActionStep)]
+        planning_steps = [step for step in self.memory.steps if isinstance(step, PlanningStep)]
+        memory_summary = []
+        for message in self.write_memory_to_messages(summary_mode=True):
+            memory_summary.append(
+                {
+                    "role": str(message.role),
+                    "content": truncate_content(str(make_json_serializable(message.content)), max_length=5000),
+                }
+            )
+
+        snapshot = RunStateSnapshot(
+            step_number=self.step_number,
+            completed_action_steps=len(action_steps),
+            pending_task=self.task,
+            last_plan=planning_steps[-1].plan if planning_steps else None,
+            memory_summary=memory_summary,
+        ).dict()
+        snapshot["stagnation_state"] = {
+            "window": self.stagnation_window,
+            "last_signature": self._last_progress_signature,
+        }
+        return snapshot
+
     def __call__(self, task: str, **kwargs):
         """Adds additional prompting for the managed agent, runs it, and wraps the output.
         This method is called only by a managed agent.
@@ -1001,6 +1130,8 @@ You have been provided with these additional arguments, that you can access dire
             "max_steps": self.max_steps,
             "verbosity_level": int(self.logger.level),
             "planning_interval": self.planning_interval,
+            "tool_retry_limit": self.tool_retry_limit,
+            "stagnation_window": self.stagnation_window,
             "name": self.name,
             "description": self.description,
             "requirements": sorted(requirements),
@@ -1051,6 +1182,8 @@ You have been provided with these additional arguments, that you can access dire
             "max_steps": agent_dict.get("max_steps"),
             "verbosity_level": agent_dict.get("verbosity_level"),
             "planning_interval": agent_dict.get("planning_interval"),
+            "tool_retry_limit": agent_dict.get("tool_retry_limit"),
+            "stagnation_window": agent_dict.get("stagnation_window"),
             "name": agent_dict.get("name"),
             "description": agent_dict.get("description"),
         }

--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -14,8 +14,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import argparse
+import json
 import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Literal
 
 from dotenv import load_dotenv
 from rich.console import Console
@@ -24,17 +30,20 @@ from rich.prompt import Confirm, Prompt
 from rich.rule import Rule
 from rich.table import Table
 
-from smolagents import (
-    CodeAgent,
+from .agents import CodeAgent, ToolCallingAgent
+from .default_tools import TOOL_MAPPING
+from .memory import ActionStep, FinalAnswerStep, MemoryStep, PlanningStep
+from .models import (
+    STRUCTURED_GENERATION_PROVIDERS,
     InferenceClientModel,
     LiteLLMModel,
     Model,
     OpenAIModel,
-    Tool,
-    ToolCallingAgent,
     TransformersModel,
 )
-from smolagents.default_tools import TOOL_MAPPING
+from .monitoring import LogLevel
+from .tools import Tool
+from .utils import make_json_serializable, truncate_content
 
 
 console = Console()
@@ -42,98 +51,297 @@ console = Console()
 leopard_prompt = "How many seconds would it take for a leopard at full speed to run through Pont des Arts?"
 
 
-def parse_arguments():
-    parser = argparse.ArgumentParser(description="Run a CodeAgent with all specified parameters")
+@dataclass(frozen=True)
+class AutonomyProfileDefaults:
+    max_steps: int
+    planning_interval: int | None
+    use_structured_internal_output: bool
+    tool_retry_limit: int
+    stagnation_window: int
+
+
+AUTONOMY_PROFILES: dict[str, AutonomyProfileDefaults] = {
+    "legacy": AutonomyProfileDefaults(
+        max_steps=20,
+        planning_interval=None,
+        use_structured_internal_output=False,
+        tool_retry_limit=0,
+        stagnation_window=0,
+    ),
+    "balanced": AutonomyProfileDefaults(
+        max_steps=32,
+        planning_interval=6,
+        use_structured_internal_output=True,
+        tool_retry_limit=1,
+        stagnation_window=2,
+    ),
+    "long-horizon": AutonomyProfileDefaults(
+        max_steps=64,
+        planning_interval=4,
+        use_structured_internal_output=True,
+        tool_retry_limit=2,
+        stagnation_window=3,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    autonomy_profile: Literal["legacy", "balanced", "long-horizon"]
+    max_steps: int
+    planning_interval: int | None
+    use_structured_internal_output: bool
+    checkpoint_path: str
+    resume: bool
+    memory_path: str
+    approval_policy: Literal["auto", "on-failure", "always"]
+    tool_retry_limit: int
+    stagnation_window: int
+    json_events: bool
+    final_schema_path: str | None
+    instructions_files: list[str]
+    append_instructions: list[str]
+    verbosity_level: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> "RunConfig":
+        profile = AUTONOMY_PROFILES[args.autonomy_profile]
+
+        max_steps = args.max_steps if args.max_steps is not None else profile.max_steps
+        if max_steps <= 0:
+            raise ValueError(f"max_steps must be > 0, got {max_steps}")
+
+        planning_interval = args.planning_interval if args.planning_interval is not None else profile.planning_interval
+        if planning_interval is not None and planning_interval <= 0:
+            planning_interval = None
+
+        use_structured_internal_output = (
+            args.use_structured_internal_output
+            if args.use_structured_internal_output is not None
+            else profile.use_structured_internal_output
+        )
+
+        tool_retry_limit = args.tool_retry_limit if args.tool_retry_limit is not None else profile.tool_retry_limit
+        if tool_retry_limit < 0:
+            raise ValueError(f"tool_retry_limit must be >= 0, got {tool_retry_limit}")
+
+        stagnation_window = args.stagnation_window if args.stagnation_window is not None else profile.stagnation_window
+        if stagnation_window < 0:
+            raise ValueError(f"stagnation_window must be >= 0, got {stagnation_window}")
+
+        return cls(
+            autonomy_profile=args.autonomy_profile,
+            max_steps=max_steps,
+            planning_interval=planning_interval,
+            use_structured_internal_output=use_structured_internal_output,
+            checkpoint_path=args.checkpoint_path,
+            resume=args.resume,
+            memory_path=args.memory_path,
+            approval_policy=args.approval_policy,
+            tool_retry_limit=tool_retry_limit,
+            stagnation_window=stagnation_window,
+            json_events=args.json_events,
+            final_schema_path=args.final_schema,
+            instructions_files=args.instructions_file,
+            append_instructions=args.append_instruction,
+            verbosity_level=args.verbosity_level,
+        )
+
+    @classmethod
+    def default(cls) -> "RunConfig":
+        profile = AUTONOMY_PROFILES["long-horizon"]
+        return cls(
+            autonomy_profile="long-horizon",
+            max_steps=profile.max_steps,
+            planning_interval=profile.planning_interval,
+            use_structured_internal_output=profile.use_structured_internal_output,
+            checkpoint_path=".smolagent/runs/latest.json",
+            resume=False,
+            memory_path=".smolagent/memory.md",
+            approval_policy="auto",
+            tool_retry_limit=profile.tool_retry_limit,
+            stagnation_window=profile.stagnation_window,
+            json_events=False,
+            final_schema_path=None,
+            instructions_files=[],
+            append_instructions=[],
+            verbosity_level=1,
+        )
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a smolagent with configurable autonomy harness settings")
     parser.add_argument(
         "prompt",
         type=str,
         nargs="?",
         default=None,
-        help="The prompt to run with the agent. If no prompt is provided, interactive mode will be launched to guide user through agent setup",
+        help=(
+            "The prompt to run with the agent. If no prompt is provided and --resume is not set, "
+            "interactive mode will be launched."
+        ),
     )
     parser.add_argument(
         "--model-type",
         type=str,
         default="InferenceClientModel",
-        help="The model type to use (e.g., InferenceClientModel, OpenAIModel, LiteLLMModel, TransformersModel)",
+        choices=["InferenceClientModel", "OpenAIModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel"],
+        help="The model type to use.",
     )
     parser.add_argument(
         "--action-type",
         type=str,
         default="code",
-        help="The action type to use (e.g., code, tool_calling)",
+        choices=["code", "tool_calling"],
+        help="The action type to use.",
     )
     parser.add_argument(
         "--model-id",
         type=str,
         default="Qwen/Qwen3-Next-80B-A3B-Thinking",
-        help="The model ID to use for the specified model type",
+        help="The model ID to use for the specified model type.",
     )
     parser.add_argument(
         "--imports",
-        nargs="*",  # accepts zero or more arguments
+        nargs="*",
         default=[],
-        help="Space-separated list of imports to authorize (e.g., 'numpy pandas')",
+        help="Space-separated list of imports to authorize (e.g., 'numpy pandas').",
     )
     parser.add_argument(
         "--tools",
         nargs="*",
         default=["web_search"],
-        help="Space-separated list of tools that the agent can use (e.g., 'tool1 tool2 tool3')",
+        help="Space-separated list of tools the agent can use.",
     )
     parser.add_argument(
         "--verbosity-level",
         type=int,
         default=1,
-        help="The verbosity level, as an int in [0, 1, 2].",
+        help="Verbosity level as int in [-1, 0, 1, 2].",
     )
+    parser.add_argument(
+        "--autonomy-profile",
+        type=str,
+        default="long-horizon",
+        choices=["legacy", "balanced", "long-horizon"],
+        help="Autonomy profile. Defaults to long-horizon.",
+    )
+    parser.add_argument("--max-steps", type=int, default=None, help="Maximum number of action steps.")
+    parser.add_argument(
+        "--planning-interval",
+        type=int,
+        default=None,
+        help="Plan every N steps. Pass 0 or negative to disable periodic planning.",
+    )
+    parser.add_argument(
+        "--use-structured-internal-output",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Use structured generation for CodeAgent internal action steps when backend supports it.",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        type=str,
+        default=".smolagent/runs/latest.json",
+        help="Path used to persist checkpoint state after each run.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume using checkpoint context from --checkpoint-path.",
+    )
+    parser.add_argument(
+        "--memory-path",
+        type=str,
+        default=".smolagent/memory.md",
+        help="Path used for persistent memory notes across runs.",
+    )
+    parser.add_argument(
+        "--approval-policy",
+        type=str,
+        default="auto",
+        choices=["auto", "on-failure", "always"],
+        help="Runtime approval policy included in harness instructions.",
+    )
+    parser.add_argument(
+        "--tool-retry-limit",
+        type=int,
+        default=None,
+        help="Number of retries for recoverable step failures.",
+    )
+    parser.add_argument(
+        "--stagnation-window",
+        type=int,
+        default=None,
+        help="Trigger re-plan after this many repeated non-progress steps.",
+    )
+    parser.add_argument(
+        "--json-events",
+        action="store_true",
+        help="Emit machine-readable JSON step events.",
+    )
+    parser.add_argument(
+        "--final-schema",
+        type=str,
+        default=None,
+        help="Path to a JSON schema used to validate final answers.",
+    )
+    parser.add_argument(
+        "--instructions-file",
+        action="append",
+        default=[],
+        help="Path to an additional instruction file. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--append-instruction",
+        action="append",
+        default=[],
+        help="Inline instruction snippet to append. Can be passed multiple times.",
+    )
+
     group = parser.add_argument_group("api options", "Options for API-based model types")
     group.add_argument(
         "--provider",
         type=str,
         default=None,
-        help="The inference provider to use for the model",
+        help="The inference provider to use for the model.",
     )
     group.add_argument(
         "--api-base",
         type=str,
-        help="The base URL for the model",
+        help="The base URL for the model.",
     )
     group.add_argument(
         "--api-key",
         type=str,
-        help="The API key for the model",
+        help="The API key for the model.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def interactive_mode():
-    """Run the CLI in interactive mode"""
+    """Run the CLI in interactive mode."""
     console.print(
         Panel.fit(
-            "[bold magenta]🤖 SmolaGents CLI[/]\n[dim]Intelligent agents at your service[/]", border_style="magenta"
+            "[bold magenta]Smolagents CLI[/]\n[dim]Intelligent agents at your service[/]", border_style="magenta"
         )
     )
 
     console.print("\n[bold yellow]Welcome to smolagents![/] Let's set up your agent step by step.\n")
 
-    # Get user input step by step
-    console.print(Rule("[bold yellow]⚙️  Configuration", style="bold yellow"))
+    console.print(Rule("[bold yellow]Configuration", style="bold yellow"))
 
-    # Get agent action type
     action_type = Prompt.ask(
         "[bold white]What action type would you like to use? 'code' or 'tool_calling'?[/]",
         default="code",
         choices=["code", "tool_calling"],
     )
 
-    # Show available tools
-    tools_table = Table(title="[bold yellow]🛠️  Available Tools", show_header=True, header_style="bold yellow")
+    tools_table = Table(title="[bold yellow]Available Tools", show_header=True, header_style="bold yellow")
     tools_table.add_column("Tool Name", style="bold yellow")
     tools_table.add_column("Description", style="white")
 
     for tool_name, tool_class in TOOL_MAPPING.items():
-        # Get description from the tool class if available
         try:
             tool_instance = tool_class()
             description = getattr(tool_instance, "description", "No description available")
@@ -142,33 +350,28 @@ def interactive_mode():
         tools_table.add_row(tool_name, description)
 
     console.print(tools_table)
-    console.print(
-        "\n[dim]You can also use HuggingFace Spaces by providing the full path (e.g., 'username/spacename')[/]"
-    )
+    console.print("\n[dim]You can also use Hugging Face Spaces by providing the full path (e.g., 'username/spacename').[/]")
 
-    console.print("[dim]Enter tool names separated by spaces (e.g., 'web_search python_interpreter')[/]")
+    console.print("[dim]Enter tool names separated by spaces (e.g., 'web_search python_interpreter').[/]")
     tools_input = Prompt.ask("[bold white]Select tools for your agent[/]", default="web_search")
     tools = tools_input.split()
 
-    # Get model configuration
     console.print("\n[bold yellow]Model Configuration:[/]")
     model_type = Prompt.ask(
         "[bold]Model type[/]",
         default="InferenceClientModel",
-        choices=["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel"],
+        choices=["InferenceClientModel", "OpenAIModel", "LiteLLMModel", "TransformersModel"],
     )
 
     model_id = Prompt.ask("[bold white]Model ID[/]", default="Qwen/Qwen2.5-Coder-32B-Instruct")
 
-    # Optional configurations
     provider = None
     api_base = None
     api_key = None
     imports = []
-    action_type = "code"
 
     if Confirm.ask("\n[bold white]Configure advanced options?[/]", default=False):
-        if model_type in ["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel"]:
+        if model_type in ["InferenceClientModel", "OpenAIModel", "LiteLLMModel"]:
             provider = Prompt.ask("[bold white]Provider[/]", default="")
             api_base = Prompt.ask("[bold white]API Base URL[/]", default="")
             api_key = Prompt.ask("[bold white]API Key[/]", default="", password=True)
@@ -177,7 +380,6 @@ def interactive_mode():
         if imports_input:
             imports = imports_input.split()
 
-    # Get prompt
     prompt = Prompt.ask(
         "[bold white]Now the final step; what task would you like the agent to perform?[/]", default=leopard_prompt
     )
@@ -192,7 +394,7 @@ def load_model(
     api_key: str | None = None,
     provider: str | None = None,
 ) -> Model:
-    if model_type == "OpenAIModel":
+    if model_type in {"OpenAIModel", "OpenAIServerModel"}:
         return OpenAIModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
             api_base=api_base or "https://api.fireworks.ai/inference/v1",
@@ -209,15 +411,277 @@ def load_model(
     elif model_type == "InferenceClientModel":
         return InferenceClientModel(
             model_id=model_id,
-            token=api_key or os.getenv("HF_API_KEY"),
+            token=api_key or os.getenv("HF_TOKEN"),
             provider=provider,
         )
     else:
         raise ValueError(f"Unsupported model type: {model_type}")
 
 
+def _resolve_log_level(level: int) -> LogLevel:
+    try:
+        return LogLevel(level)
+    except ValueError as e:
+        raise ValueError(f"Unsupported verbosity level: {level}. Expected one of -1, 0, 1, 2.") from e
+
+
+def _resolve_instruction_path(instruction_path: str, workspace_root: Path) -> Path:
+    path = Path(instruction_path).expanduser()
+    if not path.is_absolute():
+        path = workspace_root / path
+    return path
+
+
+def _load_file_text(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    content = path.read_text(encoding="utf-8").strip()
+    return content if content else None
+
+
+def _build_runtime_contract(run_config: RunConfig) -> str:
+    planning_interval = run_config.planning_interval if run_config.planning_interval is not None else "disabled"
+    return "\n".join(
+        [
+            "Runtime autonomy contract:",
+            f"- Autonomy profile: {run_config.autonomy_profile}",
+            f"- Max steps budget: {run_config.max_steps}",
+            f"- Planning interval: {planning_interval}",
+            f"- Approval policy: {run_config.approval_policy}",
+            f"- Tool retry limit: {run_config.tool_retry_limit}",
+            f"- Stagnation window: {run_config.stagnation_window}",
+            "- At every cycle provide: Objective, Next Action, Validation Check, Completion Signal.",
+            "- If no progress repeats, trigger a recovery re-plan before continuing.",
+            "- If max steps are reached, provide a handoff summary with: attempted actions, blockers, and best next step.",
+        ]
+    )
+
+
+def _build_resume_context(checkpoint_payload: dict[str, Any]) -> str | None:
+    run_state = checkpoint_payload.get("run_state")
+    if not isinstance(run_state, dict):
+        return None
+
+    lines = ["Resume context from previous run:"]
+    if run_state.get("pending_task"):
+        lines.append(f"- Pending task: {run_state['pending_task']}")
+    if run_state.get("completed_action_steps") is not None:
+        lines.append(f"- Completed action steps: {run_state['completed_action_steps']}")
+    if run_state.get("last_plan"):
+        lines.append("- Last plan:")
+        lines.append(str(run_state["last_plan"]))
+
+    memory_summary = run_state.get("memory_summary") or []
+    if memory_summary:
+        lines.append("- Recent memory summary:")
+        for item in memory_summary[:8]:
+            role = item.get("role", "unknown") if isinstance(item, dict) else "unknown"
+            content = item.get("content", "") if isinstance(item, dict) else str(item)
+            lines.append(f"  - {role}: {truncate_content(str(content), max_length=400)}")
+
+    return "\n".join(lines)
+
+
+def _load_instruction_stack(run_config: RunConfig, workspace_root: Path, checkpoint_payload: dict[str, Any] | None) -> str:
+    sections: list[str] = [_build_runtime_contract(run_config)]
+
+    project_agents = workspace_root / "AGENTS.md"
+    project_instructions = _load_file_text(project_agents)
+    if project_instructions:
+        sections.append(f"Project instructions from AGENTS.md:\n{project_instructions}")
+
+    for instruction_path in run_config.instructions_files:
+        path = _resolve_instruction_path(instruction_path, workspace_root)
+        content = _load_file_text(path)
+        if content is None:
+            raise FileNotFoundError(f"Instruction file not found or empty: {path}")
+        sections.append(f"Instructions from {path}:\n{content}")
+
+    memory_path = _resolve_instruction_path(run_config.memory_path, workspace_root)
+    memory_content = _load_file_text(memory_path)
+    if memory_content:
+        sections.append(f"Persistent memory notes:\n{memory_content}")
+
+    if checkpoint_payload:
+        resume_context = _build_resume_context(checkpoint_payload)
+        if resume_context:
+            sections.append(resume_context)
+
+    if run_config.append_instructions:
+        sections.append("Appended runtime instructions:\n" + "\n".join(run_config.append_instructions))
+
+    return "\n\n".join(sections)
+
+
+def _load_checkpoint(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint file not found: {path}")
+    with open(path, encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Checkpoint at {path} must contain a JSON object.")
+    return payload
+
+
+def _save_checkpoint(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def _append_memory_entry(path: Path, checkpoint_payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run_state = checkpoint_payload.get("run_state", {}) if isinstance(checkpoint_payload.get("run_state"), dict) else {}
+    timestamp = datetime.now(timezone.utc).isoformat()
+    final_output = truncate_content(str(checkpoint_payload.get("output")), max_length=1200)
+    last_plan = truncate_content(str(run_state.get("last_plan", "")), max_length=1200)
+    entry = "\n".join(
+        [
+            f"## {timestamp}",
+            f"Task: {checkpoint_payload.get('task', '')}",
+            f"Status: {checkpoint_payload.get('status', 'unknown')}",
+            f"Completed action steps: {run_state.get('completed_action_steps', 'n/a')}",
+            "Final output:",
+            final_output,
+            "Last plan:",
+            last_plan,
+            "",
+        ]
+    )
+
+    if path.exists():
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("\n" + entry)
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("# Smolagent Memory\n\n" + entry)
+
+
+def _matches_schema_type(value: Any, expected_type: str) -> bool:
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "null":
+        return value is None
+    return True
+
+
+def _validate_with_schema(value: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+    expected_type = schema.get("type")
+
+    if expected_type is not None:
+        if isinstance(expected_type, list):
+            if not any(_matches_schema_type(value, one_type) for one_type in expected_type):
+                errors.append(f"{path}: expected one of {expected_type}, got {type(value).__name__}")
+                return errors
+        elif not _matches_schema_type(value, expected_type):
+            errors.append(f"{path}: expected {expected_type}, got {type(value).__name__}")
+            return errors
+
+    enum_values = schema.get("enum")
+    if enum_values is not None and value not in enum_values:
+        errors.append(f"{path}: value {value!r} not in enum {enum_values!r}")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for required_key in required:
+            if required_key not in value:
+                errors.append(f"{path}.{required_key}: required property is missing")
+
+        properties = schema.get("properties", {})
+        additional_properties = schema.get("additionalProperties", True)
+
+        for key, sub_value in value.items():
+            if key in properties:
+                errors.extend(_validate_with_schema(sub_value, properties[key], f"{path}.{key}"))
+            elif additional_properties is False:
+                errors.append(f"{path}.{key}: additional properties are not allowed")
+
+    if isinstance(value, list) and "items" in schema and isinstance(schema["items"], dict):
+        for index, item in enumerate(value):
+            errors.extend(_validate_with_schema(item, schema["items"], f"{path}[{index}]"))
+
+    return errors
+
+
+def _schema_expects_json_value(schema: dict[str, Any]) -> bool:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        return "object" in schema_type or "array" in schema_type
+    return schema_type in {"object", "array"}
+
+
+def _load_final_schema(final_schema_path: str) -> dict[str, Any]:
+    path = Path(final_schema_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Final schema file not found: {path}")
+    with open(path, encoding="utf-8") as f:
+        schema = json.load(f)
+    if not isinstance(schema, dict):
+        raise ValueError("Final schema must be a JSON object")
+    return schema
+
+
+def _build_final_schema_check(schema: dict[str, Any]) -> Callable[..., bool]:
+    def check(final_answer, memory, agent) -> bool:
+        answer_for_validation = final_answer
+        if _schema_expects_json_value(schema) and isinstance(final_answer, str):
+            try:
+                answer_for_validation = json.loads(final_answer)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Final answer must be JSON for schema validation: {e}") from e
+
+        errors = _validate_with_schema(answer_for_validation, schema)
+        if errors:
+            raise ValueError("; ".join(errors[:3]))
+        return True
+
+    return check
+
+
+def _create_json_event_callback() -> Callable[..., None]:
+    def callback(memory_step: MemoryStep, **kwargs):
+        event: dict[str, Any] = {
+            "event": "step",
+            "step_type": memory_step.__class__.__name__,
+        }
+
+        if isinstance(memory_step, ActionStep):
+            event["step_number"] = memory_step.step_number
+            event["is_final_answer"] = memory_step.is_final_answer
+            event["error"] = memory_step.error.dict() if memory_step.error else None
+            event["observations"] = memory_step.observations
+        elif isinstance(memory_step, PlanningStep):
+            event["plan"] = memory_step.plan
+        elif isinstance(memory_step, FinalAnswerStep):
+            event["output"] = memory_step.output
+
+        print(json.dumps(make_json_serializable(event)), flush=True)
+
+    return callback
+
+
+def _model_supports_structured_outputs(model: Model) -> bool:
+    if not isinstance(model, Model):
+        return False
+    if isinstance(model, InferenceClientModel):
+        provider = model.client_kwargs.get("provider")
+        return provider in STRUCTURED_GENERATION_PROVIDERS
+    return True
+
+
 def run_smolagent(
-    prompt: str,
+    prompt: str | None,
     tools: list[str],
     model_type: str,
     model_id: str,
@@ -226,45 +690,126 @@ def run_smolagent(
     imports: list[str] | None = None,
     provider: str | None = None,
     action_type: str = "code",
-) -> None:
+    run_config: RunConfig | None = None,
+) -> Any:
     load_dotenv()
+    run_config = run_config or RunConfig.default()
+    workspace_root = Path.cwd()
+    checkpoint_path = _resolve_instruction_path(run_config.checkpoint_path, workspace_root)
+
+    checkpoint_payload = None
+    if run_config.resume:
+        checkpoint_payload = _load_checkpoint(checkpoint_path)
+        if prompt is None:
+            prompt = checkpoint_payload.get("task")
+
+    if prompt is None:
+        raise ValueError("A prompt is required unless --resume provides one from checkpoint state.")
 
     model = load_model(model_type, model_id, api_base=api_base, api_key=api_key, provider=provider)
 
     available_tools = []
-
     for tool_name in tools:
         if "/" in tool_name:
             space_name = tool_name.split("/")[-1].lower().replace("-", "_").replace(".", "_")
             description = f"Tool loaded from Hugging Face Space: {tool_name}"
             available_tools.append(Tool.from_space(space_id=tool_name, name=space_name, description=description))
+        elif tool_name in TOOL_MAPPING:
+            available_tools.append(TOOL_MAPPING[tool_name]())
         else:
-            if tool_name in TOOL_MAPPING:
-                available_tools.append(TOOL_MAPPING[tool_name]())
-            else:
-                raise ValueError(f"Tool {tool_name} is not recognized either as a default tool or a Space.")
+            raise ValueError(f"Tool {tool_name} is not recognized either as a default tool or a Space.")
+
+    instructions = _load_instruction_stack(run_config, workspace_root, checkpoint_payload)
+
+    final_answer_checks = []
+    if run_config.final_schema_path:
+        schema = _load_final_schema(run_config.final_schema_path)
+        final_answer_checks.append(_build_final_schema_check(schema))
+
+    step_callbacks = None
+    if run_config.json_events:
+        step_callbacks = {MemoryStep: [_create_json_event_callback()]}
+
+    structured_outputs_requested = run_config.use_structured_internal_output
+    structured_outputs_enabled = structured_outputs_requested and _model_supports_structured_outputs(model)
+
+    common_agent_kwargs = {
+        "tools": available_tools,
+        "model": model,
+        "stream_outputs": True,
+        "instructions": instructions,
+        "max_steps": run_config.max_steps,
+        "planning_interval": run_config.planning_interval,
+        "tool_retry_limit": run_config.tool_retry_limit,
+        "stagnation_window": run_config.stagnation_window,
+        "verbosity_level": _resolve_log_level(run_config.verbosity_level),
+        "step_callbacks": step_callbacks,
+        "final_answer_checks": final_answer_checks or None,
+    }
 
     if action_type == "code":
         agent = CodeAgent(
-            tools=available_tools,
-            model=model,
             additional_authorized_imports=imports,
-            stream_outputs=True,
+            use_structured_outputs_internally=structured_outputs_enabled,
+            **common_agent_kwargs,
         )
     elif action_type == "tool_calling":
-        agent = ToolCallingAgent(tools=available_tools, model=model, stream_outputs=True)
+        agent = ToolCallingAgent(**common_agent_kwargs)
     else:
         raise ValueError(f"Unsupported action type: {action_type}")
 
-    agent.run(prompt)
+    output = None
+    run_error: str | None = None
+    try:
+        output = agent.run(prompt)
+        return output
+    except Exception as e:
+        run_error = str(e)
+        raise
+    finally:
+        run_state = agent.get_run_state_snapshot()
+        checkpoint_data = {
+            "version": 1,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "status": "failed" if run_error else "success",
+            "error": run_error,
+            "task": prompt,
+            "action_type": action_type,
+            "model_type": model_type,
+            "model_id": model_id,
+            "tools": tools,
+            "imports": imports or [],
+            "provider": provider,
+            "api_base": api_base,
+            "autonomy_profile": run_config.autonomy_profile,
+            "run_config": {
+                "max_steps": run_config.max_steps,
+                "planning_interval": run_config.planning_interval,
+                "approval_policy": run_config.approval_policy,
+                "tool_retry_limit": run_config.tool_retry_limit,
+                "stagnation_window": run_config.stagnation_window,
+            },
+            "run_state": run_state,
+            "output": make_json_serializable(output),
+        }
+        _save_checkpoint(checkpoint_path, checkpoint_data)
+        memory_path = _resolve_instruction_path(run_config.memory_path, workspace_root)
+        _append_memory_entry(memory_path, checkpoint_data)
+
+        if run_config.json_events:
+            completion_event = {
+                "event": "run_complete",
+                "status": checkpoint_data["status"],
+                "checkpoint_path": str(checkpoint_path),
+            }
+            print(json.dumps(completion_event), flush=True)
 
 
 def main() -> None:
     args = parse_arguments()
+    run_config = RunConfig.from_args(args)
 
-    # Check if we should run in interactive mode
-    # Interactive mode is triggered when no prompt is provided
-    if args.prompt is None:
+    if args.prompt is None and not run_config.resume:
         prompt, tools, model_type, model_id, provider, api_base, api_key, imports, action_type = interactive_mode()
     else:
         prompt = args.prompt
@@ -287,6 +832,7 @@ def main() -> None:
         api_key=api_key,
         imports=imports,
         action_type=action_type,
+        run_config=run_config,
     )
 
 

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -156,16 +156,19 @@ system_prompt: |-
 
   Here are the rules you should always follow to solve your task:
   1. Always provide a 'Thought:' sequence, and a '{{code_block_opening_tag}}' sequence ending with '{{code_block_closing_tag}}', else you will fail.
-  2. Use only variables that you have defined!
-  3. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
-  4. For tools WITHOUT JSON output schema: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
-  5. For tools WITH JSON output schema: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
-  6. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
-  7. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
-  8. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
-  9. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
-  10. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
-  11. Don't give up! You're in charge of solving the task, not providing directions to solve it.
+  2. In every Thought, explicitly include these fields: Objective, Next Action, Validation Check, Completion Signal.
+  3. When progress stalls or observations repeat, run a recovery step: revise your plan before attempting more tool calls.
+  4. If the task cannot be fully completed within step budget, produce the best partial answer plus a concise handoff summary.
+  5. Use only variables that you have defined!
+  6. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
+  7. For tools WITHOUT JSON output schema: Take care to not chain too many sequential tool calls in the same code block, as their output format is unpredictable. For instance, a call to wikipedia_search without a JSON output schema has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
+  8. For tools WITH JSON output schema: You can confidently chain multiple tool calls and directly access structured output fields in the same code block! When a tool has a JSON output schema, you know exactly what fields and data types to expect, allowing you to write robust code that directly accesses the structured response (e.g., result['field_name']) without needing intermediate print() statements.
+  9. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
+  10. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
+  11. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
+  12. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
+  13. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
+  14. Don't give up! You're in charge of solving the task, not providing directions to solve it.
 
   {%- if custom_instructions %}
   {{custom_instructions}}
@@ -229,6 +232,11 @@ planning:
     {{task}}
     ```
     First in part 1, write the facts survey, then in part 2, write your plan.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
   update_plan_pre_messages: |-
     You are a world expert at analyzing a situation, and plan accordingly towards solving a task.
     You have been given the following task:
@@ -258,6 +266,11 @@ planning:
     Beware that you have {remaining_steps} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
 
     You can leverage these tools, behaving like regular python functions:
     ```python
@@ -311,3 +324,8 @@ final_answer:
   post_messages: |-
     Based on the above, please provide an answer to the following user task:
     {{task}}
+    If the task appears incomplete due to step limits, structure your response as:
+    1) Best current answer
+    2) Attempted actions summary
+    3) Blocking issues
+    4) Best next step

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -105,15 +105,18 @@ system_prompt: |-
   {%- endif %}
 
   Here are the rules you should always follow to solve your task:
-  1. Use only variables that you have defined!
-  2. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
-  3. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to wikipedia_search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
-  4. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
-  5. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
-  6. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
-  7. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
-  8. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
-  9. Don't give up! You're in charge of solving the task, not providing directions to solve it.
+  1. In every thought, explicitly include these fields: Objective, Next Action, Validation Check, Completion Signal.
+  2. When progress stalls or observations repeat, run a recovery step: revise your plan before attempting more tool calls.
+  3. If the task cannot be fully completed within step budget, produce the best partial answer plus a concise handoff summary.
+  4. Use only variables that you have defined!
+  5. Always use the right arguments for the tools. DO NOT pass the arguments as a dict as in 'answer = wikipedia_search({'query': "What is the place where James Bond lives?"})', but use the arguments directly as in 'answer = wikipedia_search(query="What is the place where James Bond lives?")'.
+  6. Take care to not chain too many sequential tool calls in the same code block, especially when the output format is unpredictable. For instance, a call to wikipedia_search has an unpredictable return format, so do not have another tool call that depends on its output in the same block: rather output results with print() to use them in the next block.
+  7. Call a tool only when needed, and never re-do a tool call that you previously did with the exact same parameters.
+  8. Don't name any new variable with the same name as a tool: for instance don't name a variable 'final_answer'.
+  9. Never create any notional variables in our code, as having these in your logs will derail you from the true variables.
+  10. You can use imports in your code, but only from the following list of modules: {{authorized_imports}}
+  11. The state persists between code executions: so if in one step you've created variables or imported modules, these will all persist.
+  12. Don't give up! You're in charge of solving the task, not providing directions to solve it.
 
   Now Begin!
 planning:
@@ -173,6 +176,11 @@ planning:
     {{task}}
     ```
     First in part 1, write the facts survey, then in part 2, write your plan.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
   update_plan_pre_messages: |-
     You are a world expert at analyzing a situation, and plan accordingly towards solving a task.
     You have been given the following task:
@@ -202,6 +210,11 @@ planning:
     Beware that you have {remaining_steps} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
 
     You can leverage these tools, behaving like regular python functions:
     ```python
@@ -255,3 +268,8 @@ final_answer:
   post_messages: |-
     Based on the above, please provide an answer to the following user task:
     {{task}}
+    If the task appears incomplete due to step limits, structure your response as:
+    1) Best current answer
+    2) Attempted actions summary
+    3) Blocking issues
+    4) Best next step

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -111,10 +111,13 @@ system_prompt: |-
   {%- endif %}
 
   Here are the rules you should always follow to solve your task:
-  1. ALWAYS provide a tool call, else you will fail.
-  2. Always use the right arguments for the tools. Never use variable names as the action arguments, use the value instead.
-  3. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself. If no tool call is needed, use final_answer tool to return your answer.
-  4. Never re-do a tool call that you previously did with the exact same parameters.
+  1. Before each action, reason using these fields: Objective, Next Action, Validation Check, Completion Signal.
+  2. ALWAYS provide a tool call, else you will fail.
+  3. Always use the right arguments for the tools. Never use variable names as the action arguments, use the value instead.
+  4. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself. If no tool call is needed, use final_answer tool to return your answer.
+  5. Never re-do a tool call that you previously did with the exact same parameters.
+  6. When progress stalls or observations repeat, revise the plan and try a different strategy.
+  7. If step budget is exhausted, return best effort plus a concise handoff summary.
 
   Now Begin!
 planning:
@@ -166,6 +169,11 @@ planning:
     {{task}}
     ```
     First in part 1, write the facts survey, then in part 2, write your plan.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
   update_plan_pre_messages: |-
     You are a world expert at analyzing a situation, and plan accordingly towards solving a task.
     You have been given the following task:
@@ -195,6 +203,11 @@ planning:
     Beware that you have {remaining_steps} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
+    For each plan step, use this schema:
+    - Objective:
+    - Next Action:
+    - Validation Check:
+    - Completion Signal:
 
     You can leverage these tools:
     {%- for tool in tools.values() %}
@@ -240,3 +253,8 @@ final_answer:
   post_messages: |-
     Based on the above, please provide an answer to the following user task:
     {{task}}
+    If the task appears incomplete due to step limits, structure your response as:
+    1) Best current answer
+    2) Attempted actions summary
+    3) Blocking issues
+    4) Best next step

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -414,6 +414,70 @@ print(result)
         )
 
 
+class FakeCodeModelRetry(Model):
+    def __init__(self):
+        self.calls = 0
+
+    def generate(self, messages, stop_sequences=None):
+        self.calls += 1
+        if self.calls == 1:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="""
+Thought: First try fails.
+<code>
+raise RuntimeError("temporary failure")
+</code>
+""",
+            )
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="""
+Thought: Retry succeeded.
+<code>
+final_answer("recovered")
+</code>
+""",
+        )
+
+
+class FakeCodeModelStagnation(Model):
+    def __init__(self):
+        self.plan_calls = 0
+
+    def generate(self, messages, stop_sequences=None):
+        if stop_sequences and "<end_plan>" in stop_sequences:
+            self.plan_calls += 1
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="""
+## 1. Facts survey
+### 1.1. Facts given in the task
+- The task is still unresolved.
+### 1.2. Facts to look up
+- None.
+### 1.3. Facts to derive
+- None.
+
+## 2. Plan
+1. Objective: recover from stagnation
+   Next Action: attempt a new strategy
+   Validation Check: observation changes
+   Completion Signal: useful new evidence appears
+<end_plan>
+""",
+            )
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="""
+Thought: Objective: gather signal. Next Action: print the same marker. Validation Check: compare observation. Completion Signal: observation changes.
+<code>
+print("same_observation")
+</code>
+""",
+        )
+
+
 class TestAgent:
     def test_fake_toolcalling_agent(self):
         agent = ToolCallingAgent(tools=[PythonInterpreterTool()], model=FakeToolCallModel())
@@ -738,13 +802,19 @@ nested_answer()
 
     def test_generation_errors_are_raised(self):
         class FakeCodeModel(Model):
+            def __init__(self):
+                self.calls = 0
+
             def generate(self, messages, stop_sequences=None):
+                self.calls += 1
                 assert False, "Generation failed"
 
-        agent = CodeAgent(model=FakeCodeModel(), tools=[])
+        model = FakeCodeModel()
+        agent = CodeAgent(model=model, tools=[], tool_retry_limit=3)
         with pytest.raises(AgentGenerationError) as e:
             agent.run("Dummy task.")
         assert len(agent.memory.steps) == 2
+        assert model.calls == 1, "Generation failures should not trigger step retries."
         assert "Generation failed" in str(e)
 
     def test_planning_step_with_injected_memory(self):
@@ -819,6 +889,51 @@ nested_answer()
         assert previous_task in conversation_text, "Previous task should be included in the conversation history"
         assert task in conversation_text, "Current task should be included in the conversation history"
         assert "tools" in conversation_text, "Tool interactions should be included in the conversation history"
+
+    def test_stagnation_forces_replanning(self):
+        agent = CodeAgent(
+            tools=[],
+            model=FakeCodeModelStagnation(),
+            max_steps=3,
+            planning_interval=None,
+            stagnation_window=1,
+        )
+        agent.run("keep trying")
+
+        planning_steps = [step for step in agent.memory.steps if isinstance(step, PlanningStep)]
+        assert len(planning_steps) >= 1, "Expected stagnation to trigger at least one planning step."
+
+    def test_retries_recoverable_step_failures(self):
+        agent = CodeAgent(
+            tools=[],
+            model=FakeCodeModelRetry(),
+            max_steps=2,
+            tool_retry_limit=1,
+        )
+        output = agent.run("recover from temporary failure")
+        action_steps = [step for step in agent.memory.steps if isinstance(step, ActionStep)]
+
+        assert output == "recovered"
+        assert len(action_steps) == 2
+        assert action_steps[0].error is not None
+        assert action_steps[1].is_final_answer is True
+        assert action_steps[0].step_number == action_steps[1].step_number == 1
+
+    def test_run_state_snapshot_contains_resume_fields(self):
+        agent = CodeAgent(
+            tools=[],
+            model=FakeCodeModel(),
+            max_steps=2,
+            planning_interval=1,
+        )
+        agent.run("snapshot task")
+        snapshot = agent.get_run_state_snapshot()
+
+        assert snapshot["pending_task"] == "snapshot task"
+        assert snapshot["step_number"] >= 1
+        assert snapshot["completed_action_steps"] >= 1
+        assert isinstance(snapshot["memory_summary"], list)
+        assert "stagnation_state" in snapshot
 
 
 class CustomFinalAnswerTool(FinalAnswerTool):
@@ -1509,6 +1624,8 @@ class TestMultiStepAgent:
             "max_steps": 15,
             "verbosity_level": 2,
             "planning_interval": 3,
+            "tool_retry_limit": 2,
+            "stagnation_window": 4,
             "name": "test_agent",
             "description": "Test agent description",
         }
@@ -1527,6 +1644,8 @@ class TestMultiStepAgent:
         assert agent.max_steps == 15
         assert agent.logger.level == 2
         assert agent.planning_interval == 3
+        assert agent.tool_retry_limit == 2
+        assert agent.stagnation_window == 4
         assert agent.name == "test_agent"
         assert agent.description == "Test agent description"
         # Verify the tool was created correctly
@@ -2091,15 +2210,38 @@ class TestToolCallingAgent:
 
 class TestCodeAgent:
     def test_code_agent_instructions(self):
-        agent = CodeAgent(tools=[], model=MagicMock(), instructions="Test instructions")
-        assert agent.instructions == "Test instructions"
-        assert "Test instructions" in agent.system_prompt
+        layered_instructions = (
+            "Runtime autonomy contract:\\n- Max steps budget: 64\\n- Planning interval: 4\\n\\nLayered note: keep plans concise."
+        )
+        agent = CodeAgent(tools=[], model=MagicMock(), instructions=layered_instructions)
+        assert agent.instructions == layered_instructions
+        assert "Runtime autonomy contract" in agent.system_prompt
+        assert "Layered note: keep plans concise." in agent.system_prompt
 
         agent = CodeAgent(
-            tools=[], model=MagicMock(), instructions="Test instructions", use_structured_outputs_internally=True
+            tools=[], model=MagicMock(), instructions=layered_instructions, use_structured_outputs_internally=True
         )
-        assert agent.instructions == "Test instructions"
-        assert "Test instructions" in agent.system_prompt
+        assert agent.instructions == layered_instructions
+        assert "Runtime autonomy contract" in agent.system_prompt
+        assert "Layered note: keep plans concise." in agent.system_prompt
+
+    def test_handoff_schema_is_present_in_final_answer_prompts(self):
+        expected_sections = [
+            "1) Best current answer",
+            "2) Attempted actions summary",
+            "3) Blocking issues",
+            "4) Best next step",
+        ]
+
+        agents = [
+            CodeAgent(tools=[], model=MagicMock()),
+            CodeAgent(tools=[], model=MagicMock(), use_structured_outputs_internally=True),
+            ToolCallingAgent(tools=[], model=MagicMock()),
+        ]
+        for agent in agents:
+            final_answer_prompt = agent.prompt_templates["final_answer"]["post_messages"]
+            for section in expected_sections:
+                assert section in final_answer_prompt
 
     @pytest.mark.parametrize("provide_run_summary", [False, True])
     def test_call_with_provide_run_summary(self, provide_run_summary):
@@ -2296,6 +2438,8 @@ print("Ok, calculation done!")""")
             "verbosity_level": 2,
             "use_structured_output": False,
             "planning_interval": 3,
+            "tool_retry_limit": 2,
+            "stagnation_window": 3,
             "name": "test_code_agent",
             "description": "Test code agent description",
             "authorized_imports": ["pandas", "numpy"],
@@ -2318,6 +2462,8 @@ print("Ok, calculation done!")""")
         assert agent.executor_type == "local"
         assert agent.executor_kwargs == {"max_print_outputs_length": 10_000}
         assert agent.max_print_outputs_length == 1000
+        assert agent.tool_retry_limit == 2
+        assert agent.stagnation_window == 3
 
         # Test with missing optional parameters
         minimal_agent_dict = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,14 @@
+from dataclasses import replace
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from smolagents.cli import load_model
+from smolagents.cli import RunConfig, interactive_mode, load_model, parse_arguments, run_smolagent
 from smolagents.local_python_executor import CodeOutput, LocalPythonExecutor
-from smolagents.models import InferenceClientModel, LiteLLMModel, OpenAIModel, TransformersModel
+from smolagents.memory import MemoryStep
+from smolagents.models import InferenceClientModel, LiteLLMModel, Model, OpenAIModel, TransformersModel
+from smolagents.monitoring import LogLevel
 
 
 @pytest.fixture
@@ -13,18 +17,28 @@ def set_env_vars(monkeypatch):
     monkeypatch.setenv("HF_TOKEN", "test_hf_api_key")
 
 
+def make_run_config(tmp_path: Path, **kwargs) -> RunConfig:
+    return replace(
+        RunConfig.default(),
+        checkpoint_path=str(tmp_path / "runs" / "latest.json"),
+        memory_path=str(tmp_path / "memory.md"),
+        **kwargs,
+    )
+
+
 def test_load_model_openai_model(set_env_vars):
-    with patch("openai.OpenAI") as MockOpenAI:
+    with patch("openai.OpenAI") as mock_openai:
         model = load_model("OpenAIModel", "test_model_id")
     assert isinstance(model, OpenAIModel)
     assert model.model_id == "test_model_id"
-    assert MockOpenAI.call_count == 1
-    assert MockOpenAI.call_args.kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
-    assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
+    assert mock_openai.call_count == 1
+    assert mock_openai.call_args.kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
+    assert mock_openai.call_args.kwargs["api_key"] == "test_fireworks_api_key"
 
 
 def test_load_model_litellm_model():
-    model = load_model("LiteLLMModel", "test_model_id", api_key="test_api_key", api_base="https://api.test.com")
+    with patch("smolagents.models.LiteLLMModel.create_client", return_value=object()):
+        model = load_model("LiteLLMModel", "test_model_id", api_key="test_api_key", api_base="https://api.test.com")
     assert isinstance(model, LiteLLMModel)
     assert model.api_key == "test_api_key"
     assert model.api_base == "https://api.test.com"
@@ -46,12 +60,12 @@ def test_load_model_transformers_model():
 
 
 def test_load_model_hf_api_model(set_env_vars):
-    with patch("huggingface_hub.InferenceClient") as huggingface_hub_InferenceClient:
+    with patch("huggingface_hub.InferenceClient") as huggingface_hub_inference_client:
         model = load_model("InferenceClientModel", "test_model_id")
     assert isinstance(model, InferenceClientModel)
     assert model.model_id == "test_model_id"
-    assert huggingface_hub_InferenceClient.call_count == 1
-    assert huggingface_hub_InferenceClient.call_args.kwargs["token"] == "test_hf_api_key"
+    assert huggingface_hub_inference_client.call_count == 1
+    assert huggingface_hub_inference_client.call_args.kwargs["token"] == "test_hf_api_key"
 
 
 def test_load_model_invalid_model_type():
@@ -59,36 +73,246 @@ def test_load_model_invalid_model_type():
         load_model("InvalidModel", "test_model_id")
 
 
-def test_cli_main(capsys):
-    with patch("smolagents.cli.load_model") as mock_load_model:
-        mock_load_model.return_value = "mock_model"
-        with patch("smolagents.cli.CodeAgent") as mock_code_agent:
-            from smolagents.cli import run_smolagent
+def test_parse_arguments_defaults_to_long_horizon_profile():
+    args = parse_arguments(["hello"])
+    run_config = RunConfig.from_args(args)
 
-            run_smolagent("test_prompt", [], "InferenceClientModel", "test_model_id", provider="hf-inference")
-    # load_model
-    assert len(mock_load_model.call_args_list) == 1
-    assert mock_load_model.call_args.args == ("InferenceClientModel", "test_model_id")
-    assert mock_load_model.call_args.kwargs == {"api_base": None, "api_key": None, "provider": "hf-inference"}
-    # CodeAgent
-    assert len(mock_code_agent.call_args_list) == 1
-    assert mock_code_agent.call_args.args == ()
-    assert mock_code_agent.call_args.kwargs == {
-        "tools": [],
-        "model": "mock_model",
-        "additional_authorized_imports": None,
-        "stream_outputs": True,
-    }
-    # agent.run
-    assert len(mock_code_agent.return_value.run.call_args_list) == 1
-    assert mock_code_agent.return_value.run.call_args.args == ("test_prompt",)
+    assert run_config.autonomy_profile == "long-horizon"
+    assert run_config.max_steps == 64
+    assert run_config.planning_interval == 4
+    assert run_config.use_structured_internal_output is True
+    assert run_config.tool_retry_limit == 2
+    assert run_config.stagnation_window == 3
+
+
+def test_run_config_flag_precedence_over_profile():
+    args = parse_arguments(
+        [
+            "hello",
+            "--autonomy-profile",
+            "legacy",
+            "--max-steps",
+            "99",
+            "--planning-interval",
+            "7",
+            "--no-use-structured-internal-output",
+            "--tool-retry-limit",
+            "5",
+            "--stagnation-window",
+            "4",
+        ]
+    )
+    run_config = RunConfig.from_args(args)
+
+    assert run_config.autonomy_profile == "legacy"
+    assert run_config.max_steps == 99
+    assert run_config.planning_interval == 7
+    assert run_config.use_structured_internal_output is False
+    assert run_config.tool_retry_limit == 5
+    assert run_config.stagnation_window == 4
+
+
+def test_interactive_mode_keeps_selected_action_type():
+    prompt_answers = ["tool_calling", "web_search", "InferenceClientModel", "test-model", "do a task"]
+    with (
+        patch("smolagents.cli.Prompt.ask", side_effect=prompt_answers),
+        patch("smolagents.cli.Confirm.ask", return_value=False),
+    ):
+        result = interactive_mode()
+
+    assert result[-1] == "tool_calling"
+
+
+def test_run_smolagent_passes_autonomy_and_verbosity_to_agent(tmp_path):
+    run_config = make_run_config(tmp_path)
+    dummy_model = Model(model_id="dummy")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=dummy_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "test_prompt",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        output = run_smolagent(
+            "test_prompt",
+            [],
+            "InferenceClientModel",
+            "test_model_id",
+            provider="hf-inference",
+            run_config=run_config,
+        )
+
+    assert output == "done"
+    assert mock_code_agent.call_args.kwargs["max_steps"] == 64
+    assert mock_code_agent.call_args.kwargs["planning_interval"] == 4
+    assert mock_code_agent.call_args.kwargs["tool_retry_limit"] == 2
+    assert mock_code_agent.call_args.kwargs["stagnation_window"] == 3
+    assert mock_code_agent.call_args.kwargs["verbosity_level"] == LogLevel.INFO
+
+
+def test_run_smolagent_instruction_layering(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("project-guideline", encoding="utf-8")
+    (tmp_path / "extra.md").write_text("extra-guideline", encoding="utf-8")
+    (tmp_path / "memory.md").write_text("memory-guideline", encoding="utf-8")
+
+    run_config = make_run_config(
+        tmp_path,
+        instructions_files=[str(tmp_path / "extra.md")],
+        append_instructions=["inline-guideline"],
+    )
+    dummy_model = Model(model_id="dummy")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=dummy_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "test_prompt",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        run_smolagent("test_prompt", [], "InferenceClientModel", "test_model_id", run_config=run_config)
+
+    instructions = mock_code_agent.call_args.kwargs["instructions"]
+    assert "Runtime autonomy contract" in instructions
+    assert "project-guideline" in instructions
+    assert "extra-guideline" in instructions
+    assert "memory-guideline" in instructions
+    assert "inline-guideline" in instructions
+
+
+def test_run_smolagent_resume_uses_checkpoint_task(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    checkpoint_path = tmp_path / "runs" / "latest.json"
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_path.write_text(
+        '{"task": "resume-task", "run_state": {"completed_action_steps": 2, "memory_summary": []}}',
+        encoding="utf-8",
+    )
+
+    run_config = make_run_config(tmp_path, resume=True)
+    dummy_model = Model(model_id="dummy")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=dummy_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "resume-task",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        run_smolagent(None, [], "InferenceClientModel", "test_model_id", run_config=run_config)
+
+    assert mock_code_agent.return_value.run.call_args.args == ("resume-task",)
+    assert "Resume context from previous run" in mock_code_agent.call_args.kwargs["instructions"]
+
+
+def test_run_smolagent_disables_structured_output_when_backend_not_supported(tmp_path):
+    run_config = make_run_config(tmp_path, use_structured_internal_output=True)
+    inference_model = InferenceClientModel(model_id="test-model", provider=None, token="hf_test")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=inference_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "task",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        run_smolagent("task", [], "InferenceClientModel", "test_model_id", run_config=run_config)
+
+    assert mock_code_agent.call_args.kwargs["use_structured_outputs_internally"] is False
+
+
+def test_run_smolagent_passes_final_schema_check(tmp_path):
+    schema_path = tmp_path / "final-schema.json"
+    schema_path.write_text(
+        '{"type": "object", "required": ["answer"], "properties": {"answer": {"type": "string"}}}',
+        encoding="utf-8",
+    )
+    run_config = make_run_config(tmp_path, final_schema_path=str(schema_path))
+    dummy_model = Model(model_id="dummy")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=dummy_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "task",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        run_smolagent("task", [], "InferenceClientModel", "test_model_id", run_config=run_config)
+
+    checks = mock_code_agent.call_args.kwargs["final_answer_checks"]
+    assert len(checks) == 1
+    check = checks[0]
+    assert check('{"answer": "ok"}', memory=None, agent=None) is True
+    with pytest.raises(ValueError):
+        check('{"wrong": "shape"}', memory=None, agent=None)
+
+
+def test_run_smolagent_json_events_use_memory_step_callbacks(tmp_path):
+    run_config = make_run_config(tmp_path, json_events=True)
+    dummy_model = Model(model_id="dummy")
+
+    with (
+        patch("smolagents.cli.load_model", return_value=dummy_model),
+        patch("smolagents.cli.CodeAgent") as mock_code_agent,
+    ):
+        mock_code_agent.return_value.run.return_value = "done"
+        mock_code_agent.return_value.get_run_state_snapshot.return_value = {
+            "step_number": 1,
+            "completed_action_steps": 1,
+            "pending_task": "task",
+            "last_plan": None,
+            "memory_summary": [],
+        }
+
+        run_smolagent("task", [], "InferenceClientModel", "test_model_id", run_config=run_config)
+
+    step_callbacks = mock_code_agent.call_args.kwargs["step_callbacks"]
+    assert MemoryStep in step_callbacks
+    assert len(step_callbacks[MemoryStep]) == 1
 
 
 def test_vision_web_browser_main():
-    with patch("smolagents.vision_web_browser.helium"):
-        with patch("smolagents.vision_web_browser.load_model") as mock_load_model:
+    pytest.importorskip("helium")
+    pytest.importorskip("selenium")
+    import importlib
+
+    vision_web_browser = importlib.import_module("smolagents.vision_web_browser")
+
+    with patch.object(vision_web_browser, "helium"):
+        with patch.object(vision_web_browser, "load_model") as mock_load_model:
             mock_load_model.return_value = "mock_model"
-            with patch("smolagents.vision_web_browser.CodeAgent") as mock_code_agent:
+            with patch.object(vision_web_browser, "CodeAgent") as mock_code_agent:
                 from smolagents.vision_web_browser import helium_instructions, run_webagent
 
                 run_webagent("test_prompt", "InferenceClientModel", "test_model_id", provider="hf-inference")


### PR DESCRIPTION
Summary
- move the CLI to the long-horizon autonomy profile, wire the new profiling flags, checkpoint/resume controls, instruction layering, and structured-state outputs
- add run-state persistence, stagnation recovery, and bounded retries plus instruction contract updates so agents cycle through plan/execute/validate/repair with machine-readable milestones
- refresh the prompt templates and unit tests to cover runtime contracts, instruction layering, and the new defaults described in the autonomy plan
Testing
- Not run (not requested)