### PR TITLE
Remove unused safe_serialization param from _websocket_run_code_raise_errors

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -481,9 +481,7 @@ def _websocket_send_execute_request(code: str, ws) -> str:
     return msg_id
 
 
-def _websocket_run_code_raise_errors(
-    code: str, ws, logger, allow_pickle: bool = True, safe_serialization: bool = False
-) -> CodeOutput:
+def _websocket_run_code_raise_errors(code: str, ws, logger, allow_pickle: bool = True) -> CodeOutput:
     """Run code over a websocket."""
     try:
         # Send execute request


### PR DESCRIPTION
Remove unused `safe_serialization` param from `_websocket_run_code_raise_errors`.

This PR makes a minor change to the `_websocket_run_code_raise_errors` function in `src/smolagents/remote_executors.py`, removing the unused `safe_serialization` parameter from its definition.

Follow-up to:
- #1637