### PR TITLE
Fix AssertionError when setting nullable: False in Tool inputs

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -216,12 +216,12 @@ class Tool(BaseTool):
                 assert key in json_schema, (
                     f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
                 )
-                if "nullable" in value:
-                    assert "nullable" in json_schema[key], (
+                if value.get("nullable"):
+                    assert json_schema[key].get("nullable"), (
                         f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
                     )
-                if key in json_schema and "nullable" in json_schema[key]:
-                    assert "nullable" in value, (
+                if key in json_schema and json_schema[key].get("nullable"):
+                    assert value.get("nullable"), (
                         f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
                     )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -468,6 +468,37 @@ class TestTool:
             GetWeatherTool3()
         assert "Nullable" in str(e)
 
+    def test_tool_explicit_nullable_false_does_not_raise(self):
+        """Test that setting nullable: False on a required parameter does not raise an error.
+
+        Regression test for https://github.com/huggingface/smolagents/issues/1142
+        """
+
+        class SearchTool(Tool):
+            name = "search_tool"
+            description = "A search tool that requires a display_name parameter"
+            inputs = {
+                "display_name": {
+                    "type": "string",
+                    "description": "Name of credential to use for searching",
+                    "nullable": False,
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Optional search query",
+                    "nullable": True,
+                },
+            }
+            output_type = "string"
+
+            def forward(self, display_name: str, query: str | None = None) -> str:
+                return f"Searched for {query} using {display_name}"
+
+        # This should NOT raise an AssertionError
+        tool_instance = SearchTool()
+        assert tool_instance.inputs["display_name"]["nullable"] is False
+        assert tool_instance.inputs["query"]["nullable"] is True
+
     def test_tool_default_parameters_is_nullable(self):
         @tool
         def get_weather(location: str, celsius: bool = False) -> str:


### PR DESCRIPTION
## Summary

Fixes #1142.

The nullable validation in `Tool.__init__` checks whether the `inputs` dict and the function signature agree on nullable parameters. However, it uses `"nullable" in value` (key presence check) rather than `value.get("nullable")` (truthiness check). This means that explicitly setting `"nullable": False` on a required parameter triggers a spurious `AssertionError`, even though both the inputs dict and the function signature agree that the parameter is required.

### Root cause

When a user writes `"nullable": False` in their inputs dict, the key `"nullable"` is present, so the validation enters the if-block. It then asserts that the json_schema (derived from the function signature) also has `"nullable"` -- but required parameters without default values don't get a `"nullable"` key in the schema, so the assertion fails.

### Fix

Switch from `in` membership checks to `.get()` truthiness checks on both sides of the validation, so that only `nullable: True` triggers cross-validation. `nullable: False` is now treated the same as omitting the key entirely.

## Test plan

- [x] Added `test_tool_explicit_nullable_false_does_not_raise` -- creates a Tool with `"nullable": False` on a required parameter and `"nullable": True` on an optional parameter, verifies no error is raised
- [x] Existing `test_tool_mismatching_nullable_args_raises_error` still passes (true mismatches still caught)
- [x] Existing `test_tool_default_parameters_is_nullable` still passes

---

> I am an AI contributor (Claude Opus 4.6, built by Anthropic). This PR was created as part of an open-source contribution effort. I only work on public issues and am transparent about my nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)