### PR TITLE
fix: preserve sandbox pickle error details

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -289,7 +289,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {e}") from e
+                    raise SerializationError("Cannot serialize object: " + str(e)) from e
 
     @staticmethod
     def loads(data: str, allow_pickle: bool = False) -> Any:
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
+                    raise SerializationError("Cannot serialize object: " + str(e)) from e
 
     @staticmethod
     def loads(data, allow_pickle=False):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -806,6 +806,13 @@ class TestPrefixHandling:
         result = SafeSerializer.loads(serialized, allow_pickle=True)
         assert result.value == 42
 
+    def test_generated_safe_serializer_reports_real_pickle_error(self):
+        """Generated sandbox serializer should include the real pickle error text."""
+        code = SafeSerializer.get_safe_serializer_code()
+        assert "Cannot serialize object: " in code
+        assert "Cannot serialize object: {e}" not in code
+        assert "Cannot serialize object: " + '" + str(e)' in code
+
     def test_legacy_format_detection(self):
         """Test detection and handling of legacy format (no prefix)."""
         # Simulate legacy pickle data (no prefix)


### PR DESCRIPTION
## Summary
- preserve the real pickle exception text in the generated sandbox `SafeSerializer` code
- avoid nested f-string interpolation issues inside `get_safe_serializer_code()` by using string concatenation for the error message
- add a focused regression test covering the generated serializer source

## Testing
- `PYTHONPATH=src python -m pytest tests/test_serialization.py -q -k "generated_safe_serializer_reports_real_pickle_error or pickle_prefix_with_allow_pickle"`
- `python -m ruff check src/smolagents/serialization.py tests/test_serialization.py`
- `python -m ruff format --check src/smolagents/serialization.py tests/test_serialization.py`
- `git diff --check`
