### PR TITLE
fix: correctly slice excess args for *args and **kwargs in interpreter

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -489,11 +489,13 @@ def create_function(
         # Handle variable arguments
         if func_def.args.vararg:
             vararg_name = func_def.args.vararg.arg
-            func_state[vararg_name] = args
+            # Only store excess positional args (those not consumed by named parameters)
+            func_state[vararg_name] = args[len(arg_names):]
 
         if func_def.args.kwarg:
             kwarg_name = func_def.args.kwarg.arg
-            func_state[kwarg_name] = kwargs
+            # Only store excess keyword args (those not consumed by named parameters)
+            func_state[kwarg_name] = {k: v for k, v in kwargs.items() if k not in arg_names}
 
         # Set default values for arguments that were not provided
         for name, value in defaults.items():

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -926,7 +926,7 @@ var_args_method(1, 2, 3, x=4, y=5)
 """
         state = {}
         result, _ = evaluate_python_code(code, {"sum": sum}, state=state)
-        assert result == 15
+        assert result == 14
 
     def test_exceptions(self):
         code = """


### PR DESCRIPTION
## Summary

- Fix `create_function` in `local_python_executor.py` to correctly assign only **excess** positional arguments to `*args` and only **excess** keyword arguments to `**kwargs`, matching standard Python semantics.
- The bug caused `*args` to receive **all** positional arguments (including those already bound to named parameters) and `**kwargs` to receive **all** keyword arguments (including those matching named parameters).

## Reproduction

```python
# In real Python:
def var_args_method(self, *args, **kwargs):
    return sum(args) + sum(kwargs.values())

var_args_method(1, 2, 3, x=4, y=5)
# self=1, args=(2,3), kwargs={x:4, y:5}
# Result: 5 + 9 = 14

# In smolagents interpreter (before fix):
# self=1, args=(1,2,3), kwargs={x:4, y:5}
# Result: 6 + 9 = 15  <-- wrong!
```

## Changes

- `src/smolagents/local_python_executor.py`: Slice `args[len(arg_names):]` for `*args` and filter named parameter keys from `**kwargs`
- `tests/test_local_python_executor.py`: Correct the test expectation from 15 to 14 (the value that real Python produces)

## Test plan

- [x] Verified real Python produces 14 for the test case
- [x] Verified the fix produces the correct slicing behavior
- [ ] Existing test suite passes with updated expectation