### PR TITLE
fix: display error messages in Gradio UI instead of generic Error bubble

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -19,6 +19,7 @@ import shutil
 from pathlib import Path
 from typing import Generator
 
+from litellm import logging
 from smolagents.agent_types import AgentAudio, AgentImage, AgentText
 from smolagents.agents import MultiStepAgent, PlanningStep
 from smolagents.memory import ActionStep, FinalAnswerStep
@@ -385,39 +386,45 @@ class GradioUI:
         accumulated_events: list[ChatMessageStreamDelta] = []
         streaming_msg_idx: int | None = None
 
-        for event in self.agent.run(
-            task, images=task_files, stream=True, reset=self.reset_agent_memory, additional_args=None
-        ):
-            if isinstance(event, ActionStep | PlanningStep | FinalAnswerStep):
-                # Remove streaming message if present
-                if streaming_msg_idx is not None:
-                    all_messages.pop(streaming_msg_idx)
-                    streaming_msg_idx = None
+        try:
+            for event in self.agent.run(
+                task, images=task_files, stream=True, reset=self.reset_agent_memory, additional_args=None
+            ):
+                if isinstance(event, ActionStep | PlanningStep | FinalAnswerStep):
+                    if streaming_msg_idx is not None:
+                        all_messages.pop(streaming_msg_idx)
+                        streaming_msg_idx = None
 
-                for msg in pull_messages_from_step(
-                    event,
-                    skip_model_outputs=getattr(self.agent, "stream_outputs", False),
-                ):
-                    all_messages.append(
-                        gr.ChatMessage(
-                            role=msg.role,
-                            content=msg.content,
-                            metadata=msg.metadata,
+                    for msg in pull_messages_from_step(
+                        event,
+                        skip_model_outputs=getattr(self.agent, "stream_outputs", False),
+                    ):
+                        all_messages.append(
+                            gr.ChatMessage(
+                                role=msg.role,
+                                content=msg.content,
+                                metadata=msg.metadata,
+                            )
                         )
-                    )
+                        yield all_messages
+                    accumulated_events = []
+                elif isinstance(event, ChatMessageStreamDelta):
+                    accumulated_events.append(event)
+                    text = agglomerate_stream_deltas(accumulated_events).render_as_markdown()
+                    text = text.replace("<", r"\<").replace(">", r"\>")
+                    msg = gr.ChatMessage(role=MessageRole.ASSISTANT, content=text)
+                    if streaming_msg_idx is None:
+                        streaming_msg_idx = len(all_messages)
+                        all_messages.append(msg)
+                    else:
+                        all_messages[streaming_msg_idx] = msg
                     yield all_messages
-                accumulated_events = []
-            elif isinstance(event, ChatMessageStreamDelta):
-                accumulated_events.append(event)
-                text = agglomerate_stream_deltas(accumulated_events).render_as_markdown()
-                text = text.replace("<", r"\<").replace(">", r"\>")
-                msg = gr.ChatMessage(role="assistant", content=text)
-                if streaming_msg_idx is None:
-                    streaming_msg_idx = len(all_messages)
-                    all_messages.append(msg)
-                else:
-                    all_messages[streaming_msg_idx] = msg
-                yield all_messages
+        except Exception as e:
+            print(f"Agent error: {e}")
+            all_messages.append(
+                gr.ChatMessage(role=MessageRole.ASSISTANT, content=f"❌ Error: {str(e)}")
+            )
+            yield all_messages
 
     def launch(self, share: bool = True, **kwargs):
         """


### PR DESCRIPTION
Problem: When the agent raises an exception (e.g. missing API key), the Gradio UI shows a generic "Error" bubble with no useful information. The actual error message is only visible in the terminal.
Fix: Wrap the agent run loop in a try/except block and display the error message directly in the chat UI.
Before:
<img width="1902" height="1375" alt="before" src="https://github.com/user-attachments/assets/8eebf108-ef79-44af-81ae-606ee1431681" />
After:
<img width="1470" height="956" alt="after" src="https://github.com/user-attachments/assets/70d87951-4919-4a74-b1d1-e1d33ee2d082" />