### PR TITLE
feat: support serialization for step_callbacks and final_answer_checks in MultiStepAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -99,6 +99,24 @@ from .utils import (
 logger = getLogger(__name__)
 
 
+MEMORY_STEP_MAP = {
+    "ActionStep": ActionStep,
+    "PlanningStep": PlanningStep,
+    "TaskStep": TaskStep,
+    "SystemPromptStep": SystemPromptStep,
+    "FinalAnswerStep": FinalAnswerStep,
+}
+
+# Callback Registry for secure deserialization.
+# Maps callback path strings to their actual callable objects.
+# Checked first during deserialization before importlib resolution.
+CALLBACK_REGISTRY: dict[str, Callable] = {}
+
+# Namespaces allowed for dynamic callback import during deserialization.
+# Extend this set to allow callbacks from additional packages.
+ALLOWED_CALLBACK_NAMESPACES: set[str] = {"smolagents"}
+
+
 def populate_template(template: str, variables: dict[str, Any]) -> str:
     compiled_template = Template(template, undefined=StrictUndefined)
     try:
@@ -309,6 +327,8 @@ class MultiStepAgent(ABC):
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
         logger: AgentLogger | None = None,
+        allowed_callback_namespaces: set[str] | None = None,
+        callback_registry: dict[str, Callable] | None = None,
     ):
         self.agent_name = self.__class__.__name__
         self.model = model
@@ -350,6 +370,12 @@ class MultiStepAgent(ABC):
         self.monitor = Monitor(self.model, self.logger)
         self._setup_step_callbacks(step_callbacks)
         self.stream_outputs = False
+        self.allowed_callback_namespaces = (
+            allowed_callback_namespaces
+            if allowed_callback_namespaces is not None
+            else ALLOWED_CALLBACK_NAMESPACES.copy()
+        )
+        self.callback_registry = callback_registry if callback_registry is not None else CALLBACK_REGISTRY.copy()
 
     @property
     def system_prompt(self) -> str:
@@ -967,16 +993,99 @@ You have been provided with these additional arguments, that you can access dire
         with open(os.path.join(output_dir, "app.py"), "w", encoding="utf-8") as f:
             f.write(app_text + "\n")  # Append newline at the end
 
+    def _serialize_callable(self, c: Callable) -> str | None:
+        """Helper to serialize a callable to a string path."""
+        # Reverse check in registry
+        for path, registered_c in self.callback_registry.items():
+            if c == registered_c:
+                return path
+
+        if not hasattr(c, "__module__") or not hasattr(c, "__qualname__"):
+            # Check if it has a __name__ at least
+            if hasattr(c, "__name__"):
+                # If it's a simple function/method, __module__ is usually available.
+                # If not, it might be a built-in or something weird.
+                self.logger.log(
+                    f"Callable {c} missing __module__ or __qualname__ and not in CALLBACK_REGISTRY. Using __name__ '{c.__name__}'.",
+                    LogLevel.WARNING,
+                )
+                return c.__name__
+            self.logger.log(f"Callable {c} cannot be serialized. Skipping.", LogLevel.WARNING)
+            return None
+
+        if "<lambda>" in c.__qualname__ or "<locals>" in c.__qualname__:
+            self.logger.log(
+                f"Callable {c} is a lambda or local function and cannot be serialized. Skipping.", LogLevel.WARNING
+            )
+            return None
+
+        return f"{c.__module__}.{c.__qualname__}"
+
+    @classmethod
+    def _deserialize_callable(
+        cls,
+        path: str,
+        allowed_callback_namespaces: set[str] | None = None,
+        callback_registry: dict[str, Callable] | None = None,
+    ) -> Callable | None:
+        """Helper to deserialize a string path back to a callable."""
+        effective_registry = callback_registry if callback_registry is not None else CALLBACK_REGISTRY
+        effective_namespaces = (
+            allowed_callback_namespaces if allowed_callback_namespaces is not None else ALLOWED_CALLBACK_NAMESPACES
+        )
+
+        if path in effective_registry:
+            return effective_registry[path]
+
+        try:
+            if "." in path:
+                module_name, qualname = path.rsplit(".", 1)
+
+                # Security verification: check if it's a safe namespace
+                safe = any(module_name == ns or module_name.startswith(ns + ".") for ns in effective_namespaces)
+                if not safe:
+                    logger.warning(
+                        f"Skipping potentially unsafe callback path: '{path}'. "
+                        f"If this is intentional, add the namespace to ALLOWED_CALLBACK_NAMESPACES or CALLBACK_REGISTRY."
+                    )
+                    return None
+
+                module = importlib.import_module(module_name)
+                obj = module
+                for part in qualname.split("."):
+                    obj = getattr(obj, part)
+                return obj
+        except (ImportError, AttributeError, ValueError) as e:
+            logger.warning(f"Failed to deserialize callable from path '{path}': {e}")
+        return None
+
     def to_dict(self) -> dict[str, Any]:
         """Convert the agent to a dictionary representation.
 
         Returns:
             `dict`: Dictionary representation of the agent.
         """
-        # TODO: handle serializing step_callbacks and final_answer_checks
-        for attr in ["final_answer_checks", "step_callbacks"]:
-            if getattr(self, attr, None):
-                self.logger.log(f"This agent has {attr}: they will be ignored by this method.", LogLevel.INFO)
+        # Pre-process final_answer_checks and step_callbacks for serialization
+        final_answer_checks_paths = []
+        for check in self.final_answer_checks:
+            res = self._serialize_callable(check)
+            if res:
+                final_answer_checks_paths.append(res)
+
+        step_callbacks_paths = {}
+        # Avoid serializing the automatic monitor callback
+        for step_cls, callbacks in self.step_callbacks.items():
+            cls_name = step_cls.__name__
+            serialized_cbs = []
+            for cb in callbacks:
+                # Filter out the monitor's update_metrics as it will be re-registered during initialization
+                if hasattr(self, "monitor") and cb == self.monitor.update_metrics:
+                    continue
+                res = self._serialize_callable(cb)
+                if res:
+                    serialized_cbs.append(res)
+            if serialized_cbs:
+                step_callbacks_paths[cls_name] = serialized_cbs
 
         tool_dicts = [tool.to_dict() for tool in self.tools.values()]
         tool_requirements = {req for tool in self.tools.values() for req in tool.to_dict()["requirements"]}
@@ -998,6 +1107,8 @@ You have been provided with these additional arguments, that you can access dire
             },
             "managed_agents": [managed_agent.to_dict() for managed_agent in self.managed_agents.values()],
             "prompt_templates": self.prompt_templates,
+            "final_answer_checks": final_answer_checks_paths,
+            "step_callbacks": step_callbacks_paths,
             "max_steps": self.max_steps,
             "verbosity_level": int(self.logger.level),
             "planning_interval": self.planning_interval,
@@ -1008,11 +1119,19 @@ You have been provided with these additional arguments, that you can access dire
         return agent_dict
 
     @classmethod
-    def from_dict(cls, agent_dict: dict[str, Any], **kwargs) -> "MultiStepAgent":
+    def from_dict(
+        cls,
+        agent_dict: dict[str, Any],
+        allowed_callback_namespaces: set[str] | None = None,
+        callback_registry: dict[str, Callable] | None = None,
+        **kwargs,
+    ) -> "MultiStepAgent":
         """Create agent from a dictionary representation.
 
         Args:
             agent_dict (`dict[str, Any]`): Dictionary representation of the agent.
+            allowed_callback_namespaces (`set[str]`, *optional*): Additional allowed namespaces for callbacks.
+            callback_registry (`dict[str, Callable]`, *optional*): Additional callback registry.
             **kwargs: Additional keyword arguments that will override agent_dict values.
 
         Returns:
@@ -1031,6 +1150,34 @@ You have been provided with these additional arguments, that you can access dire
         tools = []
         for tool_info in agent_dict["tools"]:
             tools.append(Tool.from_code(tool_info["code"]))
+
+        # Load final answer checks and step callbacks
+        final_answer_checks = []
+        if "final_answer_checks" in agent_dict:
+            for path in agent_dict["final_answer_checks"]:
+                cb = cls._deserialize_callable(
+                    path, allowed_callback_namespaces=allowed_callback_namespaces, callback_registry=callback_registry
+                )
+                if cb:
+                    final_answer_checks.append(cb)
+
+        step_callbacks = {}
+        if "step_callbacks" in agent_dict:
+            for cls_name, paths in agent_dict["step_callbacks"].items():
+                step_cls = MEMORY_STEP_MAP.get(cls_name)
+                if step_cls:
+                    loaded_cbs = []
+                    for path in paths:
+                        cb = cls._deserialize_callable(
+                            path,
+                            allowed_callback_namespaces=allowed_callback_namespaces,
+                            callback_registry=callback_registry,
+                        )
+                        if cb:
+                            loaded_cbs.append(cb)
+                    if loaded_cbs:
+                        step_callbacks[step_cls] = loaded_cbs
+
         # Load managed agents
         managed_agents = []
         for managed_agent_dict in agent_dict["managed_agents"]:
@@ -1053,6 +1200,8 @@ You have been provided with these additional arguments, that you can access dire
             "planning_interval": agent_dict.get("planning_interval"),
             "name": agent_dict.get("name"),
             "description": agent_dict.get("description"),
+            "final_answer_checks": final_answer_checks or None,
+            "step_callbacks": step_callbacks or None,
         }
         # Filter out None values to use defaults from __init__
         agent_args = {k: v for k, v in agent_args.items() if v is not None}

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1001,16 +1001,10 @@ You have been provided with these additional arguments, that you can access dire
                 return path
 
         if not hasattr(c, "__module__") or not hasattr(c, "__qualname__"):
-            # Check if it has a __name__ at least
-            if hasattr(c, "__name__"):
-                # If it's a simple function/method, __module__ is usually available.
-                # If not, it might be a built-in or something weird.
-                self.logger.log(
-                    f"Callable {c} missing __module__ or __qualname__ and not in CALLBACK_REGISTRY. Using __name__ '{c.__name__}'.",
-                    LogLevel.WARNING,
-                )
-                return c.__name__
-            self.logger.log(f"Callable {c} cannot be serialized. Skipping.", LogLevel.WARNING)
+            self.logger.log(
+                f"Callable {c} missing __module__ or __qualname__ and not in CALLBACK_REGISTRY. Cannot serialize, skipping.",
+                LogLevel.WARNING,
+            )
             return None
 
         if "<lambda>" in c.__qualname__ or "<locals>" in c.__qualname__:

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1001,15 +1001,14 @@ You have been provided with these additional arguments, that you can access dire
                 return path
 
         if not hasattr(c, "__module__") or not hasattr(c, "__qualname__"):
-            self.logger.log(
-                f"Callable {c} missing __module__ or __qualname__ and not in CALLBACK_REGISTRY. Cannot serialize, skipping.",
-                LogLevel.WARNING,
+            logger.warning(
+                f"Callable {c} missing __module__ or __qualname__ and not in CALLBACK_REGISTRY. Cannot serialize, skipping."
             )
             return None
 
         if "<lambda>" in c.__qualname__ or "<locals>" in c.__qualname__:
-            self.logger.log(
-                f"Callable {c} is a lambda or local function and cannot be serialized. Skipping.", LogLevel.WARNING
+            logger.warning(
+                f"Callable {c} is a lambda or local function and cannot be serialized. Skipping."
             )
             return None
 

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -297,6 +297,10 @@ class CallbackRegistry:
             self._callbacks[step_cls] = []
         self._callbacks[step_cls].append(callback)
 
+    def items(self):
+        """Returns the internal callbacks dictionary items for serialization."""
+        return self._callbacks.items()
+
     def callback(self, memory_step, **kwargs):
         """Call callbacks registered for a step type.
 

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -120,9 +120,8 @@ class Monitor:
 class LogLevel(IntEnum):
     OFF = -1  # No output
     ERROR = 0  # Only errors
-    WARNING = 1  # Warnings
-    INFO = 2  # Normal output (default)
-    DEBUG = 3  # Detailed output
+    INFO = 1  # Normal output (default)
+    DEBUG = 2  # Detailed output
 
 
 YELLOW_HEX = "#d4b702"

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -114,14 +114,15 @@ class Monitor:
                 f"| Input tokens: {self.total_input_token_count:,} | Output tokens: {self.total_output_token_count:,}"
             )
         console_outputs += "]"
-        self.logger.log(Text(console_outputs, style="dim"), level=1)
+        self.logger.log(Text(console_outputs, style="dim"), level=LogLevel.INFO)
 
 
 class LogLevel(IntEnum):
     OFF = -1  # No output
     ERROR = 0  # Only errors
-    INFO = 1  # Normal output (default)
-    DEBUG = 2  # Detailed output
+    WARNING = 1  # Warnings
+    INFO = 2  # Normal output (default)
+    DEBUG = 3  # Detailed output
 
 
 YELLOW_HEX = "#d4b702"

--- a/tests/test_callable_serialization.py
+++ b/tests/test_callable_serialization.py
@@ -1,0 +1,174 @@
+import json
+import os
+import tempfile
+import unittest
+
+from smolagents.agents import ALLOWED_CALLBACK_NAMESPACES, CALLBACK_REGISTRY, CodeAgent, MultiStepAgent
+from smolagents.memory import ActionStep
+from smolagents.models import LiteLLMModel
+
+
+def my_test_callback(step):
+    """A dummy callback for testing."""
+    pass
+
+
+def my_test_check(answer):
+    """A dummy check for testing."""
+    return True
+
+
+class TestCallableSerialization(unittest.TestCase):
+    def setUp(self):
+        # Allow the tests namespace for deserialization during tests
+        ALLOWED_CALLBACK_NAMESPACES.add("tests")
+
+    def tearDown(self):
+        # Clean up: remove the tests namespace and any registry entries
+        ALLOWED_CALLBACK_NAMESPACES.discard("tests")
+        CALLBACK_REGISTRY.pop("custom.my_test_callback", None)
+
+    def test_roundtrip(self):
+        """Test full save/load cycle verifying callbacks are preserved."""
+        model = LiteLLMModel(model_id="gpt-4o", api_key="dummy")
+        agent = CodeAgent(
+            tools=[], model=model, step_callbacks=[my_test_callback], final_answer_checks=[my_test_check]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Save
+            agent.save(tmp_dir)
+
+            # 1. Verify JSON content
+            with open(os.path.join(tmp_dir, "agent.json"), "r") as f:
+                data = json.load(f)
+
+            # Check for serialized paths
+            self.assertIn("final_answer_checks", data)
+            self.assertIn("step_callbacks", data)
+
+            # Depending on how the test is run, the module might be __main__ or the file name
+            callback_path = f"{my_test_callback.__module__}.{my_test_callback.__qualname__}"
+            check_path = f"{my_test_check.__module__}.{my_test_check.__qualname__}"
+
+            self.assertIn(check_path, data["final_answer_checks"])
+            self.assertIn("ActionStep", data["step_callbacks"])
+            self.assertIn(callback_path, data["step_callbacks"]["ActionStep"])
+
+            # 2. Verify Reload
+            reloaded_agent = CodeAgent.from_folder(tmp_dir)
+
+            # Check checks
+            loaded_checks = reloaded_agent.final_answer_checks
+            self.assertEqual(len(loaded_checks), 1)
+            self.assertEqual(loaded_checks[0].__name__, "my_test_check")
+
+            # Check callbacks
+            loaded_cbs = reloaded_agent.step_callbacks._callbacks[ActionStep]
+            # One should be our callback, one should be monitor.update_metrics
+            cb_names = [cb.__name__ for cb in loaded_cbs]
+            self.assertIn("my_test_callback", cb_names)
+            self.assertIn("update_metrics", cb_names)
+
+    def test_lambda_skipping(self):
+        """Verify lambda functions are safely skipped during serialization."""
+        model = LiteLLMModel(model_id="gpt-4o", api_key="dummy")
+        agent = CodeAgent(tools=[], model=model, final_answer_checks=[lambda x: True])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            agent.save(tmp_dir)
+            with open(os.path.join(tmp_dir, "agent.json"), "r") as f:
+                data = json.load(f)
+
+            # Lambda should be skipped
+            self.assertEqual(len(data["final_answer_checks"]), 0)
+
+    def test_security_whitelist_blocks_unsafe(self):
+        """Verify unsafe module paths (e.g., os.system) are blocked."""
+        unsafe_path = "os.system"
+        res = MultiStepAgent._deserialize_callable(unsafe_path)
+        self.assertIsNone(res)
+
+    def test_security_whitelist_allows_smolagents(self):
+        """Verify smolagents namespace is allowed."""
+        safe_path = "smolagents.agents.MultiStepAgent"
+        res = MultiStepAgent._deserialize_callable(safe_path)
+        self.assertEqual(res, MultiStepAgent)
+
+    def test_callback_registry_lookup(self):
+        """Verify CALLBACK_REGISTRY is checked before namespace validation."""
+        # Register a callback under a custom (normally blocked) path
+        CALLBACK_REGISTRY["custom.my_test_callback"] = my_test_callback
+
+        res = MultiStepAgent._deserialize_callable("custom.my_test_callback")
+        self.assertEqual(res, my_test_callback)
+
+    def test_allowed_namespaces_extension(self):
+        """Verify that ALLOWED_CALLBACK_NAMESPACES can be extended for user packages."""
+        # 'tests' was already added in setUp
+        path = f"{my_test_callback.__module__}.{my_test_callback.__qualname__}"
+        res = MultiStepAgent._deserialize_callable(path)
+        self.assertEqual(res, my_test_callback)
+
+        # Remove the namespace and verify it's now blocked
+        ALLOWED_CALLBACK_NAMESPACES.discard("tests")
+        res = MultiStepAgent._deserialize_callable(path)
+        self.assertIsNone(res)
+
+    def test_instance_level_isolation(self):
+        """Verify that setting allowed_callback_namespaces on one agent does not affect another."""
+        model = LiteLLMModel(model_id="gpt-4o", api_key="dummy")
+        # Agent 1 allows 'tests'
+        agent1 = CodeAgent(
+            tools=[],
+            model=model,
+            step_callbacks=[my_test_callback],
+            allowed_callback_namespaces={"smolagents", "tests"},
+        )
+        # Agent 2 allows only 'smolagents'
+        agent2 = CodeAgent(
+            tools=[], model=model, step_callbacks=[my_test_callback], allowed_callback_namespaces={"smolagents"}
+        )
+
+        # Agent 1 should be able to serialize/deserialize it (if it used its own namespaces)
+        # Note: _deserialize_callable is a classmethod, so we need to pass the namespaces manually
+        # OR we check if the agent instance uses it in to_dict/from_dict logic
+
+        with tempfile.TemporaryDirectory() as tmp_dir1, tempfile.TemporaryDirectory() as tmp_dir2:
+            agent1.save(tmp_dir1)
+            agent2.save(tmp_dir2)
+
+            # Loading agent1 with 'tests' whitelist should work
+            loaded1 = CodeAgent.from_folder(tmp_dir1, allowed_callback_namespaces={"smolagents", "tests"})
+            self.assertEqual(len(loaded1.step_callbacks._callbacks[ActionStep]), 2)  # our cb + monitor
+
+            # Loading agent2 WITH 'tests' whitelist should check if it was even saved
+            # Wait, serialization ALWAYS saves the path. Deserialization checks the whitelist.
+
+            # Loading agent1 WITHOUT 'tests' whitelist should fail to load our callback
+            loaded1_restricted = CodeAgent.from_folder(tmp_dir1, allowed_callback_namespaces={"smolagents"})
+            cb_names = [cb.__name__ for cb in loaded1_restricted.step_callbacks._callbacks[ActionStep]]
+            self.assertNotIn("my_test_callback", cb_names)
+
+    def test_callback_registry_instance_level(self):
+        """Verify instance-level callback_registry works."""
+        model = LiteLLMModel(model_id="gpt-4o", api_key="dummy")
+        custom_registry = {"custom.path": my_test_callback}
+        agent = CodeAgent(tools=[], model=model, callback_registry=custom_registry, step_callbacks=[my_test_callback])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            agent.save(tmp_dir)
+
+            # Should load if we pass the same registry
+            loaded = CodeAgent.from_folder(tmp_dir, callback_registry=custom_registry)
+            cb_names = [cb.__name__ for cb in loaded.step_callbacks._callbacks[ActionStep]]
+            self.assertIn("my_test_callback", cb_names)
+
+            # Should NOT load if we don't pass the registry and it's not in global or whitelist
+            loaded_no_reg = CodeAgent.from_folder(tmp_dir)
+            cb_names_no_reg = [cb.__name__ for cb in loaded_no_reg.step_callbacks._callbacks[ActionStep]]
+            self.assertNotIn("my_test_callback", cb_names_no_reg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_callable_serialization.py
+++ b/tests/test_callable_serialization.py
@@ -19,13 +19,8 @@ def my_test_check(answer):
 
 
 class TestCallableSerialization(unittest.TestCase):
-    def setUp(self):
-        # Allow the tests namespace for deserialization during tests
-        ALLOWED_CALLBACK_NAMESPACES.add("tests")
-
     def tearDown(self):
-        # Clean up: remove the tests namespace and any registry entries
-        ALLOWED_CALLBACK_NAMESPACES.discard("tests")
+        # Clean up any registry entries
         CALLBACK_REGISTRY.pop("custom.my_test_callback", None)
 
     def test_roundtrip(self):
@@ -56,7 +51,7 @@ class TestCallableSerialization(unittest.TestCase):
             self.assertIn(callback_path, data["step_callbacks"]["ActionStep"])
 
             # 2. Verify Reload
-            reloaded_agent = CodeAgent.from_folder(tmp_dir)
+            reloaded_agent = CodeAgent.from_folder(tmp_dir, allowed_callback_namespaces={"smolagents", "tests"})
 
             # Check checks
             loaded_checks = reloaded_agent.final_answer_checks
@@ -64,7 +59,7 @@ class TestCallableSerialization(unittest.TestCase):
             self.assertEqual(loaded_checks[0].__name__, "my_test_check")
 
             # Check callbacks
-            loaded_cbs = reloaded_agent.step_callbacks._callbacks[ActionStep]
+            loaded_cbs = dict(reloaded_agent.step_callbacks.items())[ActionStep]
             # One should be our callback, one should be monitor.update_metrics
             cb_names = [cb.__name__ for cb in loaded_cbs]
             self.assertIn("my_test_callback", cb_names)
@@ -105,15 +100,18 @@ class TestCallableSerialization(unittest.TestCase):
 
     def test_allowed_namespaces_extension(self):
         """Verify that ALLOWED_CALLBACK_NAMESPACES can be extended for user packages."""
-        # 'tests' was already added in setUp
-        path = f"{my_test_callback.__module__}.{my_test_callback.__qualname__}"
-        res = MultiStepAgent._deserialize_callable(path)
-        self.assertEqual(res, my_test_callback)
+        ALLOWED_CALLBACK_NAMESPACES.add("tests")
+        try:
+            path = f"{my_test_callback.__module__}.{my_test_callback.__qualname__}"
+            res = MultiStepAgent._deserialize_callable(path)
+            self.assertEqual(res, my_test_callback)
 
-        # Remove the namespace and verify it's now blocked
-        ALLOWED_CALLBACK_NAMESPACES.discard("tests")
-        res = MultiStepAgent._deserialize_callable(path)
-        self.assertIsNone(res)
+            # Remove the namespace and verify it's now blocked
+            ALLOWED_CALLBACK_NAMESPACES.discard("tests")
+            res = MultiStepAgent._deserialize_callable(path)
+            self.assertIsNone(res)
+        finally:
+            ALLOWED_CALLBACK_NAMESPACES.discard("tests")
 
     def test_instance_level_isolation(self):
         """Verify that setting allowed_callback_namespaces on one agent does not affect another."""
@@ -140,14 +138,11 @@ class TestCallableSerialization(unittest.TestCase):
 
             # Loading agent1 with 'tests' whitelist should work
             loaded1 = CodeAgent.from_folder(tmp_dir1, allowed_callback_namespaces={"smolagents", "tests"})
-            self.assertEqual(len(loaded1.step_callbacks._callbacks[ActionStep]), 2)  # our cb + monitor
-
-            # Loading agent2 WITH 'tests' whitelist should check if it was even saved
-            # Wait, serialization ALWAYS saves the path. Deserialization checks the whitelist.
+            self.assertEqual(len(dict(loaded1.step_callbacks.items())[ActionStep]), 2)  # our cb + monitor
 
             # Loading agent1 WITHOUT 'tests' whitelist should fail to load our callback
             loaded1_restricted = CodeAgent.from_folder(tmp_dir1, allowed_callback_namespaces={"smolagents"})
-            cb_names = [cb.__name__ for cb in loaded1_restricted.step_callbacks._callbacks[ActionStep]]
+            cb_names = [cb.__name__ for cb in dict(loaded1_restricted.step_callbacks.items()).get(ActionStep, [])]
             self.assertNotIn("my_test_callback", cb_names)
 
     def test_callback_registry_instance_level(self):
@@ -161,12 +156,12 @@ class TestCallableSerialization(unittest.TestCase):
 
             # Should load if we pass the same registry
             loaded = CodeAgent.from_folder(tmp_dir, callback_registry=custom_registry)
-            cb_names = [cb.__name__ for cb in loaded.step_callbacks._callbacks[ActionStep]]
+            cb_names = [cb.__name__ for cb in dict(loaded.step_callbacks.items())[ActionStep]]
             self.assertIn("my_test_callback", cb_names)
 
             # Should NOT load if we don't pass the registry and it's not in global or whitelist
             loaded_no_reg = CodeAgent.from_folder(tmp_dir)
-            cb_names_no_reg = [cb.__name__ for cb in loaded_no_reg.step_callbacks._callbacks[ActionStep]]
+            cb_names_no_reg = [cb.__name__ for cb in dict(loaded_no_reg.step_callbacks.items()).get(ActionStep, [])]
             self.assertNotIn("my_test_callback", cb_names_no_reg)
 
 


### PR DESCRIPTION
## What does this PR do?

Implements secure, path-based serialization for [step_callbacks](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:441:4-459:77) and `final_answer_checks` in [MultiStepAgent](cci:2://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:285:0-1354:13), enabling these callable attributes to be properly saved via [save()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:917:4-993:65) and restored via [from_folder()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1260:4-1300:50).

Closes #2142

## Problem

Currently, when a [MultiStepAgent](cci:2://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:285:0-1354:13) is saved using [save()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:917:4-993:65) and reloaded via [from_folder()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1260:4-1300:50), custom [step_callbacks](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:441:4-459:77) or `final_answer_checks` are lost. The existing code explicitly skips these attributes in [to_dict()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1055:4-1112:25) with a TODO comment.

## Solution

### 🔐 Security & Design (Updated after review)
- **Safe Defaults**: Removed `__main__` from the default `ALLOWED_CALLBACK_NAMESPACES` to prevent unauthorized symbol loading in shared environments.
- **Design / Isolation**: `CALLBACK_REGISTRY` and `ALLOWED_CALLBACK_NAMESPACES` are now fully configurable at the instance-level (via `MultiStepAgent.__init__` and [from_folder](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1260:4-1300:50)). *Note: The module-level globals still exist and safely act as default fallbacks when instantiated without specific overrides*, which maintains backward compatibility while enabling true scoping for multi-agent processes.
- **Improved Encapsulation**: Added a public `items()` method to `CallbackRegistry` to avoid direct access to private `._callbacks` during serialization.
- **Enhanced Visibility**: Serialization failures (e.g., lambdas/locals) now log at `LogLevel.WARNING` level instead of `INFO`.

### Serialization ([to_dict](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1055:4-1112:25))
- Added [_serialize_callable()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:995:4-1015:49) instance method that converts callables to module paths using `__module__` + `__qualname__`.
- Lambda functions and local functions are safely skipped with a warning log.
- `monitor.update_metrics` is filtered out to prevent duplication on reload.

### Deserialization ([from_dict](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1922:4-1946:65))
- Added [_deserialize_callable()](cci:1://file:///Users/cheonhyeonjun/workspace/09opensource_smolagents/smolagents/src/smolagents/agents.py:1017:4-1053:19) class method that restores callables from module paths using `importlib.import_module` + `getattr`.
- **Whitelisting**: Checks against the agent's `allowed_callback_namespaces` (default: `{"smolagents"}`).
- Failed deserialization logs a warning and skips the callback gracefully.

## Example

### Option 1: Using Instance-level Security
```python
# Pass allowed namespaces during initialization for isolation
agent = CodeAgent(
    tools=[],
    model=model,
    step_callbacks=[my_callback],
    allowed_callback_namespaces={"smolagents", "my_custom_package"}
)
agent.save("./my_agent")

# Load with the same allowance
loaded_agent = CodeAgent.from_folder("./my_agent", allowed_callback_namespaces={"smolagents", "my_custom_package"})
