### PR TITLE
fix(models): handle string content when merging consecutive same-role messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,21 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+            # Normalize string content to list format for merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                prev_content = output_message_list[-1]["content"]
+                if isinstance(prev_content, str):
+                    output_message_list[-1]["content"] = prev_content + "\n" + message.content[0]["text"]
+                else:
+                    output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:
+                prev_content = output_message_list[-1]["content"]
+                if isinstance(prev_content, str):
+                    # Previous message had plain string content; convert to list first
+                    output_message_list[-1]["content"] = [{"type": "text", "text": prev_content}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
@@ -385,7 +396,7 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = message.content if isinstance(message.content, str) else message.content[0]["text"]
             else:
                 content = message.content
             output_message_list.append(


### PR DESCRIPTION
## Problem

`LiteLLMModel` (and any `ApiModel` subclass) fails with an `AssertionError` when the input message list contains multiple consecutive messages with the same role (e.g., two `system` messages in a row):

```python
messages = [
    {"role": "system", "content": "When you say anything Start with 'FOO'"},
    {"role": "system", "content": "When you say anything End with 'BAR'"},
    {"role": "user", "content": "Just say '.'"},
]
response = model(messages)  # AssertionError: Error: wrong content: ...
```

The `prepare_completion_kwargs()` helper in `models.py` merges consecutive same-role messages but asserts that `message.content` is a list before merging. When messages are provided with plain string content (the common dict format), this assertion fails.

## Fix

- Normalize string content to `[{"type": "text", "text": ...}]` before merging
- Handle the case where the **previous** output message also has plain string content
- Fix `flatten_messages_as_text` path to handle string content gracefully

Fixes #1972