### PR TITLE
fix(executors): register signal handlers in DockerExecutor to prevent orphaned containers

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -21,6 +21,7 @@ import os
 import pickle
 import re
 import secrets
+import signal
 import subprocess
 import tempfile
 import time
@@ -667,9 +668,26 @@ class DockerExecutor(RemotePythonExecutor):
                 f"Container {self.container.short_id} is running with kernel {self.kernel_id}", level=LogLevel.INFO
             )
 
+            # Register signal handlers to cleanup on unexpected exit
+            self._original_sigint_handler = signal.signal(signal.SIGINT, self._signal_handler)
+            self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._signal_handler)
+
         except Exception as e:
             self.cleanup()
             raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
+
+    def _signal_handler(self, signum, frame):
+        """Handle SIGINT and SIGTERM signals by cleaning up the container."""
+        self.logger.log(f"Received signal {signum}, cleaning up container...", level=LogLevel.INFO)
+        self.cleanup()
+        # Restore original signal handlers
+        if hasattr(self, '_original_sigint_handler'):
+            signal.signal(signal.SIGINT, self._original_sigint_handler)
+        if hasattr(self, '_original_sigterm_handler'):
+            signal.signal(signal.SIGTERM, self._original_sigterm_handler)
+        # Exit cleanly
+        import sys
+        sys.exit(0)
 
     def run_code_raise_errors(self, code: str) -> CodeOutput:
         """
@@ -697,6 +715,16 @@ class DockerExecutor(RemotePythonExecutor):
                 del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")
+        finally:
+            # Restore original signal handlers
+            try:
+                if hasattr(self, "_original_sigint_handler"):
+                    signal.signal(signal.SIGINT, self._original_sigint_handler)
+                if hasattr(self, "_original_sigterm_handler"):
+                    signal.signal(signal.SIGTERM, self._original_sigterm_handler)
+            except Exception:
+                # Ignore errors when restoring signal handlers (e.g., if not in main thread)
+                pass
 
     def delete(self):
         """Ensure cleanup on deletion."""

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -261,6 +261,89 @@ class TestDockerExecutorUnit:
             mock_container.stop.assert_called_once()
             mock_container.remove.assert_called_once()
 
+    def test_signal_handlers_registered_on_init(self):
+        """Test that SIGINT and SIGTERM handlers are registered on initialization."""
+        logger = MagicMock()
+        with (
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+            patch("signal.signal") as mock_signal,
+        ):
+            # Setup mocks
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+
+            # Track registered signal handlers
+            registered_handlers = {}
+
+            def mock_signal_handler(sig, handler):
+                registered_handlers[sig] = handler
+
+            mock_signal.side_effect = mock_signal_handler
+
+            # Create executor
+            executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+
+            # Verify signal handlers were registered
+            import signal
+
+            assert signal.SIGINT in registered_handlers, "SIGINT handler should be registered"
+            assert signal.SIGTERM in registered_handlers, "SIGTERM handler should be registered"
+            assert registered_handlers[signal.SIGINT] == executor._signal_handler
+            assert registered_handlers[signal.SIGTERM] == executor._signal_handler
+
+            executor.cleanup()
+
+    def test_signal_handler_calls_cleanup(self):
+        """Test that the signal handler properly cleans up the container on signal."""
+        logger = MagicMock()
+        with (
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+            patch("sys.exit") as mock_exit,
+        ):
+            # Setup mocks
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+
+            # Create executor
+            executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+
+            # Verify container exists before signal
+            assert hasattr(executor, "container")
+
+            import signal
+
+            # Call signal handler directly (simulating SIGINT)
+            executor._signal_handler(signal.SIGINT, None)
+
+            # Verify cleanup was called (container should be stopped and removed)
+            mock_container.stop.assert_called_once()
+            mock_container.remove.assert_called_once()
+
+            # Verify sys.exit was called
+            mock_exit.assert_called_once_with(0)
+
 
 class CommonDockerExecutorIntegration:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Docker containers created by DockerExecutor were not being cleaned up when scripts stopped unexpectedly (SIGINT/SIGTERM), leaving orphaned containers that block port 8888.

Register SIGINT and SIGTERM signal handlers during initialization that trigger cleanup when the process receives these signals. Original handlers are stored and restored during cleanup to avoid side effects.

Includes tests for signal handler registration and behavior.

Fixes #2050