### PR TITLE
fix: correct f-string escape in SafeSerializer error message

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
+                    raise SerializationError(f"Cannot serialize object: {e}") from e
 
     @staticmethod
     def loads(data, allow_pickle=False):


### PR DESCRIPTION
Fixes #2133

Line 429 in `serialization.py` had `{{e}}` instead of `{e}` inside an f-string, so the error message from `SafeSerializer.dumps` always printed the literal text `{e}` instead of the actual exception. Line 292 in the same file already does it correctly. One character fix.