### PR TITLE
fix: handle string content in consecutive same-role messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,19 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            # Normalize string content to list format for merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                text = message.content[0]["text"] if isinstance(message.content, list) else message.content
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] += "\n" + text
+                else:
+                    output_message_list[-1]["content"] += "\n" + text
             else:
+                # Ensure previous message content is also in list format
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones


### PR DESCRIPTION
## Summary

Fixes #1972

`get_clean_message_list()` crashes with `AssertionError` when the message list contains multiple consecutive messages with the same role (e.g. two system messages).

### Root cause

Line 376 in `models.py`:
```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

When messages are created from plain dicts like `{"role": "system", "content": "When you say anything..."}`, `ChatMessage.from_dict()` stores the content as a string. The assertion expects list-format content (e.g., `[{"type": "text", "text": "..."}]`), but string content is valid and common.

### Fix

Instead of asserting, normalize string content to list format before merging:

```python
if isinstance(message.content, str):
    message.content = [{"type": "text", "text": message.content}]
```

Also handle the case where the previous message's content is a string (from `flatten_messages_as_text` mode).

### Reproduction

```python
from smolagents import LiteLLMModel

model = LiteLLMModel(model_id="gemini/gemini-2.5-flash", api_key="...")
messages = [
    {"role": "system", "content": "Start with 'FOO'"},
    {"role": "system", "content": "End with 'BAR'"},
    {"role": "user", "content": "Just say '.'"},
]
response = model(messages)  # Previously: AssertionError
```
