### PR TITLE
Fix typo cleanups across docs, examples, and tests

### DIFF
--- a/docs/source/en/tutorials/building_good_agents.md
+++ b/docs/source/en/tutorials/building_good_agents.md
@@ -388,7 +388,7 @@ agent.prompt_templates["system_prompt"] = agent.prompt_templates["system_prompt"
 
 This also works with the [`ToolCallingAgent`].
 
-But generally it's just simpler to pass argument `instructions` upon agent initalization, like:
+But generally it's just simpler to pass argument `instructions` upon agent initialization, like:
 ```py
 agent = CodeAgent(tools=[], model=InferenceClientModel(model_id=model_id), instructions="Always talk like a 5 year old.")
 ```

--- a/examples/inspect_multiagent_run.py
+++ b/examples/inspect_multiagent_run.py
@@ -36,4 +36,4 @@ run_result = manager_agent.run(
     "If the US keeps it 2024 growth rate, how many years would it take for the GDP to double?"
 )
 print("Here is the token usage for the manager agent", run_result.token_usage)
-print("Here are the timing informations for the manager agent:", run_result.timing)
+print("Here are the timing details for the manager agent:", run_result.timing)

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1153,7 +1153,7 @@ class ApiModel(Model):
         requests_per_minute (`float`, **optional**):
             Rate limit in requests per minute.
         retry (`bool`, **optional**):
-            Wether to retry on rate limit errors, up to RETRY_MAX_ATTEMPTS times. Defaults to True.
+            Whether to retry on rate limit errors, up to RETRY_MAX_ATTEMPTS times. Defaults to True.
         **kwargs:
             Additional keyword arguments to forward to the underlying model completion call.
     """

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -722,11 +722,11 @@ class Tool(BaseTool):
                     output = output[
                         0
                     ]  # Sometime the space also returns the generation seed, in which case the result is at index 0
-                IMAGE_EXTENTIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
-                AUDIO_EXTENTIONS = [".mp3", ".wav", ".ogg", ".m4a", ".flac"]
-                if isinstance(output, str) and any([output.endswith(ext) for ext in IMAGE_EXTENTIONS]):
+                IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
+                AUDIO_EXTENSIONS = [".mp3", ".wav", ".ogg", ".m4a", ".flac"]
+                if isinstance(output, str) and any([output.endswith(ext) for ext in IMAGE_EXTENSIONS]):
                     output = AgentImage(output)
-                elif isinstance(output, str) and any([output.endswith(ext) for ext in AUDIO_EXTENTIONS]):
+                elif isinstance(output, str) and any([output.endswith(ext) for ext in AUDIO_EXTENSIONS]):
                     output = AgentAudio(output)
                 return output
 
@@ -976,7 +976,7 @@ class ToolCollection:
             trust_remote_code (`bool`, *optional*, defaults to `False`):
                 Whether to trust the execution of code from tools defined on the MCP server.
                 This option should only be set to `True` if you trust the MCP server,
-                and undertand the risks associated with running remote code on your local machine.
+                and understand the risks associated with running remote code on your local machine.
                 If set to `False`, loading tools from MCP will fail.
             structured_output (`bool`, *optional*, defaults to `False`):
                 Whether to enable structured output features for MCP tools. If True, enables:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -555,7 +555,7 @@ class TestTool:
         assert get_choice.inputs["choice"]["nullable"] is True
         assert get_choice.inputs["choice"]["enum"] == [1, 2, 3]
 
-    def test_saving_tool_produces_valid_pyhon_code_with_multiline_description(self, tmp_path):
+    def test_saving_tool_produces_valid_python_code_with_multiline_description(self, tmp_path):
         @tool
         def get_weather(location: Any) -> None:
             """


### PR DESCRIPTION
## Summary

This PR fixes a small set of spelling / wording issues across docs, examples, docstrings, and tests.

Closes #2207.

## Changes

- fix `initalization` -> `initialization` in the English tutorial
- improve example wording from `timing informations` to `timing details`
- fix `Wether` -> `Whether` in a model docstring
- fix `EXTENTIONS` -> `EXTENSIONS` and `undertand` -> `understand` in tool code / docstrings
- fix `pyhon` -> `python` in a test name

## Notes

- one file per commit
- no functional behavior changes intended
- `.typos.toml` was not included
