### PR TITLE
test: Add regression test for threading.Lock with statement

### DIFF
--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1098,6 +1098,23 @@ assert cm.exited == True
     """
         evaluate_python_code(code, {}, state={})
 
+    def test_with_threading_lock(self):
+        """Test that threading.Lock works correctly with the with statement.
+
+        This is a regression test for GitHub issue #2090.
+        threading.Lock().__enter__() returns a boolean (True), not the lock itself,
+        so we need to ensure __exit__ is called on the original lock object.
+        """
+        code = """
+import threading
+lock = threading.Lock()
+with lock:
+    x = 1
+x
+"""
+        result, _ = evaluate_python_code(code, {}, state={}, authorized_imports=["threading"])
+        assert result == 1
+
     def test_with_exception_suppressed_by_exit(self):
         """Test that __exit__ returning True suppresses the exception."""
         code = """


### PR DESCRIPTION
This PR adds a regression test for GitHub issue #2090.

## Summary
The bug in `evaluate_with` was already fixed in commit 563dae8, where `__exit__` was being called on the return value of `__enter__` instead of the original context manager object. This caused issues with context managers like `threading.Lock` where `__enter__` returns a boolean rather than the lock itself.

## Changes
- Added `test_with_threading_lock` to verify `threading.Lock` works correctly with the `with` statement

## Related Issue
Fixes #2090 (test coverage)