### PR TITLE
Fix stale print outputs on syntax errors

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,11 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1620,12 +1625,8 @@ def evaluate_python_code(
             f"{' ' * (e.offset or 0)}^"
         )
 
-    if state is None:
-        state = {}
     static_tools = static_tools.copy() if static_tools is not None else {}
     custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1378,6 +1378,17 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_clears_previous_print_outputs(self):
+        state = {}
+        evaluate_python_code("print('old output')", BASE_PYTHON_TOOLS, state=state)
+        assert state["_print_outputs"].value == "old output\n"
+
+        with pytest.raises(InterpreterError) as e:
+            evaluate_python_code("print('new output')\ndef bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        assert "SyntaxError" in str(e.value)
+        assert state["_print_outputs"].value == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Summary
- reset `_print_outputs` and `_operations_count` before parsing code
- prevent syntax errors from leaking print output from a previous run when reusing state
- add a regression test for the stale print output case

Fixes #1998

## Testing
- `PYTHONPATH=src pytest tests/test_local_python_executor.py -k 'syntax_error or print_output'`
- `PYTHONPATH=src pytest tests/test_agents.py -k 'error_saves_previous_print_outputs or syntax_error_show_offending_lines'`
