### PR TITLE
fix(models): handle string content when merging consecutive same-role messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,6 +373,17 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+            # Normalise plain-string content to list format so the merge logic below
+            # works uniformly regardless of whether the caller supplied strings or
+            # structured lists.  Models like LiteLLMModel pass raw strings, not the
+            # [{\"type\": \"text\", \"text\": ...}] format, which previously caused an
+            # AssertionError when two consecutive system (or user) messages were provided.
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
+            if isinstance(output_message_list[-1]["content"], str):
+                output_message_list[-1]["content"] = [
+                    {"type": "text", "text": output_message_list[-1]["content"]}
+                ]
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]


### PR DESCRIPTION
## Problem

Fixes #1972

When a caller passes two consecutive messages with the same role (e.g. two system messages), `get_clean_message_list()` tries to merge them. The merge path asserts that `message.content` is a list:

```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

But `LiteLLMModel` (and other callers) may pass messages with **plain string** content:

```python
messages = [
    {"role": "system", "content": "When you say anything Start with 'FOO""},
    {"role": "system", "content": "When you say anything End with 'BAR""},
    {"role": "user", "content": "Just say '.""},
]
model(messages)  # → AssertionError: Error: wrong content: When you say anything...
```

## Solution

Before entering the merge block, normalise plain-string `content` on **both** the incoming message and the last entry already in `output_message_list` to the structured `[{"type": "text", "text": ...}]` form. The rest of the merge logic is untouched.

```python
if isinstance(message.content, str):
    message.content = [{"type": "text", "text": message.content}]
if isinstance(output_message_list[-1]["content"], str):
    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
```

## Testing

```python
from smolagents.models import get_clean_message_list

messages = [
    {"role": "system", "content": "Instruction A"},
    {"role": "system", "content": "Instruction B"},
    {"role": "user",   "content": "Hello"},
]
result = get_clean_message_list(messages)  # no longer raises AssertionError
assert len(result) == 2  # system messages merged, user message kept
assert "Instruction A" in result[0]["content"][0]["text"]
assert "Instruction B" in result[0]["content"][0]["text"]
```