### PR TITLE
feat: make HTTP timeout configurable in WebSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -345,10 +345,11 @@ class WebSearchTool(Tool):
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
 
-    def __init__(self, max_results: int = 10, engine: str = "duckduckgo"):
+    def __init__(self, max_results: int = 10, engine: str = "duckduckgo", timeout: int = 30):
         super().__init__()
         self.max_results = max_results
         self.engine = engine
+        self.timeout = timeout
 
     def forward(self, query: str) -> str:
         results = self.search(query)
@@ -376,6 +377,7 @@ class WebSearchTool(Tool):
             "https://lite.duckduckgo.com/lite/",
             params={"q": query},
             headers={"User-Agent": "Mozilla/5.0"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         parser = self._create_duckduckgo_parser()
@@ -436,6 +438,7 @@ class WebSearchTool(Tool):
         response = requests.get(
             "https://www.bing.com/search",
             params={"q": query, "format": "rss"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         root = ET.fromstring(response.text)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 from smolagents import DuckDuckGoSearchTool
+from smolagents.default_tools import WebSearchTool
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
@@ -33,3 +36,37 @@ class TestDuckDuckGoSearchTool(ToolTesterMixin):
     @require_run_all
     def test_agent_type_output(self):
         super().test_agent_type_output()
+
+
+class TestWebSearchToolTimeout:
+    """Tests for the configurable timeout parameter on WebSearchTool."""
+
+    def test_default_timeout_is_30_seconds(self):
+        tool = WebSearchTool()
+        assert tool.timeout == 30
+
+    def test_custom_timeout_is_stored(self):
+        tool = WebSearchTool(timeout=60)
+        assert tool.timeout == 60
+
+    def test_timeout_passed_to_duckduckgo_request(self):
+        tool = WebSearchTool(engine="duckduckgo", timeout=45)
+        mock_response = MagicMock()
+        mock_response.text = "<html></html>"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            tool.search_duckduckgo("test query")
+            mock_get.assert_called_once()
+            assert mock_get.call_args.kwargs["timeout"] == 45
+
+    def test_timeout_passed_to_bing_request(self):
+        tool = WebSearchTool(engine="bing", timeout=15)
+        mock_response = MagicMock()
+        mock_response.text = "<rss><channel></channel></rss>"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            tool.search_bing("test query")
+            mock_get.assert_called_once()
+            assert mock_get.call_args.kwargs["timeout"] == 15


### PR DESCRIPTION
Fixes #2162

## Summary

The DuckDuckGo and Bing backends in `WebSearchTool` were making `requests.get` calls with no timeout at all, which can hang indefinitely on slow or unresponsive servers. This PR adds an optional `timeout` parameter to `WebSearchTool.__init__` (default 30 seconds) and passes it to all HTTP calls in the search backends.

## Changes

**`src/smolagents/default_tools.py`**
- Added `timeout: int = 30` parameter to `WebSearchTool.__init__`
- Stored as `self.timeout` instance attribute
- Passed `timeout=self.timeout` to `requests.get` calls in `search_duckduckgo` and `search_bing`

**`tests/test_search.py`**
- Added `TestWebSearchToolTimeout` class with 4 tests:
  - `test_default_timeout_is_30_seconds` verifies the default value
  - `test_custom_timeout_is_stored` verifies custom values are stored
  - `test_timeout_passed_to_duckduckgo_request` mocks `requests.get` and asserts the timeout kwarg is passed correctly
  - `test_timeout_passed_to_bing_request` same check for the Bing backend

## Usage

```python
from smolagents.default_tools import WebSearchTool

# Default 30s timeout
tool = WebSearchTool()

# Custom timeout for slow corporate proxies
tool = WebSearchTool(engine="duckduckgo", timeout=60)

# Short timeout for latency-sensitive agents
tool = WebSearchTool(engine="bing", timeout=10)
```

## Why this matters

- **Corporate proxies and slow networks** where 30s default may not be enough
- **Latency-sensitive applications** (streaming agents, real-time dashboards) where waiting 30s before failing is unacceptable
- **Reliability**: previously, requests with no timeout could hang the entire agent run indefinitely

The default of 30 seconds preserves backward compatibility for all existing code.

## Test plan

- [x] Tests use `unittest.mock` to avoid real network calls
- [x] Default value preserved (no breaking change)
- [x] Custom values verified for both DuckDuckGo and Bing backends
- [x] All existing tests still pass (no behavior change for default usage)