### PR TITLE
docs: add Doubleword as a provider example

### DIFF
--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -78,6 +78,35 @@ model = OpenAIModel(
 )
 ```
 
+## Using Doubleword
+
+[Doubleword](https://doubleword.ai) is an AI model gateway that provides unified routing across multiple inference providers, with batch pricing offering up to 90% savings. It exposes an OpenAI-compatible API, so you can use [`OpenAIModel`] to connect to it directly.
+
+First, install the required dependencies:
+```bash
+pip install 'smolagents[openai]'
+```
+
+Then, [get a Doubleword API key](https://docs.doubleword.ai) and set it as an environment variable:
+```bash
+export DOUBLEWORD_API_KEY=<YOUR-DOUBLEWORD-API-KEY>
+```
+
+Now, you can initialize any model available on Doubleword using the `OpenAIModel` class:
+```python
+import os
+from smolagents import OpenAIModel, CodeAgent
+
+model = OpenAIModel(
+    model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+    api_base="https://api.doubleword.ai/v1",
+    api_key=os.environ["DOUBLEWORD_API_KEY"],
+)
+
+agent = CodeAgent(tools=[], model=model)
+agent.run("What is 2+2?")
+```
+
 ## Using xAI's Grok Models
 
 xAI's Grok models can be accessed through [`LiteLLMModel`].


### PR DESCRIPTION
## Summary
- Add a new "Using Doubleword" section to the `using_different_models.md` examples page
- Shows how to connect to Doubleword's OpenAI-compatible AI model gateway via `OpenAIModel`
- Includes setup instructions, environment variable configuration, and a `CodeAgent` usage example

[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing across multiple inference providers, with batch pricing offering up to 90% savings. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm the code example runs successfully with a valid Doubleword API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)