### PR TITLE
feat: add Agoragentic marketplace example — agent-to-agent capability router

### DIFF
--- a/examples/agoragentic_marketplace.py
+++ b/examples/agoragentic_marketplace.py
@@ -23,7 +23,7 @@ Run:
 import json
 import os
 
-from smolagents import CodeAgent, HfApiModel, Tool
+from smolagents import CodeAgent, InferenceClientModel, Tool
 
 
 # ─── Tool 1: execute() — Route any task to the best provider ──
@@ -65,11 +65,16 @@ class AgoragenticExecuteTool(Tool):
         if not key:
             return json.dumps({"error": "Set AGORAGENTIC_API_KEY environment variable"})
 
+        try:
+            parsed_input = json.loads(input_json) if input_json else {}
+        except (json.JSONDecodeError, TypeError):
+            parsed_input = {}
+
         resp = requests.post(
             "https://agoragentic.com/api/execute",
             json={
                 "task": task,
-                "input": json.loads(input_json) if input_json else {},
+                "input": parsed_input,
                 "constraints": {"max_cost": max_cost},
             },
             headers={
@@ -154,10 +159,11 @@ class AgoragenticSearchTool(Tool):
 
 # ─── Run ──────────────────────────────────────────────────────
 
+
 if __name__ == "__main__":
     agent = CodeAgent(
         tools=[AgoragenticExecuteTool(), AgoragenticSearchTool()],
-        model=HfApiModel(),
+        model=InferenceClientModel(),
     )
 
     # The agent will search the marketplace, find the best provider,


### PR DESCRIPTION
## Agoragentic Marketplace Example

Adds a self-contained example showing how to give any smolagents `CodeAgent` access to 200+ AI capabilities through the [Agoragentic marketplace](https://agoragentic.com).

### What the example demonstrates

1. **`AgoragenticExecuteTool`** — Route any task to the best provider automatically. The marketplace scores providers by trust, price, latency, and capability, then invokes the winner. Payment is automatic in USDC on Base L2.

2. **`AgoragenticSearchTool`** — Browse 200+ capabilities across 20+ categories (AI services, data, devtools, etc.)

### How it works

`
Your smolagent  ->  execute('summarize this text')
                          |
                    Agoragentic Router
                          |
               Matches best provider (scored by
               trust, price, latency, capability)
                          |
               Invokes provider, settles USDC on Base L2
                          |
                    Returns result
`

### Setup

`ash
pip install smolagents requests
export AGORAGENTIC_API_KEY='amk_your_key'
python examples/agoragentic_marketplace.py
`

Get a free API key:
`ash
curl -X POST https://agoragentic.com/api/quickstart \
  -H 'Content-Type: application/json' \
  -d '{"name":"my-smolagent","type":"buyer"}'
`

### Additional integrations

Full 10-tool integration library (execute, match, search, invoke, vault, memory, secrets, passport) available at:
https://github.com/rhein1/agoragentic-integrations/tree/main/smolagents

### Links

- [Agoragentic Marketplace](https://agoragentic.com)
- [API Docs](https://agoragentic.com/SKILL.md)
- [OpenAPI Spec](https://agoragentic.com/openapi.yaml)
- [All Framework Integrations](https://github.com/rhein1/agoragentic-integrations) — LangChain, CrewAI, MCP, AutoGen, OpenAI Agents, Google ADK, and 15+ more