### PR TITLE
docs: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ import os
 from smolagents import OpenAIModel
 
 model = OpenAIModel(
-    model_id="MiniMax-M1",
+    model_id="MiniMax-M2.7",
     api_base="https://api.minimax.io/v1",
     api_key=os.environ["MINIMAX_API_KEY"],
 )

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ model = OpenAIModel(
 
 </details>
 <details>
+<summary> <b>OpenAI-compatible servers: MiniMax</b></summary>
+
+```py
+import os
+from smolagents import OpenAIModel
+
+model = OpenAIModel(
+    model_id="MiniMax-M1",
+    api_base="https://api.minimax.io/v1",
+    api_key=os.environ["MINIMAX_API_KEY"],
+)
+```
+
+</details>
+<details>
 <summary> <b>Local `transformers` model</b></summary>
 
 ```py

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ import os
 from smolagents import OpenAIModel
 
 model = OpenAIModel(
-    model_id="MiniMax-M2.7",
+    model_id="MiniMax-M3",
     api_base="https://api.minimax.io/v1",
     api_key=os.environ["MINIMAX_API_KEY"],
 )

--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -83,12 +83,16 @@ model = OpenAIModel(
 [MiniMax](https://www.minimax.io/) provides powerful language models through an OpenAI-compatible API,
 allowing you to use the [`OpenAIModel`] class directly.
 
+Available models:
+- `MiniMax-M2.7` — Latest flagship model with enhanced reasoning and coding
+- `MiniMax-M2.7-highspeed` — High-speed version of M2.7 for low-latency scenarios
+
 First, install the required dependencies:
 ```bash
 pip install 'smolagents[openai]'
 ```
 
-Then, [get a MiniMax API key](https://platform.minimax.chat/) and set it in your code:
+Then, [get a MiniMax API key](https://platform.minimax.io/) and set it in your code:
 ```python
 MINIMAX_API_KEY = <YOUR-MINIMAX-API-KEY>
 ```
@@ -98,7 +102,7 @@ Now, you can initialize MiniMax models using the `OpenAIModel` class:
 from smolagents import OpenAIModel
 
 model = OpenAIModel(
-    model_id="MiniMax-M1",
+    model_id="MiniMax-M2.7",
     api_base="https://api.minimax.io/v1",
     api_key=MINIMAX_API_KEY,
 )

--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -78,6 +78,32 @@ model = OpenAIModel(
 )
 ```
 
+## Using MiniMax Models
+
+[MiniMax](https://www.minimax.io/) provides powerful language models through an OpenAI-compatible API,
+allowing you to use the [`OpenAIModel`] class directly.
+
+First, install the required dependencies:
+```bash
+pip install 'smolagents[openai]'
+```
+
+Then, [get a MiniMax API key](https://platform.minimax.chat/) and set it in your code:
+```python
+MINIMAX_API_KEY = <YOUR-MINIMAX-API-KEY>
+```
+
+Now, you can initialize MiniMax models using the `OpenAIModel` class:
+```python
+from smolagents import OpenAIModel
+
+model = OpenAIModel(
+    model_id="MiniMax-M1",
+    api_base="https://api.minimax.io/v1",
+    api_key=MINIMAX_API_KEY,
+)
+```
+
 ## Using xAI's Grok Models
 
 xAI's Grok models can be accessed through [`LiteLLMModel`].

--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -84,7 +84,8 @@ model = OpenAIModel(
 allowing you to use the [`OpenAIModel`] class directly.
 
 Available models:
-- `MiniMax-M2.7` — Latest flagship model with enhanced reasoning and coding
+- `MiniMax-M3` — Latest flagship model with 512K context, 128K max output, and image input support
+- `MiniMax-M2.7` — Previous-generation model with enhanced reasoning and coding
 - `MiniMax-M2.7-highspeed` — High-speed version of M2.7 for low-latency scenarios
 
 First, install the required dependencies:
@@ -102,7 +103,7 @@ Now, you can initialize MiniMax models using the `OpenAIModel` class:
 from smolagents import OpenAIModel
 
 model = OpenAIModel(
-    model_id="MiniMax-M2.7",
+    model_id="MiniMax-M3",
     api_base="https://api.minimax.io/v1",
     api_key=MINIMAX_API_KEY,
 )


### PR DESCRIPTION
## Summary
- Upgrade MiniMax default model from M2.7 to MiniMax-M3 in README and docs
- Keep MiniMax-M2.7 and MiniMax-M2.7-highspeed as available alternatives
- Set MiniMax-M3 (512K context, 128K max output, image input support) as the new default

## Changes
- `README.md`: Update model_id in MiniMax example code snippet to MiniMax-M3
- `docs/source/en/examples/using_different_models.md`: Add MiniMax-M3 to the available models list, mark it as the latest flagship, and update the example model_id

## Why
MiniMax-M3 is the latest flagship model, with a 512K context window, up to 128K output, and image input support. M2.7 remains available as a fallback for users who prefer the previous generation.

## Testing
- Docs-only change, no code logic affected
- Verified all MiniMax references are updated consistently