### PR TITLE
fix(agents): do not forward parent kwargs to managed agents in from_dict

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,13 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            # Do NOT forward **kwargs here. kwargs contain the *parent* agent's
+            # parameters (e.g. additional_authorized_imports). Passing them down
+            # would override the child's own serialized configuration, causing
+            # settings such as authorized_imports to be silently discarded after
+            # deserialization. Each managed agent is fully self-contained in its
+            # own serialized dict and reconstructs itself from that alone.
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {


### PR DESCRIPTION
## Summary

Fixes #1849

`MultiStepAgent.from_dict()` was passing `**kwargs` (which contains parent-level parameters like `additional_authorized_imports`) to each managed-agent `agent_class.from_dict()` call. Inside `CodeAgent.from_dict()` those kwargs were then merged via `code_agent_kwargs.update(kwargs)`, silently overriding the child agent's own serialized configuration.

Concretely: a sub-agent with `additional_authorized_imports=["sympy"]` lost the `"sympy"` import after deserialization because the parent agent's (empty) `authorized_imports` were written on top of it, causing `AgentExecutionError: Import of 'sympy' is not allowed` at runtime.

## Root Cause

```python
# MultiStepAgent.from_dict() — line ~1043
managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)  # ← leaks parent kwargs

# CodeAgent.from_dict() — line ~1802
code_agent_kwargs.update(kwargs)  # ← parent kwargs overwrite child's own config
```

## Fix

Stop forwarding `**kwargs` to managed agents. Every managed agent is fully described by its own serialized dict (including its model), so it does not need the parent's kwargs to reconstruct itself correctly.

```python
managed_agent = agent_class.from_dict(managed_agent_dict)  # no kwargs
```