### PR TITLE
Fix f-string escape in `SafeSerializer.dumps` error message

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
+                    raise SerializationError(f"Cannot serialize object: {e}") from e
 
     @staticmethod
     def loads(data, allow_pickle=False):


### PR DESCRIPTION
Fixes #2133

### What does this PR do?

Fixes an f-string formatting bug in `SafeSerializer.dumps` (line 429 of `serialization.py`) where double braces `{{e}}` produce the literal text `{e}` instead of interpolating the exception variable.

**Before:** `Cannot serialize object: {e}` (literal text, unhelpful)
**After:** `Cannot serialize object: PicklingError('...')` (actual exception details)

The correct single-brace form is already used on line 292 in the same file.

### One-line change