### PR TITLE
docs: add Aegis governance integration guide

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -40,6 +40,8 @@
     title: "Human-in-the-Loop: Customize agent plan interactively"
   - local: examples/async_agent
     title: Async Applications with Agents
+  - local: examples/aegis_governance
+    title: Governance with Aegis
 - title: Reference
   sections:
   - title: Agent-related objects

--- a/docs/source/en/examples/aegis_governance.md
+++ b/docs/source/en/examples/aegis_governance.md
@@ -1,0 +1,68 @@
+# Governance with Aegis
+
+[Aegis](https://github.com/Acacian/aegis) is an open-source governance runtime that auto-instruments smolagents (and other AI frameworks) with security guardrails. It adds prompt injection detection, PII masking, policy-as-code enforcement, and audit trail -- without modifying your agent code.
+
+## Quick Start
+
+Install Aegis alongside smolagents:
+
+```bash
+pip install agent-aegis smolagents
+```
+
+Initialize Aegis before creating your agent:
+
+```python
+import aegis
+from smolagents import CodeAgent, HfApiModel
+
+# Auto-instrument all supported frameworks including smolagents
+aegis.auto_instrument()
+
+model = HfApiModel()
+agent = CodeAgent(tools=[], model=model)
+
+# Aegis transparently applies governance policies to all LLM calls
+agent.run("What is the capital of France?")
+```
+
+## Policy Configuration
+
+Define governance rules in a YAML policy file:
+
+```yaml
+# policy.yaml
+version: "1.0"
+guardrails:
+  injection_detection:
+    enabled: true
+    action: block
+  pii_masking:
+    enabled: true
+    mask_types: [email, phone, ssn]
+```
+
+Load the policy:
+
+```python
+import aegis
+
+aegis.auto_instrument()
+aegis.init(policy_path="policy.yaml")
+```
+
+## Key Features
+
+| Feature | Description |
+|---|---|
+| **Auto-instrumentation** | One-line setup, no code changes needed |
+| **Prompt Injection Detection** | 107 detection patterns across 13 categories |
+| **PII Masking** | Automatic redaction of sensitive data |
+| **Policy-as-Code** | YAML-based governance policies with `aegis plan/test` |
+| **Audit Trail** | Complete log of all LLM interactions |
+
+## References
+
+- [Aegis Documentation](https://acacian.github.io/aegis/)
+- [Aegis on PyPI](https://pypi.org/project/agent-aegis/)
+- [Aegis GitHub](https://github.com/Acacian/aegis)


### PR DESCRIPTION
## Summary
Add a guide for integrating Aegis governance runtime with smolagents.

[Aegis](https://github.com/Acacian/aegis) is an open-source governance library that auto-instruments smolagents with:
- Prompt injection detection (107 patterns)
- PII masking
- Policy-as-code enforcement
- Audit trail

It requires zero code changes — just `aegis.auto_instrument()` before creating agents.

- PyPI: https://pypi.org/project/agent-aegis/
- Docs: https://acacian.github.io/aegis/