### PR TITLE
fix(WebSearchTool): add configurable timeout parameter

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -345,10 +345,11 @@ class WebSearchTool(Tool):
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
 
-    def __init__(self, max_results: int = 10, engine: str = "duckduckgo"):
+    def __init__(self, max_results: int = 10, engine: str = "duckduckgo", timeout: int = 30):
         super().__init__()
         self.max_results = max_results
         self.engine = engine
+        self.timeout = timeout
 
     def forward(self, query: str) -> str:
         results = self.search(query)
@@ -376,6 +377,7 @@ class WebSearchTool(Tool):
             "https://lite.duckduckgo.com/lite/",
             params={"q": query},
             headers={"User-Agent": "Mozilla/5.0"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         parser = self._create_duckduckgo_parser()
@@ -436,6 +438,7 @@ class WebSearchTool(Tool):
         response = requests.get(
             "https://www.bing.com/search",
             params={"q": query, "format": "rss"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         root = ET.fromstring(response.text)


### PR DESCRIPTION
## Problem
Both `search_duckduckgo()` and `search_bing()` in `WebSearchTool` call `requests.get()` without a timeout argument. This causes requests to hang indefinitely in slow/corporate proxy environments, and provides no way for users to adjust the wait time.

## Solution
Adds an optional `timeout` parameter to `WebSearchTool.__init__()` with a default of `30` seconds. All `requests.get` calls inside the search methods now pass `timeout=self.timeout`.

This is a **non-breaking change**: the default behavior is unchanged.

## Usage example
```python
from smolagents import WebSearchTool

# Use default 30-second timeout
tool = WebSearchTool()

# Custom 60-second timeout for slow networks
tool = WebSearchTool(timeout=60)
```

## Notes
- Related to issue #2162 (open)