### PR TITLE
Fix action_type being overwritten in interactive mode

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -165,7 +165,6 @@ def interactive_mode():
     api_base = None
     api_key = None
     imports = []
-    action_type = "code"
 
     if Confirm.ask("\n[bold white]Configure advanced options?[/]", default=False):
         if model_type in ["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel"]:


### PR DESCRIPTION
In interactive_mode() in cli.py, the user picks action_type via Prompt.ask (code or tool_calling), but a few lines below there's a hardcoded action_type = "code" that overwrites the choice. Because of this, selecting          
  tool_calling in interactive mode never actually works — the agent always runs as CodeAgent.
                                                                                                                                                                                                                                    
The fix is just removing that redundant assignment so the user's selection is actually used.                                                                                                                                      
                                                                                                                                                                                                                                  
This bug has been there since the feature was introduced in 4dbab6d