### PR TITLE
fix: fix typos and formatting in remote_executors.py

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -1060,7 +1060,7 @@ class BlaxelExecutor(RemotePythonExecutor):
             self._delete_sandbox()
         except Exception as e:
             # Log cleanup errors but don't raise - cleanup should be best-effort
-            self.logger.log(f"Error during cleanup: : {e}", level=LogLevel.INFO)
+            self.logger.log(f"Error during cleanup: {e}", level=LogLevel.INFO)
         finally:
             # Always clean up local references
             if hasattr(self, "sandbox"):
@@ -1083,8 +1083,8 @@ class WasmExecutor(RemotePythonExecutor):
     """
     Remote Python code executor in a sandboxed WebAssembly environment powered by Pyodide and Deno.
 
-    This executor combines Deno's secure runtime with Pyodide's WebAssembly‑compiled Python interpreter to deliver s
-    trong isolation guarantees while enabling full Python execution.
+    This executor combines Deno's secure runtime with Pyodide's WebAssembly‑compiled Python interpreter to deliver
+    strong isolation guarantees while enabling full Python execution.
 
     Args:
         additional_imports (`list[str]`): Additional Python packages to install in the Pyodide environment.
@@ -1365,7 +1365,7 @@ class WasmExecutor(RemotePythonExecutor):
                 error.pythonExceptionType = errorMatch[1].split(".").pop();
               }
 
-              // If the error is a FinalAnswerException, extract its the encoded value
+              // If the error is a FinalAnswerException, extract the encoded value
               if (error.pythonExceptionType === "FinalAnswerException") {
                 // Extract the base64 encoded value from the error message
                 const valueMatch = e.message.match(/FinalAnswerException: (.*?)(?:\\n|$)/);

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -1057,7 +1057,7 @@ class BlaxelExecutor(RemotePythonExecutor):
             self._delete_sandbox()
         except Exception as e:
             # Log cleanup errors but don't raise - cleanup should be best-effort
-            self.logger.log(f"Error during cleanup: : {e}", level=LogLevel.INFO)
+            self.logger.log(f"Error during cleanup: {e}", level=LogLevel.INFO)
         finally:
             # Always clean up local references
             if hasattr(self, "sandbox"):


### PR DESCRIPTION
## Summary
- Remove duplicate colon in cleanup error log message (`Error during cleanup: : {e}` → `Error during cleanup: {e}`)
- Fix grammar in comment: `extract its the encoded value` → `extract the encoded value`
- Fix word "strong" broken mid-word across lines in WasmExecutor docstring (shows as "s\ntrong" in `help()` output)

## Test plan
- [ ] Verify log message formatting is correct
- [ ] Verify `help(WasmExecutor)` displays docstring properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)