### PR TITLE
feat: track cache tokens in TokenUsage for Anthropic, OpenAI, and Bedrock

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1303,6 +1303,8 @@ class LiteLLMModel(ApiModel):
             token_usage=TokenUsage(
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
+                cache_creation_input_tokens=getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
+                cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
             ),
         )
 
@@ -1336,6 +1338,8 @@ class LiteLLMModel(ApiModel):
                     token_usage=TokenUsage(
                         input_tokens=event.usage.prompt_tokens,
                         output_tokens=event.usage.completion_tokens,
+                        cache_creation_input_tokens=getattr(event.usage, "cache_creation_input_tokens", 0) or 0,
+                        cache_read_input_tokens=getattr(event.usage, "cache_read_input_tokens", 0) or 0,
                     ),
                 )
             if event.choices:
@@ -1585,6 +1589,8 @@ class InferenceClientModel(ApiModel):
             token_usage=TokenUsage(
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
+                cache_creation_input_tokens=getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
+                cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
             ),
         )
 
@@ -1619,6 +1625,8 @@ class InferenceClientModel(ApiModel):
                     token_usage=TokenUsage(
                         input_tokens=event.usage.prompt_tokens,
                         output_tokens=event.usage.completion_tokens,
+                        cache_creation_input_tokens=getattr(event.usage, "cache_creation_input_tokens", 0) or 0,
+                        cache_read_input_tokens=getattr(event.usage, "cache_read_input_tokens", 0) or 0,
                     ),
                 )
             if event.choices:
@@ -1730,11 +1738,13 @@ class OpenAIModel(ApiModel):
             stream_options={"include_usage": True},
         ):
             if event.usage:
+                _ptd = getattr(event.usage, "prompt_tokens_details", None)
                 yield ChatMessageStreamDelta(
                     content="",
                     token_usage=TokenUsage(
                         input_tokens=event.usage.prompt_tokens,
                         output_tokens=event.usage.completion_tokens,
+                        cache_read_input_tokens=getattr(_ptd, "cached_tokens", 0) or 0,
                     ),
                 )
             if event.choices:
@@ -1781,6 +1791,7 @@ class OpenAIModel(ApiModel):
         content = response.choices[0].message.content
         if stop_sequences is not None and not self.supports_stop_parameter:
             content = remove_content_after_stop_sequences(content, stop_sequences)
+        _ptd = getattr(response.usage, "prompt_tokens_details", None)
         return ChatMessage(
             role=response.choices[0].message.role,
             content=content,
@@ -1789,6 +1800,7 @@ class OpenAIModel(ApiModel):
             token_usage=TokenUsage(
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
+                cache_read_input_tokens=getattr(_ptd, "cached_tokens", 0) or 0,
             ),
         )
 
@@ -2056,6 +2068,8 @@ class AmazonBedrockModel(ApiModel):
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],
                 output_tokens=response["usage"]["outputTokens"],
+                cache_creation_input_tokens=response["usage"].get("cacheWriteInputTokenCount", 0) or 0,
+                cache_read_input_tokens=response["usage"].get("cacheReadInputTokenCount", 0) or 0,
             ),
         )
 

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2100,3 +2100,4 @@ __all__ = [
     "AmazonBedrockModel",
     "ChatMessage",
 ]
+

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -41,6 +41,8 @@ class TokenUsage:
 
     input_tokens: int
     output_tokens: int
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
     total_tokens: int = field(init=False)
 
     def __post_init__(self):
@@ -50,6 +52,8 @@ class TokenUsage:
         return {
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
             "total_tokens": self.total_tokens,
         }
 
@@ -79,23 +83,29 @@ class Timing:
 
 
 class Monitor:
-    def __init__(self, tracked_model, logger):
+    def __init__(self, tracked_model=None, logger=None):
         self.step_durations = []
         self.tracked_model = tracked_model
         self.logger = logger
         self.total_input_token_count = 0
         self.total_output_token_count = 0
+        self.total_cache_creation_input_token_count = 0
+        self.total_cache_read_input_token_count = 0
 
     def get_total_token_counts(self) -> TokenUsage:
         return TokenUsage(
             input_tokens=self.total_input_token_count,
             output_tokens=self.total_output_token_count,
+            cache_creation_input_tokens=self.total_cache_creation_input_token_count,
+            cache_read_input_tokens=self.total_cache_read_input_token_count,
         )
 
     def reset(self):
         self.step_durations = []
         self.total_input_token_count = 0
         self.total_output_token_count = 0
+        self.total_cache_creation_input_token_count = 0
+        self.total_cache_read_input_token_count = 0
 
     def update_metrics(self, step_log):
         """Update the metrics of the monitor.
@@ -110,6 +120,8 @@ class Monitor:
         if step_log.token_usage is not None:
             self.total_input_token_count += step_log.token_usage.input_tokens
             self.total_output_token_count += step_log.token_usage.output_tokens
+            self.total_cache_creation_input_token_count += step_log.token_usage.cache_creation_input_tokens
+            self.total_cache_read_input_token_count += step_log.token_usage.cache_read_input_tokens
             console_outputs += (
                 f"| Input tokens: {self.total_input_token_count:,} | Output tokens: {self.total_output_token_count:,}"
             )

--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -271,3 +271,4 @@ class AgentLogger:
             )
         build_agent_tree(main_tree, agent)
         self.console.print(main_tree)
+


### PR DESCRIPTION
Fixes #2055

smolagents was silently dropping cache token fields from API responses. Anthropic charges significantly less for cache reads, but there was no way to tell if prompt caching was actually working since the counts weren't surfaced anywhere.

Added two new optional fields to `TokenUsage` — `cache_creation_input_tokens` and `cache_read_input_tokens` — both default to 0 so it's backward compatible. Each provider extracts them differently: LiteLLM/Anthropic uses `cache_creation_input_tokens` and `cache_read_input_tokens` on the usage object, OpenAI uses `prompt_tokens_details.cached_tokens`, and Bedrock uses `cacheWriteInputTokenCount` / `cacheReadInputTokenCount`. Monitor now aggregates these across steps and includes them in `get_total_token_counts()`.