### PR TITLE
fix: don't pass parent kwargs to managed agents in from_dict()

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {


### PR DESCRIPTION
## Summary

Fixes #1849

When deserializing agents with `from_dict()`, the parent agent's `**kwargs` (including `additional_authorized_imports`) were passed to child managed agents via:

```python
managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
```

This caused child agents to lose their custom configurations after deserialization. For example, a child agent with `additional_authorized_imports=["sympy"]` would lose that import because the parent's kwargs (without `sympy`) overwrote it via `code_agent_kwargs.update(kwargs)` in `CodeAgent.from_dict()`.

## Fix

Remove `**kwargs` from the managed agent `from_dict()` call in `MultiStepAgent.from_dict()`:

```python
# Before (buggy)
managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)

# After (fixed)
managed_agent = agent_class.from_dict(managed_agent_dict)
```

Each managed agent's serialized dict already contains all the information needed for its own deserialization — there is no reason to propagate the parent's kwargs down to children.

## Test plan

- [ ] Create a `CodeAgent` with a managed sub-agent that has custom `additional_authorized_imports` (e.g., `["sympy"]`)
- [ ] Serialize with `.to_dict()` and deserialize with `.from_dict()`
- [ ] Verify the sub-agent retains its custom `authorized_imports` after round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)