### PR TITLE
Surface cache token usage in TokenUsage and Monitor

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -506,6 +506,8 @@ You have been provided with these additional arguments, that you can access dire
         if return_full_result:
             total_input_tokens = 0
             total_output_tokens = 0
+            total_cache_write_tokens = 0
+            total_cache_read_tokens = 0
             correct_token_usage = True
             for step in self.memory.steps:
                 if isinstance(step, (ActionStep, PlanningStep)):
@@ -515,8 +517,15 @@ You have been provided with these additional arguments, that you can access dire
                     else:
                         total_input_tokens += step.token_usage.input_tokens
                         total_output_tokens += step.token_usage.output_tokens
+                        total_cache_write_tokens += step.token_usage.cache_write_tokens
+                        total_cache_read_tokens += step.token_usage.cache_read_tokens
             if correct_token_usage:
-                token_usage = TokenUsage(input_tokens=total_input_tokens, output_tokens=total_output_tokens)
+                token_usage = TokenUsage(
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
+                    cache_write_tokens=total_cache_write_tokens,
+                    cache_read_tokens=total_cache_read_tokens,
+                )
             else:
                 token_usage = None
 

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -227,10 +227,14 @@ def agglomerate_stream_deltas(
     accumulated_content = ""
     total_input_tokens = 0
     total_output_tokens = 0
+    total_cache_write_tokens = 0
+    total_cache_read_tokens = 0
     for stream_delta in stream_deltas:
         if stream_delta.token_usage:
             total_input_tokens += stream_delta.token_usage.input_tokens
             total_output_tokens += stream_delta.token_usage.output_tokens
+            total_cache_write_tokens += stream_delta.token_usage.cache_write_tokens
+            total_cache_read_tokens += stream_delta.token_usage.cache_read_tokens
         if stream_delta.content:
             accumulated_content += stream_delta.content
         if stream_delta.tool_calls:
@@ -275,6 +279,8 @@ def agglomerate_stream_deltas(
         token_usage=TokenUsage(
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
+            cache_write_tokens=total_cache_write_tokens,
+            cache_read_tokens=total_cache_read_tokens,
         ),
     )
 
@@ -1303,6 +1309,9 @@ class LiteLLMModel(ApiModel):
             token_usage=TokenUsage(
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
+                cache_write_tokens=getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
+                cache_read_tokens=(getattr(response.usage, "cache_read_input_tokens", 0) or 0)
+                + (getattr(getattr(response.usage, "prompt_tokens_details", None), "cached_tokens", 0) or 0),
             ),
         )
 
@@ -1336,6 +1345,9 @@ class LiteLLMModel(ApiModel):
                     token_usage=TokenUsage(
                         input_tokens=event.usage.prompt_tokens,
                         output_tokens=event.usage.completion_tokens,
+                        cache_write_tokens=getattr(event.usage, "cache_creation_input_tokens", 0) or 0,
+                        cache_read_tokens=(getattr(event.usage, "cache_read_input_tokens", 0) or 0)
+                        + (getattr(getattr(event.usage, "prompt_tokens_details", None), "cached_tokens", 0) or 0),
                     ),
                 )
             if event.choices:

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -41,6 +41,8 @@ class TokenUsage:
 
     input_tokens: int
     output_tokens: int
+    cache_write_tokens: int = 0
+    cache_read_tokens: int = 0
     total_tokens: int = field(init=False)
 
     def __post_init__(self):
@@ -50,6 +52,8 @@ class TokenUsage:
         return {
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
             "total_tokens": self.total_tokens,
         }
 
@@ -85,17 +89,23 @@ class Monitor:
         self.logger = logger
         self.total_input_token_count = 0
         self.total_output_token_count = 0
+        self.total_cache_write_token_count = 0
+        self.total_cache_read_token_count = 0
 
     def get_total_token_counts(self) -> TokenUsage:
         return TokenUsage(
             input_tokens=self.total_input_token_count,
             output_tokens=self.total_output_token_count,
+            cache_write_tokens=self.total_cache_write_token_count,
+            cache_read_tokens=self.total_cache_read_token_count,
         )
 
     def reset(self):
         self.step_durations = []
         self.total_input_token_count = 0
         self.total_output_token_count = 0
+        self.total_cache_write_token_count = 0
+        self.total_cache_read_token_count = 0
 
     def update_metrics(self, step_log):
         """Update the metrics of the monitor.
@@ -110,6 +120,8 @@ class Monitor:
         if step_log.token_usage is not None:
             self.total_input_token_count += step_log.token_usage.input_tokens
             self.total_output_token_count += step_log.token_usage.output_tokens
+            self.total_cache_write_token_count += step_log.token_usage.cache_write_tokens
+            self.total_cache_read_token_count += step_log.token_usage.cache_read_tokens
             console_outputs += (
                 f"| Input tokens: {self.total_input_token_count:,} | Output tokens: {self.total_output_token_count:,}"
             )

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -186,6 +186,20 @@ def test_code_agent_metrics(agent_class):
     assert agent.monitor.total_output_token_count == 20
 
 
+def test_token_usage_cache_fields():
+    usage = TokenUsage(input_tokens=100, output_tokens=50, cache_write_tokens=20, cache_read_tokens=30)
+    assert usage.cache_write_tokens == 20
+    assert usage.cache_read_tokens == 30
+    assert usage.total_tokens == 150
+
+
+def test_token_usage_cache_fields_default_zero():
+    usage = TokenUsage(input_tokens=10, output_tokens=5)
+    assert usage.cache_write_tokens == 0
+    assert usage.cache_read_tokens == 0
+    assert usage.total_tokens == 15
+
+
 class ReplayTester(unittest.TestCase):
     def test_replay_with_chatmessage(self):
         """Regression test for dict(message) to message.dict() fix"""


### PR DESCRIPTION
`TokenUsage` only tracked `input_tokens` and `output_tokens`, silently
dropping cache token counts returned by Anthropic and OpenAI via LiteLLM.
This makes it impossible to verify that prompt caching is working or to
build accurate cost tracking for agentic runs.

This PR adds two optional fields to `TokenUsage`:
- `cache_write_tokens`: tokens written to cache (Anthropic `cache_creation_input_tokens`)
- `cache_read_tokens`: tokens read from cache (Anthropic `cache_read_input_tokens` + OpenAI `prompt_tokens_details.cached_tokens`)

Both fields default to `0` so all existing code is unaffected. `total_tokens`
is unchanged — cache tokens are a subset of `input_tokens`, not additive.

The `Monitor` class and `RunResult` aggregation are also updated to propagate
cache token counts across steps.

Closes #2055