### PR TITLE
fix: skip empty assistant messages in ActionStep.to_messages

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -91,7 +91,7 @@ class ActionStep(MemoryStep):
 
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         messages = []
-        if self.model_output is not None and not summary_mode:
+        if self.model_output is not None and self.model_output.strip() and not summary_mode:
             messages.append(
                 ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.model_output.strip()}])
             )

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -91,9 +91,10 @@ class ActionStep(MemoryStep):
 
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         messages = []
-        if self.model_output is not None and self.model_output.strip() and not summary_mode:
+        stripped = self.model_output.strip() if self.model_output is not None else ""
+        if stripped and not summary_mode:
             messages.append(
-                ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.model_output.strip()}])
+                ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": stripped}])
             )
 
         if self.tool_calls is not None:


### PR DESCRIPTION
When the model returns only tool calls (no text), model_output is set to empty string. Since '' is not None, an assistant message with empty text was created, which Bedrock's Converse API rejects.

Add a truthiness check on stripped content so empty/whitespace-only strings are skipped. This is safe because the message already calls .strip() on the text, and an empty assistant message carries no information.