### PR TITLE
Add Exa as a search engine option in WebSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -474,6 +474,7 @@ class WebSearchTool(Tool):
                 "numResults": self.max_results,
                 "contents": {"highlights": True},
             },
+            timeout=30,
         )
         response.raise_for_status()
         data = response.json()
@@ -481,7 +482,7 @@ class WebSearchTool(Tool):
             {
                 "title": result.get("title", ""),
                 "link": result["url"],
-                "description": " ".join(result.get("highlights", [])),
+                "description": " ".join(result.get("highlights") or []),
             }
             for result in data.get("results", [])
         ]

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -474,7 +474,7 @@ class WebSearchTool(Tool):
                 "numResults": self.max_results,
                 "contents": {"highlights": True},
             },
-            timeout=30,
+            timeout=getattr(self, "timeout", 30),
         )
         response.raise_for_status()
         data = response.json()

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -361,6 +361,8 @@ class WebSearchTool(Tool):
             return self.search_duckduckgo(query)
         elif self.engine == "bing":
             return self.search_bing(query)
+        elif self.engine == "exa":
+            return self.search_exa(query)
         else:
             raise ValueError(f"Unsupported engine: {self.engine}")
 
@@ -449,6 +451,40 @@ class WebSearchTool(Tool):
             for item in items[: self.max_results]
         ]
         return results
+
+    def search_exa(self, query: str) -> list:
+        """Search using the Exa API. Requires an EXA_API_KEY environment variable."""
+        import os
+
+        import requests
+
+        api_key = os.getenv("EXA_API_KEY")
+        if not api_key:
+            raise ValueError("Missing API key. Make sure you have 'EXA_API_KEY' in your env variables.")
+
+        response = requests.post(
+            "https://api.exa.ai/search",
+            headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json",
+                "x-exa-integration": "smolagents",
+            },
+            json={
+                "query": query,
+                "numResults": self.max_results,
+                "contents": {"highlights": True},
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [
+            {
+                "title": result.get("title", ""),
+                "link": result["url"],
+                "description": " ".join(result.get("highlights", [])),
+            }
+            for result in data.get("results", [])
+        ]
 
 
 class VisitWebpageTool(Tool):

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -22,6 +23,7 @@ from smolagents.default_tools import (
     PythonInterpreterTool,
     SpeechToTextTool,
     VisitWebpageTool,
+    WebSearchTool,
     WikipediaSearchTool,
 )
 from smolagents.local_python_executor import ExecutionTimeoutError
@@ -131,6 +133,77 @@ class TestSpeechToTextTool:
         assert tool is not None
         assert tool.pre_processor_class == WhisperProcessor
         assert tool.model_class == WhisperForConditionalGeneration
+
+
+class TestWebSearchToolExa:
+    """Tests for the Exa engine in WebSearchTool."""
+
+    def test_exa_missing_api_key(self):
+        tool = WebSearchTool(engine="exa")
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="EXA_API_KEY"):
+                tool("test query")
+
+    def test_exa_search_results(self):
+        mock_response_data = {
+            "results": [
+                {
+                    "title": "Exa AI",
+                    "url": "https://exa.ai",
+                    "highlights": ["Exa is a search engine for AI."],
+                },
+                {
+                    "title": "Hugging Face",
+                    "url": "https://huggingface.co",
+                    "highlights": ["The AI community", "building the future."],
+                },
+            ]
+        }
+        tool = WebSearchTool(engine="exa", max_results=2)
+        with patch.dict("os.environ", {"EXA_API_KEY": "test-key"}):
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.json.return_value = mock_response_data
+                mock_post.return_value.raise_for_status = lambda: None
+                result = tool("test query")
+
+        assert "## Search Results" in result
+        assert "[Exa AI](https://exa.ai)" in result
+        assert "[Hugging Face](https://huggingface.co)" in result
+        assert "Exa is a search engine for AI." in result
+        assert "The AI community building the future." in result
+
+        # Verify the API was called with correct headers and payload
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["headers"]["x-exa-integration"] == "smolagents"
+        assert call_kwargs.kwargs["json"]["numResults"] == 2
+        assert call_kwargs.kwargs["json"]["contents"] == {"highlights": True}
+
+    def test_exa_no_results(self):
+        tool = WebSearchTool(engine="exa")
+        with patch.dict("os.environ", {"EXA_API_KEY": "test-key"}):
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.json.return_value = {"results": []}
+                mock_post.return_value.raise_for_status = lambda: None
+                with pytest.raises(Exception, match="No results found"):
+                    tool("obscure query")
+
+    def test_exa_empty_highlights(self):
+        mock_response_data = {
+            "results": [
+                {
+                    "title": "No Highlights Page",
+                    "url": "https://example.com",
+                }
+            ]
+        }
+        tool = WebSearchTool(engine="exa")
+        with patch.dict("os.environ", {"EXA_API_KEY": "test-key"}):
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.json.return_value = mock_response_data
+                mock_post.return_value.raise_for_status = lambda: None
+                result = tool("test")
+
+        assert "[No Highlights Page](https://example.com)" in result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -205,6 +205,25 @@ class TestWebSearchToolExa:
 
         assert "[No Highlights Page](https://example.com)" in result
 
+    def test_exa_null_highlights(self):
+        mock_response_data = {
+            "results": [
+                {
+                    "title": "Null Highlights Page",
+                    "url": "https://example.com",
+                    "highlights": None,
+                }
+            ]
+        }
+        tool = WebSearchTool(engine="exa")
+        with patch.dict("os.environ", {"EXA_API_KEY": "test-key"}):
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.json.return_value = mock_response_data
+                mock_post.return_value.raise_for_status = lambda: None
+                result = tool("test")
+
+        assert "[Null Highlights Page](https://example.com)" in result
+
 
 @pytest.mark.parametrize(
     "language, content_type, extract_format, query",


### PR DESCRIPTION
## Summary

Adds `"exa"` as a new `engine` parameter value for `WebSearchTool`, following the same pattern as the existing `"bing"` engine added in #1313.

## Changes

- Added `search_exa()` method to `WebSearchTool` class (~35 lines, 1 file)
- Uses the [Exa REST API](https://docs.exa.ai) directly via `requests` — no new dependencies
- Returns search results with highlights as descriptions
- Requires `EXA_API_KEY` environment variable

## Usage

```python
from smolagents import WebSearchTool

tool = WebSearchTool(engine="exa")
results = tool("latest AI research papers")
print(results)
```

## Tests

Added 4 unit tests with mocked API calls:
- `test_exa_missing_api_key` — raises `ValueError` when `EXA_API_KEY` is not set
- `test_exa_search_results` — verifies correct parsing and markdown output
- `test_exa_no_results` — raises exception on empty results
- `test_exa_empty_highlights` — gracefully handles missing highlights

All existing tests continue to pass.