### PR TITLE
fix(docker): add atexit/signal handlers to prevent orphaned containers

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atexit
 import base64
 import inspect
 import json
@@ -21,6 +22,7 @@ import os
 import pickle
 import re
 import secrets
+import signal as _signal
 import subprocess
 import tempfile
 import time
@@ -667,6 +669,10 @@ class DockerExecutor(RemotePythonExecutor):
                 f"Container {self.container.short_id} is running with kernel {self.kernel_id}", level=LogLevel.INFO
             )
 
+            # Регистрируем обработчики для гарантированной очистки контейнера при завершении процесса
+            atexit.register(self._cleanup_container)
+            _signal.signal(_signal.SIGTERM, lambda s, f: self._cleanup_container())
+
         except Exception as e:
             self.cleanup()
             raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
@@ -686,15 +692,31 @@ class DockerExecutor(RemotePythonExecutor):
         with closing(create_connection(self.ws_url)) as ws:
             return _websocket_run_code_raise_errors(code, ws, self.logger, self.allow_pickle)
 
+    def _cleanup_container(self):
+        """Безопасно останавливает и удаляет контейнер Docker.
+
+        Вызывается через atexit, обработчик SIGTERM и __del__ для предотвращения
+        появления осиротевших контейнеров при аварийном завершении процесса.
+        """
+        if getattr(self, "container", None) is not None:
+            try:
+                self.container.stop(timeout=5)
+                self.container.remove(force=True)
+            except Exception:
+                pass
+            self.container = None
+
+    def __del__(self):
+        """Запасной вариант очистки при уничтожении объекта сборщиком мусора."""
+        self._cleanup_container()
+
     def cleanup(self):
         """Clean up the Docker container and resources."""
         try:
-            if hasattr(self, "container"):
+            if hasattr(self, "container") and self.container is not None:
                 self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)
-                self.container.stop()
-                self.container.remove()
+                self._cleanup_container()
                 self.logger.log("Container cleanup completed", level=LogLevel.INFO)
-                del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")
 


### PR DESCRIPTION
Fixes #2050

## Problem

`DockerExecutor` leaves orphaned containers that block port 8888 when the host script crashes or is killed via SIGTERM. The existing `cleanup()` method is never called automatically in these scenarios.

## Fix

Added three layers of defensive cleanup to `DockerExecutor`:

1. **`atexit.register(self._cleanup_container)`** — runs on normal process exit, unhandled exceptions, and `sys.exit()`.
2. **`signal.signal(SIGTERM, ...)`** — handles `docker stop` / `kill -15` gracefully.
3. **`__del__`** — last-resort fallback when the object is garbage-collected.

A new internal `_cleanup_container()` method performs an idempotent stop+remove with a 5-second timeout, sets `self.container = None` afterwards to prevent double-removal, and swallows all exceptions so it never breaks interpreter shutdown.

The existing public `cleanup()` method now delegates to `_cleanup_container()` to keep the logic in one place.