### PR TITLE
feat: add optional `reason` parameter to `interrupt()` method

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -468,6 +468,7 @@ class MultiStepAgent(ABC):
         max_steps = max_steps or self.max_steps
         self.task = task
         self.interrupt_switch = False
+        self.interrupt_reason = None
         if additional_args:
             self.state.update(additional_args)
             self.task += f"""
@@ -544,7 +545,8 @@ You have been provided with these additional arguments, that you can access dire
         returned_final_answer = False
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
-                raise AgentError("Agent interrupted.", self.logger)
+                reason = self.interrupt_reason or "Agent interrupted."
+                raise AgentError(reason, self.logger)
 
             # Run a planning step if scheduled
             if self.planning_interval is not None and (
@@ -751,9 +753,17 @@ You have been provided with these additional arguments, that you can access dire
         """To be implemented in child classes"""
         ...
 
-    def interrupt(self):
-        """Interrupts the agent execution."""
+    def interrupt(self, reason: str | None = None):
+        """Interrupts the agent execution.
+
+        Args:
+            reason: Optional custom reason for the interruption. If not provided,
+                defaults to "Agent interrupted." This allows callers to specify
+                why the agent was interrupted (e.g., "Critical tool failure",
+                "User requested stop", "Timeout exceeded").
+        """
         self.interrupt_switch = True
+        self.interrupt_reason = reason
 
     def write_memory_to_messages(
         self,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1448,6 +1448,149 @@ class TestMultiStepAgent:
             agent.run("Test task")
         assert "Agent interrupted" in str(e)
 
+    def test_interrupt_with_custom_reason(self):
+        """Test that interrupt() accepts a custom reason that propagates to the error message."""
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Model output.",
+            tool_calls=None,
+            raw="Model output.",
+            token_usage=None,
+        )
+
+        custom_reason = "Critical tool failure: API rate limit exceeded"
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt(reason=custom_reason)
+
+        agent = CodeAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+        with pytest.raises(AgentError) as exc_info:
+            agent.run("Test task")
+        assert custom_reason in str(exc_info.value)
+
+    def test_interrupt_without_reason_uses_default(self):
+        """Test that interrupt() without a reason uses the default 'Agent interrupted.' message."""
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Model output.",
+            tool_calls=None,
+            raw="Model output.",
+            token_usage=None,
+        )
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt()
+
+        agent = CodeAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+        with pytest.raises(AgentError) as exc_info:
+            agent.run("Test task")
+        assert "Agent interrupted." in str(exc_info.value)
+
+    def test_interrupt_with_none_reason_uses_default(self):
+        """Test that interrupt(reason=None) uses the default message."""
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Model output.",
+            tool_calls=None,
+            raw="Model output.",
+            token_usage=None,
+        )
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt(reason=None)
+
+        agent = CodeAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+        with pytest.raises(AgentError) as exc_info:
+            agent.run("Test task")
+        assert "Agent interrupted." in str(exc_info.value)
+
+    def test_interrupt_reason_with_tool_calling_agent(self):
+        """Test that custom interrupt reason works with ToolCallingAgent too."""
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Model output.",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_0",
+                    type="function",
+                    function=ChatMessageToolCallFunction(
+                        name="final_answer",
+                        arguments={"answer": "done"},
+                    ),
+                )
+            ],
+            raw="Model output.",
+            token_usage=None,
+        )
+
+        custom_reason = "User requested stop via UI button"
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt(reason=custom_reason)
+
+        agent = ToolCallingAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+        with pytest.raises(AgentError) as exc_info:
+            agent.run("Test task")
+        assert custom_reason in str(exc_info.value)
+
+    def test_interrupt_reason_resets_between_runs(self):
+        """Test that interrupt reason is reset between agent runs."""
+        fake_model = MagicMock()
+        call_count = 0
+
+        def generate_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="Model output.",
+                tool_calls=None,
+                raw="Model output.",
+                token_usage=None,
+            )
+
+        fake_model.generate.side_effect = generate_side_effect
+
+        custom_reason = "First run: timeout exceeded"
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt(reason=custom_reason)
+
+        agent = CodeAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+
+        # First run with custom reason
+        with pytest.raises(AgentError) as exc_info:
+            agent.run("Test task 1")
+        assert custom_reason in str(exc_info.value)
+
+        # Verify interrupt state is reset for the next run
+        assert agent.interrupt_switch is False
+        assert agent.interrupt_reason is None
+
     @pytest.mark.parametrize(
         "tools, managed_agents, name, expectation",
         [


### PR DESCRIPTION
## Summary

- Adds an optional `reason: str | None` parameter to `MultiStepAgent.interrupt()`, allowing callers to provide a custom interruption message (e.g., "Critical tool failure", "User requested stop", "Timeout exceeded")
- When no reason is provided, defaults to the existing `"Agent interrupted."` message for full backwards compatibility
- Stores `interrupt_reason` on the agent instance and resets it (along with `interrupt_switch`) at the start of each `run()` call

Fixes #2178

## Changes

**`src/smolagents/agents.py`:**
- Added `self.interrupt_reason = None` initialization in `run()` (alongside existing `interrupt_switch` reset)
- Updated `interrupt()` signature: `def interrupt(self, reason: str | None = None)`
- Updated the interruption check in `_run_stream()` to use the custom reason when available

**`tests/test_agents.py`:**
- `test_interrupt_with_custom_reason` — verifies custom reason propagates to `AgentError`
- `test_interrupt_without_reason_uses_default` — verifies backwards compatibility
- `test_interrupt_with_none_reason_uses_default` — verifies explicit `None` uses default
- `test_interrupt_reason_with_tool_calling_agent` — verifies it works with `ToolCallingAgent`
- `test_interrupt_reason_resets_between_runs` — verifies reason is cleared between runs

## Test plan

- [ ] Run `pytest tests/test_agents.py -k "test_interrupt"` to verify all interrupt-related tests pass
- [ ] Verify existing `test_interrupt` still passes (backwards compatibility)
- [ ] Verify the 5 new test methods cover custom reason, default reason, None reason, ToolCallingAgent, and state reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)