### PR TITLE
fix(models): handle Azure GPT-5 stop detection

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -430,8 +430,10 @@ def supports_stop_parameter(model_id: str) -> bool:
     model_name = model_id.split("/")[-1]
     if model_name == "o3-mini":
         return True
-    # o3* (except mini), o4*, all grok-* models, and the gpt-5* family (including versioned variants) don't support stop parameter
-    openai_model_pattern = r"(o3(?:$|[-.].*)|o4(?:$|[-.].*)|gpt-5.*)"
+    # o3* (except mini), o4*, all grok-* models, and the GPT-5 family
+    # (including Azure deployments that omit the dash, such as "gpt5.1")
+    # don't support the stop parameter.
+    openai_model_pattern = r"(o3(?:$|[-.].*)|o4(?:$|[-.].*)|gpt-?5.*)"
     grok_model_pattern = r"([A-Za-z][A-Za-z0-9_-]*\.)?grok-[A-Za-z0-9][A-Za-z0-9_.-]*"
     pattern = rf"^({openai_model_pattern}|{grok_model_pattern})$"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -144,6 +144,8 @@ class TestModel:
             ("regular-model", ["stop1", "stop2"], True),  # Regular model should include stop
             ("openai/o3", ["stop1", "stop2"], False),  # o3 model should not include stop
             ("openai/o4-mini", ["stop1", "stop2"], False),  # o4-mini model should not include stop
+            ("gpt5.1", ["stop1", "stop2"], False),  # Azure-style GPT-5 deployment names should not include stop
+            ("azure/gpt5.1", ["stop1", "stop2"], False),  # Prefixed Azure-style deployment names should not include stop
             ("something/else/o3", ["stop1", "stop2"], False),  # Path ending with o3 should not include stop
             ("something/else/o4-mini", ["stop1", "stop2"], False),  # Path ending with o4-mini should not include stop
             ("o3", ["stop1", "stop2"], False),  # Exact o3 model should not include stop
@@ -862,9 +864,13 @@ def test_flatten_messages_as_text_for_all_models(
         ("o3", False),
         ("o4-mini", False),
         ("gpt-5.1", False),
+        ("gpt5.1", False),
         ("gpt-5.2", False),
+        ("gpt5.2", False),
         ("gpt-5", False),
+        ("gpt5", False),
         ("gpt-5-mini", False),
+        ("gpt5-mini", False),
         ("gpt-5-nano", False),
         ("gpt-5-turbo", False),
         ("gpt-5.2-mini", False),
@@ -883,6 +889,7 @@ def test_flatten_messages_as_text_for_all_models(
         ("openai/o3-2025-04-16", False),
         ("openai/o4-mini-2025-04-16", False),
         ("openai/gpt-5.2", False),
+        ("azure/gpt5.1", False),
         ("openai/gpt-5.2-mini", False),
         ("openai/gpt-5.2-2025-01-01", False),
         ("oci/xai.grok-4", False),


### PR DESCRIPTION
Treat Azure-style GPT-5 deployment names such as `gpt5.1` as stop-incompatible.
Add regression coverage for both stop-parameter detection and completion kwargs.
Fixes #554