### PR TITLE
fix: extend retry predicate to cover transient server errors and connection failures

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1176,7 +1176,7 @@ class ApiModel(Model):
             wait_seconds=RETRY_WAIT,
             exponential_base=RETRY_EXPONENTIAL_BASE,
             jitter=RETRY_JITTER,
-            retry_predicate=is_rate_limit_error,
+            retry_predicate=is_transient_error,
             reraise=True,
             before_sleep_logger=(logger, logging.INFO),
             after_logger=(logger, logging.INFO),
@@ -1189,6 +1189,36 @@ class ApiModel(Model):
     def _apply_rate_limit(self):
         """Apply rate limiting before making API calls."""
         self.rate_limiter.throttle()
+
+
+def is_transient_error(exception: BaseException) -> bool:
+    """Return True if the exception is a transient API error worth retrying."""
+    error_str = str(exception).lower()
+    return any(
+        signal in error_str
+        for signal in (
+            # Rate limits
+            "429",
+            "rate limit",
+            "too many requests",
+            "rate_limit",
+            # Transient server errors
+            "500",
+            "502",
+            "503",
+            "504",
+            "service unavailable",
+            "bad gateway",
+            "gateway timeout",
+            "internal server error",
+            # Connection failures
+            "connection error",
+            "connection reset",
+            "connection refused",
+            "timed out",
+            "timeout",
+        )
+    )
 
 
 def is_rate_limit_error(exception: BaseException) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,6 +37,7 @@ from smolagents.models import (
     get_clean_message_list,
     get_tool_call_from_text,
     get_tool_json_schema,
+    is_transient_error,
     parse_json_if_needed,
     remove_content_after_stop_sequences,
     supports_stop_parameter,
@@ -1077,3 +1078,38 @@ def test_tool_calls_json_serialization(model_class, model_id):
     assert len(data["tool_calls"]) > 0
     assert data["tool_calls"][0]["function"]["name"] == "final_answer"
     assert data["tool_calls"][0]["function"]["arguments"] == "test_result"
+
+
+class TestIsTransientError:
+    def test_rate_limit_429(self):
+        assert is_transient_error(Exception("HTTP 429 Too Many Requests"))
+
+    def test_rate_limit_string(self):
+        assert is_transient_error(Exception("rate limit exceeded"))
+
+    def test_503_service_unavailable(self):
+        assert is_transient_error(Exception("503 Service Unavailable"))
+
+    def test_502_bad_gateway(self):
+        assert is_transient_error(Exception("502 Bad Gateway"))
+
+    def test_500_internal_server_error(self):
+        assert is_transient_error(Exception("500 Internal Server Error"))
+
+    def test_504_gateway_timeout(self):
+        assert is_transient_error(Exception("504 Gateway Timeout"))
+
+    def test_connection_reset(self):
+        assert is_transient_error(Exception("Connection reset by peer"))
+
+    def test_timeout(self):
+        assert is_transient_error(Exception("request timed out"))
+
+    def test_non_retryable_400(self):
+        assert not is_transient_error(Exception("400 Bad Request"))
+
+    def test_non_retryable_401(self):
+        assert not is_transient_error(Exception("401 Unauthorized"))
+
+    def test_non_retryable_404(self):
+        assert not is_transient_error(Exception("404 Not Found"))


### PR DESCRIPTION
## What does this PR do?

Closes #2165

`ApiModel` already has retry logic via `Retrying`, but the predicate `is_rate_limit_error` only matches 429 / rate-limit signals. Transient server errors (502, 503, 504, 500) and connection failures (reset, timeout) are not retried today — the agent run fails immediately even though a retry would succeed.

This PR adds `is_transient_error`, a broader predicate that covers:
- Rate limits (429, "rate limit", "too many requests")
- Server-side transient errors (500, 502, 503, 504)
- Connection-level failures (reset, refused, timeout)

Non-retryable errors (400 bad request, 401 unauthorized, 404 not found) are not matched and still fail immediately.

`ApiModel` now uses `is_transient_error` as its retry predicate. The old `is_rate_limit_error` is kept for backwards compatibility.

## Tests

Added `TestIsTransientError` in `tests/test_models.py` with 11 cases: rate limit variants, each server error code, connection reset, timeout, and three non-retryable codes that must not match.