### PR TITLE
fix: reset print outputs before ast.parse to prevent leakage on syntax errors

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]


### PR DESCRIPTION
## Summary
- Move `state["_print_outputs"] = PrintContainer()` and other state initialization before `ast.parse(code)`
- Prevents print output from a previous execution step leaking into the error output when a `SyntaxError` occurs

## Problem
When `ast.parse()` raises a `SyntaxError`, the function exited before resetting `state["_print_outputs"]`. The stale `PrintContainer` from the previous step was still in `state`, so any print output from that earlier step appeared in the current step's error output.

## Test plan
- [ ] Verify existing tests pass
- [ ] Execute code with print statements, then execute code with a syntax error — confirm the error output does not include the previous step's print output

Fixes #1998