### PR TITLE
fix: prevent merging role-converted messages with subsequent user messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -346,6 +346,7 @@ def get_clean_message_list(
         flatten_messages_as_text (`bool`, default `False`): Whether to flatten messages as text.
     """
     output_message_list: list[dict[str, Any]] = []
+    output_was_converted: list[bool] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
     for message in message_list:
         if isinstance(message, dict):
@@ -354,6 +355,7 @@ def get_clean_message_list(
         if role not in MessageRole.roles():
             raise ValueError(f"Incorrect role {role}, only {MessageRole.roles()} are supported for now.")
 
+        was_converted = role in role_conversions
         if role in role_conversions:
             message.role = role_conversions[role]  # type: ignore
         # encode images if needed
@@ -372,7 +374,12 @@ def get_clean_message_list(
                     else:
                         element["image"] = encode_image_base64(element["image"])
 
-        if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+        if (
+            len(output_message_list) > 0
+            and message.role == output_message_list[-1]["role"]
+            and not was_converted
+            and not output_was_converted[-1]
+        ):
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
@@ -394,6 +401,7 @@ def get_clean_message_list(
                     "content": content,
                 }
             )
+            output_was_converted.append(was_converted)
     return output_message_list
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -736,6 +736,33 @@ def test_get_clean_message_list_role_conversions():
     assert result[1]["content"][0]["text"] == "Tool response"
 
 
+def test_get_clean_message_list_does_not_merge_converted_tool_response_with_user():
+    # Regression test for https://github.com/huggingface/smolagents/issues/1568
+    # A TOOL_RESPONSE converted to "user" must not be merged with a following genuine USER message.
+    messages = [
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Turn on the lights."}]),
+        ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": "set_lights_tool(state='on')"}]),
+        ChatMessage(role=MessageRole.TOOL_RESPONSE, content=[{"type": "text", "text": "Observation: lights on."}]),
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Turn off the lights."}]),
+    ]
+    result = get_clean_message_list(messages, role_conversions={"tool-call": "assistant", "tool-response": "user"})
+    assert [m["role"] for m in result] == ["user", "assistant", "user", "user"]
+    assert result[2]["content"][0]["text"] == "Observation: lights on."
+    assert result[3]["content"][0]["text"] == "Turn off the lights."
+
+
+def test_get_clean_message_list_still_merges_consecutive_same_role_messages():
+    # Two genuine USER messages (no role conversion involved) must still be merged.
+    messages = [
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello"}]),
+        ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Can you help me?"}]),
+    ]
+    result = get_clean_message_list(messages, role_conversions={"tool-call": "assistant", "tool-response": "user"})
+    assert len(result) == 1
+    assert result[0]["role"] == "user"
+    assert result[0]["content"][0]["text"] == "Hello\nCan you help me?"
+
+
 def test_remove_content_after_stop_sequences():
     content = "Hello<code>world!"
     stop_sequences = ["<code>"]


### PR DESCRIPTION
## Problem

`get_clean_message_list` merges consecutive same-role messages for API compliance. After role conversion (e.g., `tool-response` → `user` for non-tool-calling models), a converted tool result gets merged with the next genuine user message, corrupting the prompt.

Fixes #1568

## Changes

- Track which output messages originated from role conversion in a parallel list
- Skip merging when either the current or previous message was converted from a different role
- Two regression tests: one proving the bug, one guarding that genuine same-role merging still works

## Impact

3 lines added, 1 modified in `models.py`. No behavioral change for models that don't trigger role conversion.