### PR TITLE
Add CRW web scraping tools

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -643,6 +643,281 @@ class WikipediaSearchTool(Tool):
             return f"Error fetching Wikipedia summary: {str(e)}"
 
 
+class CrwScrapeTool(Tool):
+    """Web scraping tool that uses a CRW server (Firecrawl-compatible API) to scrape
+    a single webpage and return its content as clean markdown.
+
+    CRW is an open-source web scraper for AI agents that provides high-quality
+    content extraction with optional JavaScript rendering.
+
+    Args:
+        api_url (`str`): Base URL of the CRW server. Defaults to ``http://localhost:3000``.
+        api_key (`str`, *optional*): Bearer token for authentication. Falls back to the
+            ``CRW_API_KEY`` environment variable.
+        only_main_content (`bool`, default `True`): Strip navigation, footer, and sidebar.
+        formats (`list[str]`, *optional*): Output formats (``markdown``, ``html``,
+            ``plainText``, ``links``). Defaults to ``["markdown"]``.
+
+    Examples:
+        ```python
+        >>> from smolagents import CrwScrapeTool
+        >>> scrape_tool = CrwScrapeTool(api_url="http://localhost:3000")
+        >>> result = scrape_tool("https://example.com")
+        >>> print(result)
+        ```
+    """
+
+    name = "crw_scrape"
+    description = (
+        "Scrapes a single webpage using a CRW server and returns its content as clean markdown. "
+        "CRW handles JavaScript-rendered pages, strips boilerplate (nav, footer, ads), and "
+        "converts the result to clean markdown. Use this instead of visit_webpage when you need "
+        "higher-quality content extraction."
+    )
+    inputs = {
+        "url": {
+            "type": "string",
+            "description": "The URL of the webpage to scrape.",
+        },
+        "css_selector": {
+            "type": "string",
+            "description": "Optional CSS selector to extract only matching elements.",
+            "nullable": True,
+        },
+    }
+    output_type = "string"
+
+    def __init__(
+        self,
+        api_url: str = "http://localhost:3000",
+        api_key: str | None = None,
+        only_main_content: bool = True,
+        formats: list[str] | None = None,
+        max_output_length: int = 40000,
+    ):
+        super().__init__()
+        import os
+
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key or os.getenv("CRW_API_KEY")
+        self.only_main_content = only_main_content
+        self.formats = formats or ["markdown"]
+        self.max_output_length = max_output_length
+
+    def forward(self, url: str, css_selector: str | None = None) -> str:
+        import requests
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        payload: dict = {
+            "url": url,
+            "formats": self.formats,
+            "onlyMainContent": self.only_main_content,
+        }
+        if css_selector:
+            payload["cssSelector"] = css_selector
+
+        try:
+            response = requests.post(
+                f"{self.api_url}/v1/scrape",
+                json=payload,
+                headers=headers,
+                timeout=60,
+            )
+            response.raise_for_status()
+        except requests.exceptions.Timeout:
+            return "The CRW scrape request timed out. Try again or check the CRW server."
+        except requests.exceptions.RequestException as e:
+            return f"Error calling CRW scrape API: {e}"
+
+        data = response.json()
+        if not data.get("success"):
+            return f"CRW scrape failed: {data.get('error', 'Unknown error')}"
+
+        result_data = data.get("data", {})
+        content = (
+            result_data.get("markdown")
+            or result_data.get("html")
+            or result_data.get("plainText")
+            or ""
+        )
+
+        # If no text content was found, try to format links
+        if not content:
+            links = result_data.get("links")
+            if links:
+                if isinstance(links, list):
+                    lines = []
+                    for link in links:
+                        if isinstance(link, dict):
+                            url_value = link.get("url") or ""
+                            text_value = link.get("text") or link.get("title") or url_value
+                            if url_value:
+                                lines.append(f"- [{text_value}]({url_value})")
+                        else:
+                            lines.append(str(link))
+                    content = "\n".join(lines)
+                else:
+                    content = str(links)
+
+        metadata = result_data.get("metadata", {})
+        title = metadata.get("title", "")
+        header = f"## {title}\nSource: {url}\n\n" if title else f"Source: {url}\n\n"
+
+        full_content = header + content
+        if self.max_output_length and len(full_content) > self.max_output_length:
+            truncation_notice = f"\n..._Content truncated to {self.max_output_length} characters_...\n"
+            available_length = max(self.max_output_length - len(truncation_notice), 0)
+            full_content = full_content[:available_length] + truncation_notice
+        return full_content
+
+
+class CrwCrawlTool(Tool):
+    """Web crawling tool that uses a CRW server (Firecrawl-compatible API) to crawl
+    a website starting from a URL and return content from multiple pages.
+
+    This tool starts an asynchronous crawl job, polls for completion, and returns
+    the aggregated markdown content from all crawled pages.
+
+    Args:
+        api_url (`str`): Base URL of the CRW server. Defaults to ``http://localhost:3000``.
+        api_key (`str`, *optional*): Bearer token for authentication. Falls back to the
+            ``CRW_API_KEY`` environment variable.
+        max_depth (`int`, default `2`): Maximum link-follow depth.
+        max_pages (`int`, default `10`): Maximum number of pages to crawl.
+        poll_interval (`float`, default `2.0`): Seconds between status checks.
+        poll_timeout (`float`, default `120.0`): Maximum seconds to wait for crawl completion.
+
+    Examples:
+        ```python
+        >>> from smolagents import CrwCrawlTool
+        >>> crawl_tool = CrwCrawlTool(api_url="http://localhost:3000", max_pages=5)
+        >>> result = crawl_tool("https://example.com")
+        >>> print(result)
+        ```
+    """
+
+    name = "crw_crawl"
+    description = (
+        "Crawls a website starting from the given URL using a CRW server and returns markdown "
+        "content from multiple pages. Use this when you need to gather information from several "
+        "pages of a website, not just a single page."
+    )
+    inputs = {
+        "url": {
+            "type": "string",
+            "description": "The starting URL to crawl from.",
+        },
+        "max_pages": {
+            "type": "integer",
+            "description": "Maximum number of pages to crawl. Defaults to 10.",
+            "nullable": True,
+        },
+    }
+    output_type = "string"
+
+    def __init__(
+        self,
+        api_url: str = "http://localhost:3000",
+        api_key: str | None = None,
+        max_depth: int = 2,
+        max_pages: int = 10,
+        poll_interval: float = 2.0,
+        poll_timeout: float = 120.0,
+        max_output_length: int = 40000,
+    ):
+        super().__init__()
+        import os
+
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key or os.getenv("CRW_API_KEY")
+        self.max_depth = max_depth
+        self.max_pages = max_pages
+        self.poll_interval = poll_interval
+        self.poll_timeout = poll_timeout
+        self.max_output_length = max_output_length
+
+    def forward(self, url: str, max_pages: int | None = None) -> str:
+        import time
+
+        import requests
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        payload = {
+            "url": url,
+            "maxDepth": self.max_depth,
+            "maxPages": max_pages if max_pages is not None else self.max_pages,
+            "formats": ["markdown"],
+            "onlyMainContent": True,
+        }
+
+        # Start the crawl job
+        try:
+            response = requests.post(
+                f"{self.api_url}/v1/crawl",
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            return f"Error starting CRW crawl: {e}"
+
+        data = response.json()
+        if not data.get("success"):
+            return f"CRW crawl failed to start: {data.get('error', 'Unknown error')}"
+
+        crawl_id = data["id"]
+
+        # Poll for completion
+        start_time = time.time()
+        while time.time() - start_time < self.poll_timeout:
+            time.sleep(self.poll_interval)
+            try:
+                status_response = requests.get(
+                    f"{self.api_url}/v1/crawl/{crawl_id}",
+                    headers=headers,
+                    timeout=15,
+                )
+                status_response.raise_for_status()
+            except requests.exceptions.RequestException as e:
+                return f"Error checking crawl status: {e}"
+
+            status_data = status_response.json()
+            status = status_data.get("status")
+
+            if status == "completed":
+                return self._format_crawl_results(status_data, url)
+            elif status == "failed":
+                return f"CRW crawl failed for {url}."
+
+        return f"CRW crawl timed out after {self.poll_timeout}s. Crawl ID: {crawl_id}"
+
+    def _format_crawl_results(self, status_data: dict, start_url: str) -> str:
+        pages = status_data.get("data", [])
+        total = status_data.get("total", len(pages))
+
+        parts = [f"## Crawl Results for {start_url}\nPages crawled: {total}\n"]
+        for page in pages:
+            metadata = page.get("metadata", {})
+            title = metadata.get("title", "Untitled")
+            source = metadata.get("sourceURL", "")
+            markdown = page.get("markdown", "")
+            parts.append(f"### {title}\nURL: {source}\n\n{markdown}\n")
+
+        full_content = "\n---\n".join(parts)
+        if self.max_output_length and len(full_content) > self.max_output_length:
+            truncation_notice = f"\n..._Content truncated to {self.max_output_length} characters_...\n"
+            available_length = max(self.max_output_length - len(truncation_notice), 0)
+            full_content = full_content[:available_length] + truncation_notice
+        return full_content
+
+
 class SpeechToTextTool(PipelineTool):
     default_checkpoint = "openai/whisper-large-v3-turbo"
     description = "This is a tool that transcribes an audio into text. It returns the transcribed text."
@@ -686,6 +961,8 @@ TOOL_MAPPING = {
 
 __all__ = [
     "ApiWebSearchTool",
+    "CrwCrawlTool",
+    "CrwScrapeTool",
     "PythonInterpreterTool",
     "FinalAnswerTool",
     "UserInputTool",

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from smolagents.agent_types import _AGENT_TYPE_MAPPING
 from smolagents.default_tools import (
+    CrwCrawlTool,
+    CrwScrapeTool,
     DuckDuckGoSearchTool,
     PythonInterpreterTool,
     SpeechToTextTool,
@@ -252,3 +254,224 @@ def test_wikipedia_search(language, content_type, extract_format, query):
         assert len(result.split()) < 1000, "Summary mode should return a shorter text"
     if content_type == "text":
         assert len(result.split()) > 1000, "Full text mode should return a longer text"
+
+
+class TestCrwScrapeTool:
+    def test_initialization_defaults(self):
+        tool = CrwScrapeTool()
+        assert tool.api_url == "http://localhost:3000"
+        assert tool.formats == ["markdown"]
+        assert tool.only_main_content is True
+
+    def test_initialization_custom(self):
+        tool = CrwScrapeTool(
+            api_url="http://myserver:4000/",
+            api_key="test-key",
+            only_main_content=False,
+            formats=["markdown", "html"],
+        )
+        assert tool.api_url == "http://myserver:4000"
+        assert tool.api_key == "test-key"
+        assert tool.only_main_content is False
+        assert tool.formats == ["markdown", "html"]
+
+    @patch("requests.post")
+    def test_scrape_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {
+                "markdown": "# Hello World\n\nThis is content.",
+                "metadata": {
+                    "title": "Hello World",
+                    "sourceURL": "https://example.com",
+                },
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwScrapeTool()
+        result = tool("https://example.com")
+        assert "Hello World" in result
+        assert "https://example.com" in result
+
+    @patch("requests.post")
+    def test_scrape_with_css_selector(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {"markdown": "Selected content", "metadata": {}},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwScrapeTool()
+        tool("https://example.com", css_selector="article.main")
+
+        call_payload = mock_post.call_args[1]["json"]
+        assert call_payload["cssSelector"] == "article.main"
+
+    @patch("requests.post")
+    def test_scrape_api_error(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": False,
+            "error": "invalid_url",
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwScrapeTool()
+        result = tool("not-a-url")
+        assert "failed" in result.lower()
+
+    @patch("requests.post")
+    def test_scrape_content_truncation(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {
+                "markdown": "x" * 50000,
+                "metadata": {"title": "Big Page"},
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwScrapeTool(max_output_length=1000)
+        result = tool("https://example.com")
+        assert "truncated" in result.lower()
+        assert len(result) <= 1000
+
+    @patch("requests.post")
+    def test_scrape_links_format(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {
+                "links": ["https://example.com/a", "https://example.com/b"],
+                "metadata": {"title": "Links Page"},
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwScrapeTool(formats=["links"])
+        result = tool("https://example.com")
+        assert "https://example.com/a" in result
+        assert "https://example.com/b" in result
+
+
+class TestCrwCrawlTool:
+    def test_initialization_defaults(self):
+        tool = CrwCrawlTool()
+        assert tool.api_url == "http://localhost:3000"
+        assert tool.max_depth == 2
+        assert tool.max_pages == 10
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_crawl_success(self, mock_post, mock_get):
+        # Mock crawl start
+        mock_start = MagicMock()
+        mock_start.json.return_value = {"success": True, "id": "test-crawl-id"}
+        mock_start.raise_for_status = MagicMock()
+        mock_post.return_value = mock_start
+
+        # Mock status check — completed immediately
+        mock_status = MagicMock()
+        mock_status.json.return_value = {
+            "status": "completed",
+            "total": 1,
+            "data": [
+                {
+                    "markdown": "# Page 1 content",
+                    "metadata": {
+                        "title": "Page 1",
+                        "sourceURL": "https://example.com",
+                    },
+                }
+            ],
+        }
+        mock_status.raise_for_status = MagicMock()
+        mock_get.return_value = mock_status
+
+        tool = CrwCrawlTool(poll_interval=0.01)
+        result = tool("https://example.com")
+        assert "Page 1" in result
+        assert "https://example.com" in result
+
+    @patch("requests.post")
+    def test_crawl_start_failure(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": False,
+            "error": "invalid_url",
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        tool = CrwCrawlTool()
+        result = tool("bad-url")
+        assert "failed" in result.lower()
+
+    @patch("requests.post")
+    def test_scrape_timeout(self, mock_post):
+        import requests
+
+        mock_post.side_effect = requests.exceptions.Timeout("Connection timed out")
+
+        tool = CrwScrapeTool()
+        result = tool("https://example.com")
+        assert "timed out" in result.lower()
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_crawl_failed_status(self, mock_post, mock_get):
+        mock_start = MagicMock()
+        mock_start.json.return_value = {"success": True, "id": "crawl-fail-id"}
+        mock_start.raise_for_status = MagicMock()
+        mock_post.return_value = mock_start
+
+        mock_status = MagicMock()
+        mock_status.json.return_value = {"status": "failed"}
+        mock_status.raise_for_status = MagicMock()
+        mock_get.return_value = mock_status
+
+        tool = CrwCrawlTool(poll_interval=0.01)
+        result = tool("https://example.com")
+        assert "failed" in result.lower()
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_crawl_intermediate_then_completed(self, mock_post, mock_get):
+        mock_start = MagicMock()
+        mock_start.json.return_value = {"success": True, "id": "crawl-poll-id"}
+        mock_start.raise_for_status = MagicMock()
+        mock_post.return_value = mock_start
+
+        # First poll returns "scraping", second returns "completed"
+        mock_scraping = MagicMock()
+        mock_scraping.json.return_value = {"status": "scraping"}
+        mock_scraping.raise_for_status = MagicMock()
+
+        mock_completed = MagicMock()
+        mock_completed.json.return_value = {
+            "status": "completed",
+            "total": 1,
+            "data": [
+                {
+                    "markdown": "# Done",
+                    "metadata": {"title": "Done", "sourceURL": "https://example.com"},
+                }
+            ],
+        }
+        mock_completed.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [mock_scraping, mock_completed]
+
+        tool = CrwCrawlTool(poll_interval=0.01)
+        result = tool("https://example.com")
+        assert "Done" in result


### PR DESCRIPTION
## Summary
- Add `CrwScrapeTool` for scraping single webpages via a [CRW](https://github.com/us/crw) server (Firecrawl-compatible REST API), returning clean markdown with optional CSS selector filtering
- Add `CrwCrawlTool` for crawling multiple pages from a website with configurable depth and page limits, using async job polling
- Both tools support API key authentication, content truncation, and configurable server URLs
- Add 9 unit tests covering initialization, successful operations, error handling, and content truncation

## Details

[CRW](https://github.com/us/crw) is an open-source web scraper designed for AI agents. It provides a Firecrawl-compatible REST API with endpoints for scraping (`/v1/scrape`), crawling (`/v1/crawl`), and URL discovery (`/v1/map`).

### CrwScrapeTool
- Scrapes a single URL and returns clean markdown
- Supports CSS selector filtering for targeted extraction
- Handles JS-rendered pages, strips boilerplate (nav, footer, ads)
- Configurable output formats (markdown, html, plainText, links)

### CrwCrawlTool
- Starts an async crawl job and polls for completion
- Configurable `max_depth` and `max_pages` parameters
- Returns aggregated markdown from all crawled pages
- Handles timeout and failure states gracefully

### Usage

```python
from smolagents import CrwScrapeTool, CrwCrawlTool

# Scrape a single page
scrape_tool = CrwScrapeTool(api_url="http://localhost:3000")
result = scrape_tool("https://example.com")

# Crawl a website
crawl_tool = CrwCrawlTool(api_url="http://localhost:3000", max_pages=5)
result = crawl_tool("https://example.com")
```

## Test plan
- [x] All 9 new unit tests pass (`pytest tests/test_default_tools.py -k Crw`)
- [x] Import verification: `from smolagents import CrwScrapeTool, CrwCrawlTool` works
- [x] Existing tests unaffected
- [ ] Manual testing with a running CRW server