### PR TITLE
fix: reset PrintContainer before ast.parse to prevent print leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,14 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
-
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]
 


### PR DESCRIPTION
## Summary

Fixes #1998.

When a `SyntaxError` occurs in step N, print outputs from step N-1 leak into step N's execution logs because `state["_print_outputs"]` is reset **after** `ast.parse()`, not before.

## Root cause

In `evaluate_python_code()`, the state initialization (including `PrintContainer()` reset) happens after the `try: ast.parse(code)` block. When `ast.parse()` raises `SyntaxError`, the `InterpreterError` is raised before `_print_outputs` gets reset, so the previous step's print buffer persists.

## Fix

Move the state initialization block **before** the `ast.parse()` call, so `_print_outputs` is always reset at the start of each step regardless of whether parsing succeeds.

```python
# Before: state init was after ast.parse
# After: state init is before ast.parse (4 lines moved up)
```

**`src/smolagents/local_python_executor.py`** — reorder only, no logic changes.