### PR TITLE
fix(executor): reset _print_outputs before ast.parse to prevent prior-step log leak on SyntaxError

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,18 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    # Initialize state and reset print buffer BEFORE parsing.  When ast.parse()
+    # raises SyntaxError the except branch re-raises as InterpreterError without
+    # ever reaching the original reset below, so the previous step's print
+    # output leaks into the agent's error-handling path (which reads
+    # state["_print_outputs"] directly after catching InterpreterError).
+    if state is None:
+        state = {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1631,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]


### PR DESCRIPTION
## Problem

When the agent executes code that has a `SyntaxError`, the previous step's print output appears in the error observation for the failing step.

**Root cause:** In `evaluate_python_code`, `state["_print_outputs"] = PrintContainer()` is only reached *after* `ast.parse(code)`. When `ast.parse` raises `SyntaxError`, the function re-raises it as `InterpreterError` before the reset — leaving the old buffer intact. The agent's exception handler in `agents.py` then reads `self.python_executor.state["_print_outputs"]` directly, which still holds the previous step's output.

```python
# BEFORE (buggy order):
try:
    expression = ast.parse(code)    # SyntaxError exits here!
except SyntaxError as e:
    raise InterpreterError(...)      # ← never reaches reset below

if state is None: state = {}
state["_print_outputs"] = PrintContainer()  # ← never reached on SyntaxError!
```

## Fix

Move the state initialization (including `_print_outputs` reset) to before `ast.parse()`:

```python
# AFTER (correct order):
if state is None: state = {}
state["_print_outputs"] = PrintContainer()  # ← always reset first

try:
    expression = ast.parse(code)
except SyntaxError as e:
    raise InterpreterError(...)  # state already clean
```

## Reproducer

```python
agent.run(
    "Step 1: print('hello from step 1')\n"
    "Step 2: write code with a syntax error (e.g. `def foo(:`)"
)
# Before fix: Step 2 error shows 'hello from step 1' in logs
# After fix: Step 2 error shows empty logs
```

Fixes #1998