### PR TITLE
Make HTTP timeout configurable in WebSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -345,10 +345,11 @@ class WebSearchTool(Tool):
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
 
-    def __init__(self, max_results: int = 10, engine: str = "duckduckgo"):
+    def __init__(self, max_results: int = 10, engine: str = "duckduckgo", timeout: int = 30):
         super().__init__()
         self.max_results = max_results
         self.engine = engine
+        self.timeout = timeout
 
     def forward(self, query: str) -> str:
         results = self.search(query)
@@ -376,6 +377,7 @@ class WebSearchTool(Tool):
             "https://lite.duckduckgo.com/lite/",
             params={"q": query},
             headers={"User-Agent": "Mozilla/5.0"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         parser = self._create_duckduckgo_parser()
@@ -436,6 +438,7 @@ class WebSearchTool(Tool):
         response = requests.get(
             "https://www.bing.com/search",
             params={"q": query, "format": "rss"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         root = ET.fromstring(response.text)


### PR DESCRIPTION
## Summary

Adds an optional `timeout` parameter to `WebSearchTool.__init__` (default: 30 seconds) and threads it through to the `requests.get` calls in the DuckDuckGo and Bing search backends.

**Problem:** Neither backend currently specifies a timeout, so requests can hang indefinitely — blocking the agent run with no way for callers to control it.

**Fix:** 
- Added `timeout: int = 30` parameter to `__init__`
- Pass `timeout=self.timeout` to both `requests.get` calls
- Default of 30 seconds matches standard HTTP library conventions
- Fully backwards compatible (existing code sees no change)

```python
# Before: no way to control timeout
tool = WebSearchTool()

# After: configurable
tool = WebSearchTool(timeout=10)  # fast-fail for latency-sensitive apps
tool = WebSearchTool(timeout=60)  # lenient for slow networks
```

Closes #2162