### PR TITLE
fix: correct typos and grammar across multiple files

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 """This module contains utilities exclusively taken from `transformers` repository.
 
-Since they are not specific to `transformers` and that `transformers` is an heavy dependencies, those helpers have
+Since they are not specific to `transformers` and that `transformers` is a heavy dependency, those helpers have
 been duplicated.
 
 TODO: move them to `huggingface_hub` to avoid code duplication.

--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -152,7 +152,7 @@ class AgentImage(AgentType, PIL.Image.Image):
 
             array = self._tensor.cpu().detach().numpy()
 
-            # There is likely simpler than load into image into save
+            # There is likely a simpler way than loading into image and saving
             img = PIL.Image.fromarray((255 - array * 255).astype(np.uint8))
 
             directory = tempfile.mkdtemp()

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -613,7 +613,7 @@ class SpeechToTextTool(PipelineTool):
     inputs = {
         "audio": {
             "type": "audio",
-            "description": "The audio to transcribe. Can be a local path, an url, or a tensor.",
+            "description": "The audio to transcribe. Can be a local path, a URL, or a tensor.",
         }
     }
     output_type = "string"

--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -31,11 +31,11 @@ if TYPE_CHECKING:
 
 
 class MCPClient:
-    """Manages the connection to an MCP server and make its tools available to SmolAgents.
+    """Manages the connection to an MCP server and makes its tools available to SmolAgents.
 
     Note: tools can only be accessed after the connection has been started with the
         `connect()` method, done during the init. If you don't use the context manager
-        we strongly encourage to use "try ... finally" to ensure the connection is cleaned up.
+        we strongly encourage you to use "try ... finally" to ensure the connection is cleaned up.
 
     Args:
         server_parameters (StdioServerParameters | dict[str, Any] | list[StdioServerParameters | dict[str, Any]]):

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -234,7 +234,7 @@ def agglomerate_stream_deltas(
         if stream_delta.content:
             accumulated_content += stream_delta.content
         if stream_delta.tool_calls:
-            for tool_call_delta in stream_delta.tool_calls:  # ?ormally there should be only one call at a time
+            for tool_call_delta in stream_delta.tool_calls:  # Normally there should be only one call at a time
                 # Extend accumulated_tool_calls list to accommodate the new tool call if needed
                 if tool_call_delta.index is not None:
                     if tool_call_delta.index not in accumulated_tool_calls:
@@ -1146,14 +1146,14 @@ class ApiModel(Model):
     Parameters:
         model_id (`str`):
             The identifier for the model to be used with the API.
-        custom_role_conversions (`dict[str, str`], **optional**):
-            Mapping to convert  between internal role names and API-specific role names. Defaults to None.
+        custom_role_conversions (`dict[str, str]`, **optional**):
+            Mapping to convert between internal role names and API-specific role names. Defaults to None.
         client (`Any`, **optional**):
             Pre-configured API client instance. If not provided, a default client will be created. Defaults to None.
         requests_per_minute (`float`, **optional**):
             Rate limit in requests per minute.
         retry (`bool`, **optional**):
-            Wether to retry on rate limit errors, up to RETRY_MAX_ATTEMPTS times. Defaults to True.
+            Whether to retry on rate limit errors, up to RETRY_MAX_ATTEMPTS times. Defaults to True.
         **kwargs:
             Additional keyword arguments to forward to the underlying model completion call.
     """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -259,7 +259,7 @@ class TestModel:
         messages = [
             ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": f"Please{stop_sequence}'"}]),
         ]
-        # check our assumption that that ">" is followed by "'"
+        # check our assumption that ">" is followed by "'"
         assert model.tokenizer.vocab[">'"]
         assert model(messages, stop_sequences=[]).content == f"I'm ready to help you{stop_sequence}'"
         # check stop_sequence capture when output has trailing chars


### PR DESCRIPTION
## Summary
- Fix corrupted character in comment: `?ormally` → `Normally`
- Fix typo: `Wether` → `Whether`
- Fix misplaced backtick in docstring type annotation
- Fix double space in docstring
- Fix grammar: `an heavy dependencies` → `a heavy dependency`
- Fix article: `an url` → `a URL` (URL starts with consonant sound)
- Fix subject-verb agreement: `Manages ... and make` → `makes`
- Fix missing pronoun: `encourage to use` → `encourage you to use`
- Fix duplicate word: `that that` → `that`
- Fix broken grammar in comment

## Test plan
- [ ] No functional changes, text/comment fixes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)