### PR TITLE
fix(agents): remove duplicate action_step yield in _run_stream and fix NameError when max_steps=0

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -605,7 +605,11 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
+            # Do NOT yield action_step here: it was already yielded inside the
+            # finally block of the while loop. A second yield would send a
+            # duplicate event to stream consumers.
+            # (When max_steps=0 the loop never ran at all, so action_step is
+            # undefined — yielding it would raise NameError.)
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step


### PR DESCRIPTION
## Summary

Fixes #1816

Two bugs in `MultiStepAgent._run_stream()`:

### Bug 1 — Duplicate yield when max_steps is reached

The `finally` block inside the while loop already yields `action_step`:
```python
finally:
    ...
    yield action_step   # ← first yield
    self.step_number += 1
```
After the loop exits, the max-steps guard also yielded it:
```python
if not returned_final_answer and self.step_number == max_steps + 1:
    final_answer = self._handle_max_steps_reached(task)
    yield action_step   # ← duplicate yield — BUG
```
Stream consumers received the final step's `ActionStep` twice.

### Bug 2 — NameError when `max_steps=0`

When `max_steps=0` the while condition (`step_number <= 0`) is `False` from the start, so the body never executes and `action_step` is never defined. The max-steps guard condition (`1 == 0+1`) still evaluates to `True` and the code attempts `yield action_step`, raising `NameError: local variable 'action_step' referenced before assignment`.

## Fix

Remove the redundant `yield action_step` from the max-steps guard block. The `action_step` for the last completed step has already been emitted by the `finally` block. When `max_steps=0` there is no `action_step` to emit.