### PR TITLE
fix: correct f-string escaping in ToolSerializer.dumps error message

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
+                    raise SerializationError(f"Cannot serialize object: {e}") from e
 
     @staticmethod
     def loads(data, allow_pickle=False):


### PR DESCRIPTION
Fixes #2133

`ToolSerializer.dumps()` line 429 uses double braces `{{e}}` in the f-string, producing a literal `{e}` instead of interpolating the exception. Line 292 in the same file has the correct single-brace form.

**Before:** `Cannot serialize object: {e}`
**After:** `Cannot serialize object: TypeError('...')`

One character change.