### PR TITLE
feat(retry): honour Retry-After header when retrying rate-limit errors

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -525,6 +525,39 @@ class RateLimiter:
         self._last_call = time.time()
 
 
+def get_retry_after_seconds(exception: BaseException) -> float | None:
+    """Extract the Retry-After wait time (in seconds) from a rate-limit exception.
+
+    Many API providers include a ``Retry-After`` header (or a ``retry_after``
+    attribute) in their 429 responses.  Honouring it avoids unnecessary long
+    waits from exponential backoff while also not retrying too soon.
+
+    Returns the number of seconds to wait, or ``None`` if the information is
+    not available.
+    """
+    # Some SDK exceptions expose the header value directly
+    for attr in ("retry_after", "retry_after_seconds"):
+        value = getattr(exception, attr, None)
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                pass
+
+    # httpx / requests: look inside the response object
+    response = getattr(exception, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", {}) or {}
+        raw = headers.get("Retry-After") or headers.get("retry-after")
+        if raw is not None:
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                pass
+
+    return None
+
+
 class Retrying:
     """Simple retrying controller. Inspired from library [tenacity](https://github.com/jd/tenacity/)."""
 
@@ -538,6 +571,7 @@ class Retrying:
         reraise: bool = False,
         before_sleep_logger: tuple[Logger, int] | None = None,
         after_logger: tuple[Logger, int] | None = None,
+        respect_retry_after_header: bool = True,
     ):
         self.max_attempts = max_attempts
         self.wait_seconds = wait_seconds
@@ -547,6 +581,7 @@ class Retrying:
         self.reraise = reraise
         self.before_sleep_logger = before_sleep_logger
         self.after_logger = after_logger
+        self.respect_retry_after_header = respect_retry_after_header
 
     def __call__(self, fn, *args: Any, **kwargs: Any) -> Any:
         start_time = time.time()
@@ -592,13 +627,21 @@ class Retrying:
                 # https://cookbook.openai.com/examples/how_to_handle_rate_limits#example-3-manual-backoff-implementation
                 delay *= self.exponential_base * (1 + self.jitter * random.random())
 
+                # If the API tells us exactly how long to wait, honour that instead
+                # of the computed backoff value.  This avoids both retrying too soon
+                # (which would just get another 429) and waiting unnecessarily long.
+                if self.respect_retry_after_header:
+                    retry_after = get_retry_after_seconds(e)
+                    if retry_after is not None:
+                        delay = retry_after
+
                 # Log before sleeping
                 if self.before_sleep_logger:
                     logger, log_level = self.before_sleep_logger
                     fn_name = getattr(fn, "__name__", repr(fn))
                     logger.log(
                         log_level,
-                        f"Retrying {fn_name} in {delay} seconds as it raised {e.__class__.__name__}: {e}.",
+                        f"Retrying {fn_name} in {delay:.1f} seconds as it raised {e.__class__.__name__}: {e}.",
                     )
 
                 # Sleep before next attempt


### PR DESCRIPTION
## Description

`smolagents` already implements exponential-backoff retry for 429 / rate-limit errors via the `Retrying` class in `utils.py`.  However, it ignores the `Retry-After` header that most API providers (OpenAI, Anthropic, HuggingFace Inference, etc.) include in their 429 responses.

Ignoring the header leads to two failure modes:

| Scenario | Current behaviour | Impact |
|---|---|---|
| `Retry-After: 5s`, computed backoff = 60s | waits 60s | 12× slower than needed |
| `Retry-After: 120s`, computed backoff = 60s | retries after 60s | immediately gets another 429 → wastes an attempt |

## Changes

### `src/smolagents/utils.py`

1. **`get_retry_after_seconds(exception)`** — new helper that extracts the server-specified wait time from:
   - `exception.retry_after` / `exception.retry_after_seconds` attributes (SDK-specific)
   - `exception.response.headers["Retry-After"]` (httpx / requests style)

2. **`Retrying.__init__`** — new `respect_retry_after_header: bool = True` parameter (opt-out available)

3. **Retry sleep logic** — when `respect_retry_after_header=True` and the server provides a wait time, use that instead of the exponential backoff value

## Example

```python
# Before: always waits RETRY_WAIT * 2^n seconds regardless of server hint
# After: respects server hint when available
from smolagents import InferenceClientModel
model = InferenceClientModel("meta-llama/Meta-Llama-3.1-8B-Instruct")
# If HF Inference API returns Retry-After: 10, retrier now waits 10s instead of 60s
```

## Backward Compatibility

- Fully backward compatible: `respect_retry_after_header=True` is the new default (safest behaviour)
- Pass `respect_retry_after_header=False` to restore the old pure exponential-backoff behaviour
