### PR TITLE
Propagate contextvars in timeout decorator

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -25,6 +25,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from contextvars import copy_context
 from dataclasses import dataclass
 from functools import wraps
 from importlib import import_module
@@ -306,7 +307,8 @@ def timeout(timeout_seconds: int):
         def wrapper(*args, **kwargs):
             # Create a new ThreadPoolExecutor for each call to avoid threading issues
             with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(func, *args, **kwargs)
+                ctx = copy_context()
+                future = executor.submit(ctx.run, func, *args, **kwargs)
                 try:
                     result = future.result(timeout=timeout_seconds)
                     return result

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2313,6 +2313,19 @@ result = "completed"
         output = executor(code)
         assert output.output == "completed"
 
+    def test_timeout_decorator_preserves_contextvars(self):
+        """Test that contextvars from the caller are visible inside the timeout thread."""
+        from contextvars import ContextVar
+
+        test_var = ContextVar("test_var", default=None)
+        test_var.set("from_parent")
+
+        @timeout(5)
+        def read_context():
+            return test_var.get()
+
+        assert read_context() == "from_parent"
+
 
 @pytest.mark.parametrize(
     "module,authorized_imports,expected",


### PR DESCRIPTION
Fixes #1961

The `timeout` decorator in `local_python_executor.py` uses a `ThreadPoolExecutor` that doesn't propagate `contextvars` to the worker thread. This means OpenTelemetry span context gets lost when `CodeAgent` runs tools, so tool spans show up as disconnected root spans instead of being nested under the agent step.

The fix uses `copy_context()` before submitting to the executor — same pattern that's already used in `ToolCallingAgent` at `agents.py:1429`.

Added a test that sets a `ContextVar` before calling a `@timeout`-wrapped function and checks it's visible inside.