### PR TITLE
fix: remove duplicate action_step yield and NameError when max_steps=0

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -603,9 +603,8 @@ You have been provided with these additional arguments, that you can access dire
                 yield action_step
                 self.step_number += 1
 
-        if not returned_final_answer and self.step_number == max_steps + 1:
+        if not returned_final_answer:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step


### PR DESCRIPTION
## Summary

Fixes #1816. Two bugs in `_run_stream`:

1. **Duplicate yield**: When `max_steps` is reached, the final `action_step` is yielded twice — once in the `finally` block (line 603) and again on line 608. Stream consumers receive a duplicate step event.

2. **NameError when `max_steps=0`**: The while loop never executes, so `action_step` is never defined, but line 608 tries to yield it.

## Changes

- **Removed** `yield action_step` on line 608 (the duplicate)
- **Simplified** the post-loop condition from `if not returned_final_answer and self.step_number == max_steps + 1` to `if not returned_final_answer`

The `and self.step_number == max_steps + 1` guard was both too narrow (missed `max_steps=0` where `step_number` is `1`) and unnecessary — `returned_final_answer` already captures whether the loop found an answer. If the loop exited without a final answer for *any* reason (max steps, zero steps, etc.), we should call `_handle_max_steps_reached`.

## Test plan

- [ ] Run with `max_steps=0` — no longer raises `NameError`
- [ ] Run with `max_steps=2` and let it exhaust — `action_step` is yielded exactly once per step, not twice on the final step
- [ ] Run normally where the agent finds a final answer — behavior unchanged (`if not returned_final_answer` is `False`, so `_handle_max_steps_reached` is skipped)