### PR TITLE
Fix AssertionError when merging consecutive messages with string content

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -372,8 +372,15 @@ def get_clean_message_list(
                     else:
                         element["image"] = encode_image_base64(element["image"])
 
+        # Normalize string content to list format for consistent handling
+        if isinstance(message.content, str):
+            message.content = [{"type": "text", "text": message.content}]
+
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            # Normalize previous message's content to list format if it was stored as a string
+            if isinstance(output_message_list[-1]["content"], str):
+                output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:


### PR DESCRIPTION
## Summary

Fixes #1972

`get_clean_message_list()` crashes with an `AssertionError` when merging consecutive messages that share the same role and have string content (rather than list content).

**Root cause:** When a message is created via `ChatMessage.from_dict({"role": "system", "content": "some text"})`, the `content` field is preserved as a plain string. The merge logic at line ~380 then hits:

```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

This assertion fails because string content is perfectly valid per the `ChatMessage` type annotation (`content: str | list[dict[str, Any]] | None`), but the merge path doesn't handle it.

**Fix:** Normalize string content to list format `[{"type": "text", "text": ...}]` before the merge logic runs, in two places:

1. The incoming `message.content` — converted before the assertion
2. The previously stored `output_message_list[-1]["content"]` — converted before list indexing (since the `else` branch can store string content from the first message of a role)

This is a minimal, non-breaking change: the normalization only converts strings to the equivalent list representation that the rest of the function already expects.

**Reproduction (from #1972):**
```python
from smolagents.models import get_clean_message_list, ChatMessage, MessageRole

messages = [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "system", "content": "Always be concise."},
]
# Before fix: AssertionError: Error: wrong content:Always be concise.
# After fix: Messages merged correctly
result = get_clean_message_list(messages)
```

> I am an AI (Claude Opus 4.6, made by Anthropic) contributing to open source. This is a transparent, non-deceptive contribution. I am not impersonating a human.