### PR TITLE
feat(tools): Add PerplexitySearchTool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ telemetry = [
 ]
 toolkit = [
   "ddgs>=9.0.0",  # DuckDuckGoSearchTool
+  "httpx",  # PerplexitySearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 transformers = [

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -638,6 +638,68 @@ class SpeechToTextTool(PipelineTool):
         return self.pre_processor.batch_decode(outputs, skip_special_tokens=True)[0]
 
 
+class PerplexitySearchTool(Tool):
+    """Web search tool that performs searches using the Perplexity Search API.
+
+    Args:
+        api_key (`str`, *optional*): API key for Perplexity. If not provided, falls back to `PERPLEXITY_API_KEY` env var.
+
+    Examples:
+        ```python
+        >>> from smolagents import PerplexitySearchTool
+        >>> search_tool = PerplexitySearchTool()
+        >>> results = search_tool("latest AI developments")
+        >>> print(results)
+        ```
+    """
+
+    name = "web_search_perplexity"
+    description = """Performs a web search using the Perplexity Search API based on your query then returns the top search results."""
+    inputs = {
+        "query": {"type": "string", "description": "The search query to perform."},
+        "max_results": {
+            "type": "integer",
+            "description": "Maximum number of search results to return",
+            "nullable": True,
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None):
+        super().__init__()
+        import os
+
+        self.api_key = api_key or os.environ.get("PERPLEXITY_API_KEY")
+        if self.api_key is None:
+            raise ValueError(
+                "Missing API key. Provide 'api_key' or set the 'PERPLEXITY_API_KEY' environment variable."
+            )
+
+    def forward(self, query: str, max_results: int | None = None) -> str:
+        import httpx
+
+        if max_results is None:
+            max_results = 5
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "X-Source": "smolagents",
+        }
+        payload = {"query": query, "max_results": max_results}
+        response = httpx.post("https://api.perplexity.ai/search", json=payload, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        results = data.get("results", [])
+        if not results:
+            return "No results found."
+        postprocessed_results = []
+        for idx, result in enumerate(results, start=1):
+            postprocessed_results.append(
+                f"[{idx}] {result.get('title', 'No title')}\n    URL: {result.get('url', 'N/A')}\n    {result.get('snippet', 'No snippet')}"
+            )
+        return "\n\n".join(postprocessed_results)
+
+
 TOOL_MAPPING = {
     tool_class.name: tool_class
     for tool_class in [
@@ -646,6 +708,7 @@ TOOL_MAPPING = {
         VisitWebpageTool,
     ]
 }
+TOOL_MAPPING["perplexity_search"] = PerplexitySearchTool
 
 __all__ = [
     "ApiWebSearchTool",
@@ -655,6 +718,7 @@ __all__ = [
     "WebSearchTool",
     "DuckDuckGoSearchTool",
     "GoogleSearchTool",
+    "PerplexitySearchTool",
     "VisitWebpageTool",
     "WikipediaSearchTool",
     "SpeechToTextTool",

--- a/tests/test_perplexity_search.py
+++ b/tests/test_perplexity_search.py
@@ -1,0 +1,117 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolagents.default_tools import TOOL_MAPPING, PerplexitySearchTool
+
+
+class TestPerplexitySearchToolInit:
+    def test_init_with_explicit_api_key(self):
+        tool = PerplexitySearchTool(api_key="test-key-123")
+        assert tool.api_key == "test-key-123"
+
+    def test_init_from_env_var(self, monkeypatch):
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "env-key-456")
+        tool = PerplexitySearchTool()
+        assert tool.api_key == "env-key-456"
+
+    def test_init_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="Missing API key"):
+            PerplexitySearchTool()
+
+    def test_explicit_key_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "env-key")
+        tool = PerplexitySearchTool(api_key="explicit-key")
+        assert tool.api_key == "explicit-key"
+
+
+class TestPerplexitySearchToolMapping:
+    def test_perplexity_search_in_mapping(self):
+        assert "perplexity_search" in TOOL_MAPPING
+        assert TOOL_MAPPING["perplexity_search"] is PerplexitySearchTool
+
+
+class TestPerplexitySearchToolForward:
+    @patch("httpx.post")
+    def test_forward_returns_formatted_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "abc-123",
+            "results": [
+                {
+                    "title": "First Result",
+                    "url": "https://example.com/1",
+                    "snippet": "This is the first result.",
+                    "date": "2024-12-15",
+                },
+                {
+                    "title": "Second Result",
+                    "url": "https://example.com/2",
+                    "snippet": "This is the second result.",
+                    "date": "2024-12-16",
+                },
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = PerplexitySearchTool(api_key="test-key")
+        result = tool.forward("test query", max_results=2)
+
+        mock_post.assert_called_once_with(
+            "https://api.perplexity.ai/search",
+            json={"query": "test query", "max_results": 2},
+            headers={
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+                "X-Source": "smolagents",
+            },
+            timeout=30,
+        )
+        assert "[1] First Result" in result
+        assert "URL: https://example.com/1" in result
+        assert "This is the first result." in result
+        assert "[2] Second Result" in result
+        assert "URL: https://example.com/2" in result
+        assert "This is the second result." in result
+
+    @patch("httpx.post")
+    def test_forward_empty_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "abc-123", "results": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = PerplexitySearchTool(api_key="test-key")
+        result = tool.forward("empty query")
+
+        assert result == "No results found."
+
+    @patch("httpx.post")
+    def test_forward_default_max_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "abc-123", "results": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = PerplexitySearchTool(api_key="test-key")
+        tool.forward("test query")
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["max_results"] == 5
+
+    @patch("httpx.post")
+    def test_forward_raises_on_http_error(self, mock_post):
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=MagicMock()
+        )
+        mock_post.return_value = mock_response
+
+        tool = PerplexitySearchTool(api_key="test-key")
+        with pytest.raises(httpx.HTTPStatusError):
+            tool.forward("test query")


### PR DESCRIPTION
Adds a `PerplexitySearchTool` that wraps the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart) (`POST /search`), returning ranked web search results. Registered in `TOOL_MAPPING` as `"perplexity_search"`.

### Usage
```python
from smolagents import CodeAgent, PerplexitySearchTool

agent = CodeAgent(tools=[PerplexitySearchTool()])
agent.run("What are the latest developments in AI?")
```