### PR TITLE
Fix encode_image_base64 to handle string file paths (fixes #2088)

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -30,6 +30,7 @@ from logging import Logger
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Callable
+from PIL import Image
 
 import jinja2
 
@@ -428,6 +429,11 @@ def get_source(obj) -> str:
 
 
 def encode_image_base64(image):
+      if isinstance(image, str):
+        try:
+            image = Image.open(image)
+        except Exception as e:
+            raise ValueError(f"Could not open image: {image}. Error: {e}")
     buffered = BytesIO()
     image.save(buffered, format="PNG")
     return base64.b64encode(buffered.getvalue()).decode("utf-8")


### PR DESCRIPTION
## Problem
GradioUI throws AttributeError: 'str' object has no attribute 'save'  when uploading images. 

The root cause is in encode_image_base64() in utils.py — the function  assumes the image argument is always a PIL Image object, but when files  are uploaded through GradioUI, _process_message() passes file paths as  strings instead of PIL Images.

## Solution
Added isinstance check in encode_image_base64() to detect when a string  path is passed instead of a PIL Image, and convert it using Image.open()  before proceeding.

Also added from PIL import Image to utils.py imports. PIL/Pillow is already  a required core dependency in pyproject.toml so this is safe.

## Safety considerations
- try/except around Image.open() gives a clear ValueError if the path is  invalid, corrupted, or unreadable — instead of a confusing crash
- PIL is a guaranteed dependency so no new requirements added
- The fix is minimal — only encode_image_base64 is changed
- Does not affect behavior when a PIL Image is passed directly
- Responsibility for handling unsupported image inputs remains with the LLM/API

## Related
Fixes #2088