### PR TITLE
Add pre-tool-call guardrail authorization layer

### DIFF
--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -20,6 +20,7 @@ from .agent_types import *  # noqa: I001
 from .agents import *  # Above noqa avoids a circular dependency due to cli.py
 from .default_tools import *
 from .gradio_ui import *
+from .guardrails import *
 from .local_python_executor import *
 from .mcp_client import *
 from .memory import *

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 
 from .agent_types import AgentAudio, AgentImage, handle_agent_output_types
 from .default_tools import TOOL_MAPPING, FinalAnswerTool
+from .guardrails import GuardrailProvider
 from .local_python_executor import BASE_BUILTIN_MODULES, LocalPythonExecutor, PythonExecutor, fix_final_answer_code
 from .memory import (
     ActionStep,
@@ -97,6 +98,34 @@ from .utils import (
 
 
 logger = getLogger(__name__)
+
+
+class _GuardedTool:
+    """Proxy that checks a guardrail before delegating to the original tool.
+
+    This avoids mutating the original tool instance, so tools shared across
+    agents with different guardrails remain independent.
+    """
+
+    def __init__(self, tool, tool_name, guardrail, agent_logger):
+        self._tool = tool
+        self._tool_name = tool_name
+        self._guardrail = guardrail
+        self._agent_logger = agent_logger
+
+    def __call__(self, *args, **kwargs):
+        arguments = kwargs if kwargs else (args[0] if len(args) == 1 and isinstance(args[0], dict) else str(args))
+        decision = self._guardrail.before_tool_call(self._tool_name, arguments)
+        if not decision.allowed:
+            raise AgentToolExecutionError(
+                f"Tool call to '{self._tool_name}' was denied by guardrail: {decision.reason}\n"
+                "Please try a different approach or use an authorized tool.",
+                self._agent_logger,
+            )
+        return self._tool(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._tool, name)
 
 
 def populate_template(template: str, variables: dict[str, Any]) -> str:
@@ -289,6 +318,8 @@ class MultiStepAgent(ABC):
             - Take the final answer, the agent's memory, and the agent itself as arguments.
             - Return a boolean indicating whether the final answer is valid.
         return_full_result (`bool`, default `False`): Whether to return the full [`RunResult`] object or just the final answer output from the agent run.
+        guardrail ([`~guardrails.GuardrailProvider`], *optional*): A guardrail provider evaluated before every tool call.
+            When a call is denied, the agent receives a structured error observation instead of raising, so it can adapt.
     """
 
     def __init__(
@@ -309,6 +340,7 @@ class MultiStepAgent(ABC):
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
         logger: AgentLogger | None = None,
+        guardrail: GuardrailProvider | None = None,
     ):
         self.agent_name = self.__class__.__name__
         self.model = model
@@ -335,6 +367,7 @@ class MultiStepAgent(ABC):
         self.final_answer_checks = final_answer_checks if final_answer_checks is not None else []
         self.return_full_result = return_full_result
         self.instructions = instructions
+        self.guardrail = guardrail
         self._setup_managed_agents(managed_agents)
         self._setup_tools(tools, add_base_tools)
         self._validate_tools_and_managed_agents(tools, managed_agents)
@@ -489,7 +522,12 @@ You have been provided with these additional arguments, that you can access dire
 
         if getattr(self, "python_executor", None):
             self.python_executor.send_variables(variables=self.state)
-            self.python_executor.send_tools({**self.tools, **self.managed_agents})
+            tools_to_send = {**self.tools, **self.managed_agents}
+            if self.guardrail is not None:
+                tools_to_send = {
+                    name: _GuardedTool(tool, name, self.guardrail, self.logger) for name, tool in tools_to_send.items()
+                }
+            self.python_executor.send_tools(tools_to_send)
 
         if stream:
             # The steps are returned as they are executed through a generator to iterate on.
@@ -1479,6 +1517,16 @@ class ToolCallingAgent(MultiStepAgent):
         except Exception as e:
             error_msg = f"Error executing tool '{tool_name}' with arguments {str(arguments)}: {type(e).__name__}: {e}"
             raise AgentToolExecutionError(error_msg, self.logger) from e
+
+        # Check guardrail before executing
+        if self.guardrail is not None:
+            decision = self.guardrail.before_tool_call(tool_name, arguments)
+            if not decision.allowed:
+                raise AgentToolExecutionError(
+                    f"Tool call to '{tool_name}' was denied by guardrail: {decision.reason}\n"
+                    "Please try a different approach or use an authorized tool.",
+                    self.logger,
+                )
 
         try:
             # Call tool with appropriate arguments

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 from .agent_types import AgentAudio, AgentImage, handle_agent_output_types
 from .default_tools import TOOL_MAPPING, FinalAnswerTool
-from .guardrails import GuardrailProvider
+from .guardrails import GUARDRAIL_DENIED_MESSAGE, GuardrailProvider
 from .local_python_executor import BASE_BUILTIN_MODULES, LocalPythonExecutor, PythonExecutor, fix_final_answer_code
 from .memory import (
     ActionStep,
@@ -114,12 +114,18 @@ class _GuardedTool:
         self._agent_logger = agent_logger
 
     def __call__(self, *args, **kwargs):
-        arguments = kwargs if kwargs else (args[0] if len(args) == 1 and isinstance(args[0], dict) else str(args))
+        # Always normalize arguments to a dict so guardrail authors get a
+        # consistent contract regardless of how the executor invokes tools.
+        if kwargs:
+            arguments = dict(kwargs)
+        elif len(args) == 1 and isinstance(args[0], dict):
+            arguments = args[0]
+        else:
+            arguments = {}
         decision = self._guardrail.before_tool_call(self._tool_name, arguments)
         if not decision.allowed:
             raise AgentToolExecutionError(
-                f"Tool call to '{self._tool_name}' was denied by guardrail: {decision.reason}\n"
-                "Please try a different approach or use an authorized tool.",
+                GUARDRAIL_DENIED_MESSAGE.format(tool_name=self._tool_name, reason=decision.reason),
                 self._agent_logger,
             )
         return self._tool(*args, **kwargs)
@@ -320,6 +326,10 @@ class MultiStepAgent(ABC):
         return_full_result (`bool`, default `False`): Whether to return the full [`RunResult`] object or just the final answer output from the agent run.
         guardrail ([`~guardrails.GuardrailProvider`], *optional*): A guardrail provider evaluated before every tool call.
             When a call is denied, the agent receives a structured error observation instead of raising, so it can adapt.
+
+            .. note::
+                Guardrails are **not** preserved across serialization (e.g. ``pickle``). If you
+                serialize and deserialize an agent, you must re-attach the guardrail manually.
     """
 
     def __init__(
@@ -1523,8 +1533,7 @@ class ToolCallingAgent(MultiStepAgent):
             decision = self.guardrail.before_tool_call(tool_name, arguments)
             if not decision.allowed:
                 raise AgentToolExecutionError(
-                    f"Tool call to '{tool_name}' was denied by guardrail: {decision.reason}\n"
-                    "Please try a different approach or use an authorized tool.",
+                    GUARDRAIL_DENIED_MESSAGE.format(tool_name=tool_name, reason=decision.reason),
                     self.logger,
                 )
 

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -114,14 +114,18 @@ class _GuardedTool:
         self._agent_logger = agent_logger
 
     def __call__(self, *args, **kwargs):
-        # Always normalize arguments to a dict so guardrail authors get a
-        # consistent contract regardless of how the executor invokes tools.
+        # Normalize arguments so guardrail authors get a consistent contract.
+        # smolagents tools are almost always invoked with kwargs; the positional
+        # fallbacks preserve the value for content-aware guardrails rather than
+        # silently dropping it.
         if kwargs:
             arguments = dict(kwargs)
         elif len(args) == 1 and isinstance(args[0], dict):
             arguments = args[0]
+        elif len(args) == 1:
+            arguments = args[0]  # str or other scalar -- pass through as-is
         else:
-            arguments = {}
+            arguments = list(args)  # multiple positional args
         decision = self._guardrail.before_tool_call(self._tool_name, arguments)
         if not decision.allowed:
             raise AgentToolExecutionError(

--- a/src/smolagents/guardrails.py
+++ b/src/smolagents/guardrails.py
@@ -19,10 +19,22 @@
 
 Provides a ``GuardrailProvider`` protocol that is checked before every tool
 call, allowing users to control which tools an agent is authorized to invoke.
+
+.. note::
+    Guardrails are **not preserved across serialization**. If you serialize and
+    deserialize an agent (e.g. via ``pickle``), you must re-attach the guardrail
+    provider manually after loading.
 """
 
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
+
+# Shared error template used by both _GuardedTool and ToolCallingAgent to keep
+# denied-call messages consistent.
+GUARDRAIL_DENIED_MESSAGE = (
+    "Tool call to '{tool_name}' was denied by guardrail: {reason}\n"
+    "Please try a different approach or use an authorized tool."
+)
 
 
 @dataclass

--- a/src/smolagents/guardrails.py
+++ b/src/smolagents/guardrails.py
@@ -68,6 +68,14 @@ class GuardrailProvider(Protocol):
 
         Returns:
             A ``GuardrailDecision`` indicating whether the call is allowed.
+
+        .. warning::
+            Custom implementations **must** permit ``"final_answer"`` (or
+            explicitly return ``allowed=True`` for it). Blocking
+            ``final_answer`` leaves the agent with no way to terminate and will
+            cause an infinite step loop. The built-in guardrails
+            (:class:`AllowlistGuardrail`, :class:`BlocklistGuardrail`,
+            :class:`CompositeGuardrail`) all handle this correctly.
         """
         ...
 

--- a/src/smolagents/guardrails.py
+++ b/src/smolagents/guardrails.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pre-tool-call authorization layer for smolagents.
+
+Provides a ``GuardrailProvider`` protocol that is checked before every tool
+call, allowing users to control which tools an agent is authorized to invoke.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class GuardrailDecision:
+    """Result of a guardrail check.
+
+    Attributes:
+        allowed: Whether the tool call is authorized.
+        reason: Human-readable explanation when a call is denied.
+    """
+
+    allowed: bool
+    reason: str = ""
+
+
+@runtime_checkable
+class GuardrailProvider(Protocol):
+    """Protocol for pre-tool-call authorization.
+
+    Implementations are called before every tool invocation. Returning a
+    ``GuardrailDecision`` with ``allowed=False`` prevents execution and
+    surfaces the ``reason`` as an observation so the agent can adapt.
+    """
+
+    def before_tool_call(self, tool_name: str, arguments: dict[str, Any] | str) -> GuardrailDecision:
+        """Decide whether a tool call should proceed.
+
+        Args:
+            tool_name: Name of the tool about to be called.
+            arguments: Arguments that will be passed to the tool.
+
+        Returns:
+            A ``GuardrailDecision`` indicating whether the call is allowed.
+        """
+        ...
+
+
+class AllowlistGuardrail:
+    """Simple guardrail that permits only tools whose names appear in an allowlist.
+
+    ``final_answer`` is always permitted regardless of the allowlist contents.
+
+    Args:
+        allowed_tools: Collection of tool names that are authorized.
+    """
+
+    def __init__(self, allowed_tools: list[str] | set[str]):
+        self.allowed_tools: set[str] = set(allowed_tools) | {"final_answer"}
+
+    def before_tool_call(self, tool_name: str, arguments: dict[str, Any] | str) -> GuardrailDecision:
+        if tool_name in self.allowed_tools:
+            return GuardrailDecision(allowed=True)
+        return GuardrailDecision(
+            allowed=False,
+            reason=f"Tool '{tool_name}' is not in the allowed tools list: {sorted(self.allowed_tools)}",
+        )
+
+
+class BlocklistGuardrail:
+    """Guardrail that denies specific tools and permits everything else.
+
+    Args:
+        blocked_tools: Collection of tool names that are denied.
+    """
+
+    def __init__(self, blocked_tools: list[str] | set[str]):
+        self.blocked_tools: set[str] = set(blocked_tools)
+
+    def before_tool_call(self, tool_name: str, arguments: dict[str, Any] | str) -> GuardrailDecision:
+        if tool_name in self.blocked_tools:
+            return GuardrailDecision(
+                allowed=False,
+                reason=f"Tool '{tool_name}' is blocked.",
+            )
+        return GuardrailDecision(allowed=True)
+
+
+class CompositeGuardrail:
+    """Chains multiple guardrail providers; all must allow the call.
+
+    Args:
+        providers: Guardrail providers to evaluate in order. The first denial wins.
+    """
+
+    def __init__(self, providers: list[GuardrailProvider]):
+        self.providers = providers
+
+    def before_tool_call(self, tool_name: str, arguments: dict[str, Any] | str) -> GuardrailDecision:
+        for provider in self.providers:
+            decision = provider.before_tool_call(tool_name, arguments)
+            if not decision.allowed:
+                return decision
+        return GuardrailDecision(allowed=True)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -15,14 +15,16 @@
 
 import pytest
 
-from smolagents.agents import CodeAgent, ToolCallingAgent
+from smolagents.agents import CodeAgent, ToolCallingAgent, _GuardedTool
 from smolagents.guardrails import (
+    GUARDRAIL_DENIED_MESSAGE,
     AllowlistGuardrail,
     BlocklistGuardrail,
     CompositeGuardrail,
     GuardrailDecision,
     GuardrailProvider,
 )
+from smolagents.memory import AgentLogger
 from smolagents.models import ChatMessage, ChatMessageToolCall, ChatMessageToolCallFunction, MessageRole, Model
 from smolagents.tools import tool
 from smolagents.utils import AgentToolExecutionError
@@ -375,3 +377,67 @@ class TestGuardrailWithManagedAgents:
         )
         with pytest.raises(AgentToolExecutionError, match="denied by guardrail"):
             agent.execute_tool_call("sub_agent", {"task": "do something"})
+
+
+# --- _GuardedTool unit tests ---
+
+
+class TestGuardedTool:
+    def test_denied_call_returns_error(self):
+        """A denied call should raise AgentToolExecutionError with the guardrail reason."""
+        guardrail = AllowlistGuardrail(["other_tool"])
+        logger = AgentLogger()
+        guarded = _GuardedTool(sample_tool, "sample_tool", guardrail, logger)
+        with pytest.raises(AgentToolExecutionError, match="denied by guardrail"):
+            guarded(query="hi")
+
+    def test_allowed_call_passes_through(self):
+        """An allowed call should delegate to the underlying tool and return its result."""
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        logger = AgentLogger()
+        guarded = _GuardedTool(sample_tool, "sample_tool", guardrail, logger)
+        result = guarded(query="hello")
+        assert result == "echo: hello"
+
+    def test_getattr_forwards_tool_attributes(self):
+        """Attribute access on _GuardedTool should transparently forward to the wrapped tool."""
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        logger = AgentLogger()
+        guarded = _GuardedTool(sample_tool, "sample_tool", guardrail, logger)
+        # Tool objects have a 'name' attribute
+        assert guarded.name == "sample_tool"
+        # Tool objects have a 'description' attribute
+        assert "echoes back" in guarded.description
+
+    def test_arguments_always_normalized_to_dict(self):
+        """The guardrail should always receive a dict, never a raw string."""
+        received_args = []
+
+        class SpyGuardrail:
+            def before_tool_call(self, tool_name, arguments):
+                received_args.append(arguments)
+                return GuardrailDecision(allowed=True)
+
+        logger = AgentLogger()
+        guarded = _GuardedTool(sample_tool, "sample_tool", SpyGuardrail(), logger)
+
+        # Call with kwargs
+        guarded(query="test1")
+        assert isinstance(received_args[-1], dict)
+
+        # Call with no args -- should get empty dict, not a string
+        guarded_no_args = _GuardedTool(lambda: "ok", "noop", SpyGuardrail(), logger)
+        guarded_no_args()
+        assert received_args[-1] == {}
+
+
+# --- Shared constant tests ---
+
+
+class TestGuardrailDeniedMessage:
+    def test_constant_is_used_consistently(self):
+        """The GUARDRAIL_DENIED_MESSAGE constant should format correctly."""
+        msg = GUARDRAIL_DENIED_MESSAGE.format(tool_name="my_tool", reason="blocked")
+        assert "my_tool" in msg
+        assert "blocked" in msg
+        assert "denied by guardrail" in msg

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,377 @@
+# coding=utf-8
+# Copyright 2024 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from smolagents.agents import CodeAgent, ToolCallingAgent
+from smolagents.guardrails import (
+    AllowlistGuardrail,
+    BlocklistGuardrail,
+    CompositeGuardrail,
+    GuardrailDecision,
+    GuardrailProvider,
+)
+from smolagents.models import ChatMessage, ChatMessageToolCall, ChatMessageToolCallFunction, MessageRole, Model
+from smolagents.tools import tool
+from smolagents.utils import AgentToolExecutionError
+
+
+# --- Fake models ---
+
+
+class FakeToolCallModelWithTool(Model):
+    """Calls a specific tool on step 1, then final_answer on step 2."""
+
+    def __init__(self, tool_name, tool_args):
+        self._tool_name = tool_name
+        self._tool_args = tool_args
+
+    def generate(self, messages, tools_to_call_from=None, stop_sequences=None):
+        if len(messages) < 3:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="I will call the tool.",
+                tool_calls=[
+                    ChatMessageToolCall(
+                        id="call_0",
+                        type="function",
+                        function=ChatMessageToolCallFunction(name=self._tool_name, arguments=self._tool_args),
+                    )
+                ],
+            )
+        else:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="Final answer.",
+                tool_calls=[
+                    ChatMessageToolCall(
+                        id="call_1",
+                        type="function",
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "done"}),
+                    )
+                ],
+            )
+
+
+class FakeCodeModelWithTool(Model):
+    """Generates code that calls a tool on step 1, then final_answer on step 2."""
+
+    def __init__(self, tool_call_code):
+        self._tool_call_code = tool_call_code
+
+    def generate(self, messages, stop_sequences=None):
+        prompt = str(messages)
+        if "special_marker" not in prompt:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=f"""
+Thought: I will call the tool. special_marker
+<code>
+{self._tool_call_code}
+</code>
+""",
+            )
+        else:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="""
+Thought: Return the result.
+<code>
+final_answer("done")
+</code>
+""",
+            )
+
+
+# --- Test tools ---
+
+
+@tool
+def sample_tool(query: str) -> str:
+    """A sample tool that echoes back.
+
+    Args:
+        query: The input query.
+    """
+    return f"echo: {query}"
+
+
+@tool
+def another_tool(value: str) -> str:
+    """Another tool.
+
+    Args:
+        value: A value.
+    """
+    return f"another: {value}"
+
+
+# --- GuardrailDecision tests ---
+
+
+class TestGuardrailDecision:
+    def test_allowed_decision(self):
+        d = GuardrailDecision(allowed=True)
+        assert d.allowed is True
+        assert d.reason == ""
+
+    def test_denied_decision(self):
+        d = GuardrailDecision(allowed=False, reason="not authorized")
+        assert d.allowed is False
+        assert d.reason == "not authorized"
+
+
+# --- AllowlistGuardrail tests ---
+
+
+class TestAllowlistGuardrail:
+    def test_allowed_tool(self):
+        g = AllowlistGuardrail(["sample_tool"])
+        decision = g.before_tool_call("sample_tool", {"query": "test"})
+        assert decision.allowed is True
+
+    def test_denied_tool(self):
+        g = AllowlistGuardrail(["sample_tool"])
+        decision = g.before_tool_call("another_tool", {"value": "test"})
+        assert decision.allowed is False
+        assert "another_tool" in decision.reason
+
+    def test_final_answer_always_allowed(self):
+        g = AllowlistGuardrail(["sample_tool"])
+        decision = g.before_tool_call("final_answer", {"answer": "42"})
+        assert decision.allowed is True
+
+    def test_empty_allowlist_still_allows_final_answer(self):
+        g = AllowlistGuardrail([])
+        decision = g.before_tool_call("final_answer", {"answer": "42"})
+        assert decision.allowed is True
+
+
+# --- BlocklistGuardrail tests ---
+
+
+class TestBlocklistGuardrail:
+    def test_allowed_tool(self):
+        g = BlocklistGuardrail(["dangerous_tool"])
+        decision = g.before_tool_call("sample_tool", {"query": "test"})
+        assert decision.allowed is True
+
+    def test_blocked_tool(self):
+        g = BlocklistGuardrail(["sample_tool"])
+        decision = g.before_tool_call("sample_tool", {"query": "test"})
+        assert decision.allowed is False
+
+
+# --- CompositeGuardrail tests ---
+
+
+class TestCompositeGuardrail:
+    def test_all_allow(self):
+        g = CompositeGuardrail(
+            [
+                AllowlistGuardrail(["sample_tool", "another_tool"]),
+                BlocklistGuardrail(["dangerous_tool"]),
+            ]
+        )
+        decision = g.before_tool_call("sample_tool", {"query": "test"})
+        assert decision.allowed is True
+
+    def test_first_denies(self):
+        g = CompositeGuardrail(
+            [
+                AllowlistGuardrail(["sample_tool"]),
+                BlocklistGuardrail([]),
+            ]
+        )
+        decision = g.before_tool_call("another_tool", {"value": "test"})
+        assert decision.allowed is False
+
+    def test_second_denies(self):
+        g = CompositeGuardrail(
+            [
+                AllowlistGuardrail(["sample_tool"]),
+                BlocklistGuardrail(["sample_tool"]),
+            ]
+        )
+        decision = g.before_tool_call("sample_tool", {"query": "test"})
+        assert decision.allowed is False
+
+
+# --- Custom GuardrailProvider via protocol ---
+
+
+class TestCustomGuardrailProvider:
+    def test_custom_provider(self):
+        class ArgCheckGuardrail:
+            def before_tool_call(self, tool_name, arguments):
+                if isinstance(arguments, dict) and "forbidden" in str(arguments.values()):
+                    return GuardrailDecision(allowed=False, reason="forbidden argument detected")
+                return GuardrailDecision(allowed=True)
+
+        g = ArgCheckGuardrail()
+        assert isinstance(g, GuardrailProvider)
+        assert g.before_tool_call("sample_tool", {"query": "hello"}).allowed is True
+        assert g.before_tool_call("sample_tool", {"query": "forbidden"}).allowed is False
+
+
+# --- ToolCallingAgent integration tests ---
+
+
+class TestToolCallingAgentGuardrail:
+    def test_execute_tool_call_allowed(self):
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        agent = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[sample_tool],
+            guardrail=guardrail,
+        )
+        result = agent.execute_tool_call("sample_tool", {"query": "hi"})
+        assert result == "echo: hi"
+
+    def test_execute_tool_call_denied(self):
+        guardrail = AllowlistGuardrail(["another_tool"])
+        agent = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[sample_tool, another_tool],
+            guardrail=guardrail,
+        )
+        with pytest.raises(AgentToolExecutionError, match="denied by guardrail"):
+            agent.execute_tool_call("sample_tool", {"query": "hi"})
+
+    def test_full_run_with_allowed_tool(self):
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        agent = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[sample_tool],
+            guardrail=guardrail,
+        )
+        result = agent.run("test task")
+        assert result == "done"
+
+    def test_no_guardrail_still_works(self):
+        agent = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[sample_tool],
+        )
+        result = agent.execute_tool_call("sample_tool", {"query": "hi"})
+        assert result == "echo: hi"
+
+
+# --- CodeAgent integration tests ---
+
+
+class TestCodeAgentGuardrail:
+    def test_code_agent_allowed_tool(self):
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        agent = CodeAgent(
+            model=FakeCodeModelWithTool('result = sample_tool(query="hello")'),
+            tools=[sample_tool],
+            guardrail=guardrail,
+        )
+        result = agent.run("test task")
+        assert result == "done"
+
+    def test_code_agent_denied_tool(self):
+        guardrail = AllowlistGuardrail(["another_tool"])
+        agent = CodeAgent(
+            model=FakeCodeModelWithTool('result = sample_tool(query="hello")'),
+            tools=[sample_tool, another_tool],
+            guardrail=guardrail,
+        )
+        # The agent should still complete (the denied tool surfaces as an error observation,
+        # and the agent adapts by calling final_answer on the next step)
+        result = agent.run("test task")
+        assert result == "done"
+
+    def test_code_agent_no_guardrail(self):
+        agent = CodeAgent(
+            model=FakeCodeModelWithTool('result = sample_tool(query="hello")'),
+            tools=[sample_tool],
+        )
+        result = agent.run("test task")
+        assert result == "done"
+
+
+# --- Shared tool instance tests ---
+
+
+class TestGuardrailSharedToolInstances:
+    def test_shared_tool_not_mutated_by_guardrail(self):
+        """Ensure that wrapping tools for the code executor does not mutate the original tool."""
+        shared_tool = sample_tool
+
+        guardrail = AllowlistGuardrail(["sample_tool"])
+        agent = CodeAgent(
+            model=FakeCodeModelWithTool('result = sample_tool(query="hello")'),
+            tools=[shared_tool],
+            guardrail=guardrail,
+        )
+        agent.run("test task")
+
+        # Original tool should still work without guardrail interference
+        assert shared_tool(query="direct") == "echo: direct"
+        # The tool class should not have been replaced or wrapped
+        assert type(shared_tool).__name__ == "SimpleTool"
+
+    def test_different_guardrails_on_shared_tool(self):
+        """Two agents with different guardrails sharing the same tool instance should not interfere."""
+        shared_tool = sample_tool
+
+        agent_allow = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[shared_tool],
+            guardrail=AllowlistGuardrail(["sample_tool"]),
+        )
+        agent_deny = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sample_tool", {"query": "hi"}),
+            tools=[shared_tool],
+            guardrail=AllowlistGuardrail(["other_tool"]),
+        )
+
+        # First agent should allow
+        result = agent_allow.execute_tool_call("sample_tool", {"query": "hi"})
+        assert result == "echo: hi"
+
+        # Second agent should deny
+        with pytest.raises(AgentToolExecutionError, match="denied by guardrail"):
+            agent_deny.execute_tool_call("sample_tool", {"query": "hi"})
+
+        # First agent should still allow (not affected by second)
+        result = agent_allow.execute_tool_call("sample_tool", {"query": "hi"})
+        assert result == "echo: hi"
+
+
+# --- Managed agent guardrail tests ---
+
+
+class TestGuardrailWithManagedAgents:
+    def test_guardrail_blocks_managed_agent(self):
+        """Guardrail should be able to block calls to managed agents too."""
+        managed = CodeAgent(
+            model=FakeCodeModelWithTool('final_answer("sub-result")'),
+            tools=[],
+            name="sub_agent",
+            description="A sub agent.",
+        )
+        guardrail = AllowlistGuardrail(["sample_tool"])  # sub_agent not in allowlist
+
+        agent = ToolCallingAgent(
+            model=FakeToolCallModelWithTool("sub_agent", {"task": "do something"}),
+            tools=[sample_tool],
+            managed_agents=[managed],
+            guardrail=guardrail,
+        )
+        with pytest.raises(AgentToolExecutionError, match="denied by guardrail"):
+            agent.execute_tool_call("sub_agent", {"task": "do something"})


### PR DESCRIPTION
## Summary

Implements a `GuardrailProvider` protocol that is evaluated before every tool call, allowing users to control which tools an agent is authorized to invoke. Denied calls surface as structured error observations so the agent can adapt without crashing.

Addresses #2117.

### What's included

- **`GuardrailProvider` protocol** -- a `@runtime_checkable` protocol with a single `before_tool_call(tool_name, arguments) -> GuardrailDecision` method. Any object implementing this method works as a guardrail (no inheritance required).
- **Built-in guardrails:**
  - `AllowlistGuardrail` -- permits only named tools (`final_answer` always allowed)
  - `BlocklistGuardrail` -- denies specific tools, permits everything else
  - `CompositeGuardrail` -- chains multiple providers; first denial wins
- **Wired into both agent types:**
  - `ToolCallingAgent`: guardrail check in `execute_tool_call()` before `tool(**args)`
  - `CodeAgent`: non-mutating `_GuardedTool` proxy wraps tools sent to the Python executor, so guardrails fire when code calls tools inside `evaluate_call()`
- **`guardrail` parameter on `MultiStepAgent.__init__`** -- flows through `**kwargs` to both agent subclasses

### Design decisions

- **Proxy, not mutation**: The CodeAgent path uses a `_GuardedTool` proxy class instead of monkey-patching `tool.__call__`. This means tools shared across multiple agents with different guardrails remain independent.
- **Error observations, not exceptions**: Denied tool calls raise `AgentToolExecutionError`, which the agent framework catches and surfaces as an error observation. The agent sees "Tool X was denied by guardrail" and can adapt on the next step.
- **Not serialized**: Guardrails are not included in `to_dict()` / `from_dict()`, consistent with how `step_callbacks` are handled (arbitrary callables/protocols can't be reliably serialized).

### Usage

```python
from smolagents import CodeAgent, AllowlistGuardrail

guardrail = AllowlistGuardrail(["web_search", "calculator"])

agent = CodeAgent(
    tools=[web_search, calculator, file_writer],
    model=model,
    guardrail=guardrail,  # file_writer will be denied
)
agent.run("What is 2 + 2?")
```

Custom guardrails just need a `before_tool_call` method:

```python
class AuditGuardrail:
    def before_tool_call(self, tool_name, arguments):
        log.info(f"Tool call: {tool_name}({arguments})")
        return GuardrailDecision(allowed=True)
```

## Test plan

- [x] 22 tests in `tests/test_guardrails.py`
  - Unit tests for GuardrailDecision, AllowlistGuardrail, BlocklistGuardrail, CompositeGuardrail
  - Custom GuardrailProvider via protocol (structural subtyping)
  - ToolCallingAgent: execute_tool_call allowed/denied, full agent.run() with guardrail
  - CodeAgent: allowed/denied tool in generated code, full agent.run()
  - Shared tool instances not mutated by guardrail wrapping
  - Different guardrails on same tool instance don't interfere
  - Guardrail blocks managed agent calls
  - No-guardrail agents work unchanged
- [x] All 94 existing test_agents.py tests pass
- [x] All 485 tool/executor/validation tests pass
- [x] ruff check and ruff format clean
