### PR TITLE
Document step callbacks as a memory-drift monitoring hook

### DIFF
--- a/docs/source/en/tutorials/memory.md
+++ b/docs/source/en/tutorials/memory.md
@@ -109,7 +109,9 @@ from smolagents import ActionStep, CodeAgent
 
 def log_behavioral_fingerprint(memory_step: ActionStep, agent: CodeAgent) -> None:
     previous_steps = [
-        step for step in agent.memory.steps if isinstance(step, ActionStep)
+        step
+        for step in agent.memory.steps
+        if isinstance(step, ActionStep) and step is not memory_step
     ]
     previous_step = previous_steps[-1] if previous_steps else None
 


### PR DESCRIPTION
This addresses the practical part of #2129 without pretending a new core hook already exists.

What changed:
- adds a short section to the memory tutorial showing how to use existing step_callbacks for behavioral/memory-drift monitoring
- gives a concrete fingerprint example based on ActionStep data already exposed by the framework
- makes the current workaround discoverable while the deeper API discussion stays open

This is documentation-only and intentionally scoped to the current surface.

Refs #2129