### PR TITLE
fix(utils): handle file paths in encode_image_base64

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -428,6 +428,10 @@ def get_source(obj) -> str:
 
 
 def encode_image_base64(image):
+    from PIL import Image
+
+    if isinstance(image, str):
+        image = Image.open(image)
     buffered = BytesIO()
     image.save(buffered, format="PNG")
     return base64.b64encode(buffered.getvalue()).decode("utf-8")


### PR DESCRIPTION
Fixes #2088

**Problem**
GradioUI throws an error when uploading images because it passes file paths as strings, but encode_image_base64 expected PIL Image objects.

**Root cause**
When users upload images through the Gradio UI, file paths are passed to the agent and eventually reach encode_image_base64, which called .save() on the string path, causing AttributeError: 'str' object has no attribute 'save'.

**Fix**
Modified encode_image_base64 in src/smolagents/utils.py to check if the input is a string (file path) and load it as a PIL Image before encoding.

**Testing**
- Verified the fix works with both PIL Image objects and file path strings
- Both produce identical base64 output
- Existing image encoding tests pass