### PR TITLE
fix(utils): handle file paths in encode_image_base64

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -428,6 +428,10 @@ def get_source(obj) -> str:
 
 
 def encode_image_base64(image):
+    if isinstance(image, str):
+        from PIL import Image
+
+        image = Image.open(image)
     buffered = BytesIO()
     image.save(buffered, format="PNG")
     return base64.b64encode(buffered.getvalue()).decode("utf-8")


### PR DESCRIPTION
**Problem**
GradioUI throws an error when uploading images (fixes #2088).

When images are uploaded via GradioUI, they are saved to a folder and their file paths (strings) are passed to the agent. However, `encode_image_base64` expected PIL Image objects, causing:
```
AttributeError: 'str' object has no attribute 'save'
```

**Solution**
Modified `encode_image_base64` in `src/smolagents/utils.py` to handle both:
- PIL Image objects (original behavior)
- File paths as strings (new behavior - loads the image using PIL.Image.open)

**Testing**
- Existing tests pass (test_get_clean_message_list_image_encoding)
- Manually verified that both PIL Image objects and file paths work correctly
- Verified the fix resolves the GradioUI image upload issue

**Changes**
- 4 lines added to `encode_image_base64` function
- No breaking changes to existing functionality