### PR TITLE
feat: add max_context_chars parameter for automatic memory truncation

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -308,6 +308,7 @@ class MultiStepAgent(ABC):
         provide_run_summary: bool = False,
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
+        max_context_chars: int | None = None,
         logger: AgentLogger | None = None,
     ):
         self.agent_name = self.__class__.__name__
@@ -341,6 +342,7 @@ class MultiStepAgent(ABC):
 
         self.task: str | None = None
         self.memory = AgentMemory(self.system_prompt)
+        self.max_context_chars = max_context_chars
 
         if logger is None:
             self.logger = AgentLogger(level=verbosity_level)
@@ -756,18 +758,25 @@ You have been provided with these additional arguments, that you can access dire
         self.interrupt_switch = True
 
     def write_memory_to_messages(
-        self,
-        summary_mode: bool = False,
-    ) -> list[ChatMessage]:
-        """
-        Reads past llm_outputs, actions, and observations or errors from the memory into a series of messages
-        that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
-        the LLM.
-        """
-        messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
-        for memory_step in self.memory.steps:
-            messages.extend(memory_step.to_messages(summary_mode=summary_mode))
-        return messages
+            self,
+            summary_mode: bool = False,
+        ) -> list[ChatMessage]:
+            """
+            Reads past llm_outputs, actions, and observations or errors from the memory into a series of messages
+            that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
+            the LLM.
+            """
+            if self.max_context_chars is not None and not summary_mode:
+                removed = self.memory.truncate_steps(self.max_context_chars)
+                if removed > 0:
+                    logger.warning(
+                        f"Context limit approaching: removed {removed} oldest step(s) from memory. "
+                        f"Increase `max_context_chars` to retain more history."
+                    )
+            messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
+            for memory_step in self.memory.steps:
+                messages.extend(memory_step.to_messages(summary_mode=summary_mode))
+            return messages
 
     def _step_stream(
         self, memory_step: ActionStep

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -760,24 +760,24 @@ You have been provided with these additional arguments, that you can access dire
     def write_memory_to_messages(
         self,
         summary_mode: bool = False,
-        ) -> list[ChatMessage]:
-            """
-            Reads past llm_outputs, actions, and observations or errors from the memory into a series of messages
-            that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
-            the LLM.
-            """
-            # summary_mode already produces condensed messages, skip truncation
-            if self.max_context_chars is not None and not summary_mode:
-                removed = self.memory.truncate_steps(self.max_context_chars)
-                if removed > 0:
-                    self.logger.log(
-                        f"Context limit approaching: removed {removed} oldest step(s) from memory. "
-                        f"Increase `max_context_chars` to retain more history."
-                    )
-            messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
-            for memory_step in self.memory.steps:
-                messages.extend(memory_step.to_messages(summary_mode=summary_mode))
-            return messages
+    ) -> list[ChatMessage]:
+        """
+        Reads past llm_outputs, actions, and observations or errors from the memory into a series of messages
+        that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
+        the LLM.
+        """
+        # summary_mode already produces condensed messages, skip truncation
+        if self.max_context_chars is not None and not summary_mode:
+            removed = self.memory.truncate_steps(self.max_context_chars)
+            if removed > 0:
+                self.logger.log(
+                    f"Context limit approaching: removed {removed} oldest step(s) from memory. "
+                    f"Increase `max_context_chars` to retain more history."
+                )
+        messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
+        for memory_step in self.memory.steps:
+            messages.extend(memory_step.to_messages(summary_mode=summary_mode))
+        return messages
 
     def _step_stream(
         self, memory_step: ActionStep

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -758,18 +758,19 @@ You have been provided with these additional arguments, that you can access dire
         self.interrupt_switch = True
 
     def write_memory_to_messages(
-            self,
-            summary_mode: bool = False,
+        self,
+        summary_mode: bool = False,
         ) -> list[ChatMessage]:
             """
             Reads past llm_outputs, actions, and observations or errors from the memory into a series of messages
             that can be used as input to the LLM. Adds a number of keywords (such as PLAN, error, etc) to help
             the LLM.
             """
+            # summary_mode already produces condensed messages, skip truncation
             if self.max_context_chars is not None and not summary_mode:
                 removed = self.memory.truncate_steps(self.max_context_chars)
                 if removed > 0:
-                    logger.warning(
+                    self.logger.log(
                         f"Context limit approaching: removed {removed} oldest step(s) from memory. "
                         f"Increase `max_context_chars` to retain more history."
                     )

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -293,20 +293,14 @@ class AgentMemory:
         # compute once before the loop
         total_chars = sum(step_chars(step) for step in self.steps)
 
-        while len(self.steps) > 1:  # always keep at least the TaskStep
-            if total_chars <= max_chars:
-                break
-            # drop oldest step that is not a TaskStep
-            for i, step in enumerate(self.steps):
-                if not isinstance(step, TaskStep):
-                    total_chars -= step_chars(step)  # subtract before removing
-                    self.steps.pop(i)
-                    removed += 1
-                    break
-            else:
-                break  # only TaskSteps remain
-        return removed
+        while len(self.steps) > 1 and total_chars > max_chars:
+            step = self.steps[1]
+            total_chars -= step_chars(step)
+            self.steps.pop(1)
+            removed += 1
 
+        return removed
+    
 class CallbackRegistry:
     """Registry for callbacks that are called at each step of the agent's execution.
 

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -275,7 +275,32 @@ class AgentMemory:
         return "\n\n".join(
             [step.code_action for step in self.steps if isinstance(step, ActionStep) and step.code_action is not None]
         )
-
+    
+    def truncate_steps(self, max_chars: int) -> int:
+        """Remove oldest non-task steps until estimated character count is below max_chars.
+        Uses character count as a token proxy (4 chars ≈ 1 token).
+        Returns number of steps removed.
+        """
+        removed = 0
+        while len(self.steps) > 1:  # always keep at least the TaskStep
+            # estimate total chars across all current steps
+            total_chars = sum(
+                len(str(part.get("text", "")))
+                for step in self.steps
+                for msg in step.to_messages()
+                for part in (msg.content if isinstance(msg.content, list) else [{"text": str(msg.content)}])
+            )
+            if total_chars <= max_chars:
+                break
+            # drop oldest step that is not a TaskStep
+            for i, step in enumerate(self.steps):
+                if not isinstance(step, TaskStep):
+                    self.steps.pop(i)
+                    removed += 1
+                    break
+            else:
+                break  # only TaskSteps remain, cannot truncate further
+        return removed
 
 class CallbackRegistry:
     """Registry for callbacks that are called at each step of the agent's execution.

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -278,28 +278,33 @@ class AgentMemory:
     
     def truncate_steps(self, max_chars: int) -> int:
         """Remove oldest non-task steps until estimated character count is below max_chars.
-        Uses character count as a token proxy (4 chars ≈ 1 token).
+        Uses character count as a token proxy (4 chars ≈ 1 token). Approximation only.
         Returns number of steps removed.
         """
         removed = 0
-        while len(self.steps) > 1:  # always keep at least the TaskStep
-            # estimate total chars across all current steps
-            total_chars = sum(
+
+        def step_chars(step):
+            return sum(
                 len(str(part.get("text", "")))
-                for step in self.steps
                 for msg in step.to_messages()
                 for part in (msg.content if isinstance(msg.content, list) else [{"text": str(msg.content)}])
             )
+
+        # compute once before the loop
+        total_chars = sum(step_chars(step) for step in self.steps)
+
+        while len(self.steps) > 1:  # always keep at least the TaskStep
             if total_chars <= max_chars:
                 break
             # drop oldest step that is not a TaskStep
             for i, step in enumerate(self.steps):
                 if not isinstance(step, TaskStep):
+                    total_chars -= step_chars(step)  # subtract before removing
                     self.steps.pop(i)
                     removed += 1
                     break
             else:
-                break  # only TaskSteps remain, cannot truncate further
+                break  # only TaskSteps remain
         return removed
 
 class CallbackRegistry:

--- a/tests/test_context_truncation.py
+++ b/tests/test_context_truncation.py
@@ -1,0 +1,45 @@
+import time
+import pytest
+from smolagents.memory import AgentMemory, TaskStep, ActionStep
+from smolagents.monitoring import Timing
+
+
+def make_action_step(step_number: int, observation: str) -> ActionStep:
+    return ActionStep(
+        step_number=step_number,
+        timing=Timing(start_time=time.time(), end_time=time.time()),
+        observations=observation,
+    )
+
+
+def test_truncate_steps_removes_oldest_first():
+    mem = AgentMemory("You are a helpful agent.")
+    mem.steps.append(TaskStep(task="What is 2+2?"))
+    for i in range(3):
+        mem.steps.append(make_action_step(i, "long observation " * 200))
+
+    removed = mem.truncate_steps(max_chars=100)
+    assert removed > 0
+    # TaskStep must always be kept
+    assert any(isinstance(s, TaskStep) for s in mem.steps)
+
+
+def test_truncate_steps_no_removal_when_under_limit():
+    mem = AgentMemory("You are a helpful agent.")
+    mem.steps.append(TaskStep(task="hi"))
+    mem.steps.append(make_action_step(0, "short"))
+
+    removed = mem.truncate_steps(max_chars=999999)
+    assert removed == 0
+    assert len(mem.steps) == 2
+
+
+def test_truncate_steps_preserves_task_step():
+    mem = AgentMemory("You are a helpful agent.")
+    mem.steps.append(TaskStep(task="What is 2+2?"))
+    mem.steps.append(make_action_step(0, "x" * 10000))
+
+    mem.truncate_steps(max_chars=1)
+    # Only TaskStep should remain
+    assert len(mem.steps) == 1
+    assert isinstance(mem.steps[0], TaskStep)


### PR DESCRIPTION
## Problem

When `MultiStepAgent` runs multi-step tasks with large tool outputs, 
context grows unbounded and eventually crashes with a cryptic API error:
invalid_request_error, tool_use_failed

No warning, no graceful recovery — the agent just dies. Users have no 
idea why. Reported in HuggingFace Discord (help-and-feedback, 2026-04-02).

Related: #1385, #901

## Solution

Add an opt-in `max_context_chars` parameter to `MultiStepAgent`:
```python
agent = ToolCallingAgent(
    tools=[...],
    model=model,
    max_context_chars=40000,  # ~10k tokens
)
```

When context exceeds the limit, the agent:
1. Removes oldest non-task steps from memory
2. Logs a clear warning to the user
3. Continues running gracefully

## Changes

- `memory.py` — add `AgentMemory.truncate_steps(max_chars)`
- `agents.py` — add `max_context_chars` param, call truncation in `write_memory_to_messages()`
- `tests/test_context_truncation.py` — 3 unit tests

## Behavior

- `max_context_chars=None` (default) — zero behavior change for existing users
- `TaskStep` is never removed — agent always remembers the original task
- Uses `len(chars) / 4 ≈ tokens` estimate — no tokenizer dependency

## Test

3/3 unit tests pass. Also verified with a real model run (Qwen2.5-72B):
Step 2: Context limit approaching: removed 1 oldest step(s) from memory.
Step 3: Context limit approaching: removed 1 oldest step(s) from memory.

Agent continued running instead of crashing.