### PR TITLE
Add Anthropic prompt caching support (90% input cost savings)

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -767,6 +767,14 @@ You have been provided with these additional arguments, that you can access dire
         messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
         for memory_step in self.memory.steps:
             messages.extend(memory_step.to_messages(summary_mode=summary_mode))
+
+        # Add cache_control to the last message's last content block.
+        # This enables Anthropic prompt caching on the growing conversation prefix,
+        # so only new tokens after the last cache breakpoint are billed at full price.
+        # For non-Anthropic providers, litellm strips unknown keys automatically.
+        if messages and isinstance(messages[-1].content, list) and messages[-1].content:
+            messages[-1].content[-1]["cache_control"] = {"type": "ephemeral"}
+
         return messages
 
     def _step_stream(

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -203,7 +203,18 @@ class SystemPromptStep(MemoryStep):
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         if summary_mode:
             return []
-        return [ChatMessage(role=MessageRole.SYSTEM, content=[{"type": "text", "text": self.system_prompt}])]
+        return [
+            ChatMessage(
+                role=MessageRole.SYSTEM,
+                content=[
+                    {
+                        "type": "text",
+                        "text": self.system_prompt,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            )
+        ]
 
 
 @dataclass

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -232,6 +232,23 @@ def test_system_prompt_step_to_messages():
             assert "text" in content
 
 
+def test_system_prompt_step_has_cache_control():
+    """Test that system prompt content blocks include cache_control for Anthropic prompt caching."""
+    system_prompt_step = SystemPromptStep(system_prompt="This is a system prompt.")
+    messages = system_prompt_step.to_messages(summary_mode=False)
+    assert len(messages) == 1
+    content_block = messages[0].content[0]
+    assert "cache_control" in content_block
+    assert content_block["cache_control"] == {"type": "ephemeral"}
+
+
+def test_system_prompt_step_summary_mode_returns_empty():
+    """Test that summary mode still returns empty list (cache_control shouldn't affect this)."""
+    system_prompt_step = SystemPromptStep(system_prompt="This is a system prompt.")
+    messages = system_prompt_step.to_messages(summary_mode=True)
+    assert messages == []
+
+
 def test_memory_step_json_serialization():
     """Test that memory steps can be JSON serialized without raw fields."""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -793,6 +793,40 @@ def test_get_clean_message_list_image_encoding(convert_images_to_image_urls, exp
         assert result[0] == expected_clean_message
 
 
+def test_get_clean_message_list_preserves_cache_control():
+    """Test that cache_control on content blocks is preserved through get_clean_message_list."""
+    messages = [
+        ChatMessage(
+            role=MessageRole.SYSTEM,
+            content=[{"type": "text", "text": "System prompt", "cache_control": {"type": "ephemeral"}}],
+        ),
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello!"}]),
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in result[1]["content"][0]
+
+
+def test_get_clean_message_list_preserves_cache_control_on_merge():
+    """Test that cache_control survives when consecutive same-role messages are merged."""
+    messages = [
+        ChatMessage(
+            role=MessageRole.SYSTEM,
+            content=[{"type": "text", "text": "Part 1", "cache_control": {"type": "ephemeral"}}],
+        ),
+        ChatMessage(
+            role=MessageRole.SYSTEM,
+            content=[{"type": "text", "text": "Part 2"}],
+        ),
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 1
+    # The merged block should retain cache_control from the first block
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert "Part 1\nPart 2" in result[0]["content"][0]["text"]
+
+
 def test_get_clean_message_list_flatten_messages_as_text():
     messages = [
         ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello!"}]),


### PR DESCRIPTION
Adds cache_control headers to system prompt and the last user message in Anthropic API calls, enabling prompt caching. This can reduce input token costs by up to 90% on multi-turn conversations since the system prompt and conversation history get cached across calls.