### PR TITLE
feat: add optional reason parameter to interrupt() method

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -468,6 +468,7 @@ class MultiStepAgent(ABC):
         max_steps = max_steps or self.max_steps
         self.task = task
         self.interrupt_switch = False
+        self.interrupt_reason = None
         if additional_args:
             self.state.update(additional_args)
             self.task += f"""
@@ -544,7 +545,8 @@ You have been provided with these additional arguments, that you can access dire
         returned_final_answer = False
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
-                raise AgentError("Agent interrupted.", self.logger)
+                message = f"Agent interrupted: {self.interrupt_reason}" if self.interrupt_reason else "Agent interrupted."
+                raise AgentError(message, self.logger)
 
             # Run a planning step if scheduled
             if self.planning_interval is not None and (
@@ -751,9 +753,14 @@ You have been provided with these additional arguments, that you can access dire
         """To be implemented in child classes"""
         ...
 
-    def interrupt(self):
-        """Interrupts the agent execution."""
+    def interrupt(self, reason: str | None = None):
+        """Interrupts the agent execution.
+
+        Args:
+            reason (`str`, *optional*): The reason for the interruption. If provided, it will be included in the error message.
+        """
         self.interrupt_switch = True
+        self.interrupt_reason = reason
 
     def write_memory_to_messages(
         self,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1448,6 +1448,28 @@ class TestMultiStepAgent:
             agent.run("Test task")
         assert "Agent interrupted" in str(e)
 
+    def test_interrupt_with_reason(self):
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Model output.",
+            tool_calls=None,
+            raw="Model output.",
+            token_usage=None,
+        )
+
+        def interrupt_callback(memory_step, agent):
+            agent.interrupt(reason="user cancelled")
+
+        agent = CodeAgent(
+            tools=[],
+            model=fake_model,
+            step_callbacks=[interrupt_callback],
+        )
+        with pytest.raises(AgentError) as e:
+            agent.run("Test task")
+        assert "Agent interrupted: user cancelled" in str(e)
+
     @pytest.mark.parametrize(
         "tools, managed_agents, name, expectation",
         [


### PR DESCRIPTION
## Summary

Adds an optional `reason` parameter to the `MultiStepAgent.interrupt()` method, allowing callers to include a reason for the interruption in the `AgentError` message.

## Motivation

Currently `interrupt()` takes no arguments, so when an agent is interrupted the error always says "Agent interrupted." with no context about why. In multi-agent systems, tracing why a sub-agent was stopped is important for debugging.

## Changes

**`src/smolagents/agents.py`:**

1. `interrupt()` now accepts `reason: str | None = None`
2. `run()` resets `self.interrupt_reason = None` alongside `self.interrupt_switch = False`
3. When `interrupt_switch` is True, the error message is:
   - `"Agent interrupted: {reason}"` if reason is provided
   - `"Agent interrupted."` otherwise (backward compatible)

## Example

```python
agent.interrupt(reason="user cancelled")
# -> AgentError: Agent interrupted: user cancelled
```

## Related Issue

Fixes #2178
