### PR TITLE
Fix missing tool export requirements for commented imports

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -22,9 +22,11 @@ been duplicated.
 TODO: move them to `huggingface_hub` to avoid code duplication.
 """
 
+import ast
 import inspect
 import json
 import re
+import textwrap
 import types
 from collections.abc import Callable
 from copy import copy
@@ -66,24 +68,43 @@ def get_imports(code: str) -> list[str]:
     Returns:
         `list[str]`: List of all packages required to use the input code.
     """
-    # filter out try/except block so in custom code we can have try/except imports
-    code = re.sub(r"\s*try\s*:.*?except.*?:", "", code, flags=re.DOTALL)
+    code = textwrap.dedent(code).strip()
+    tree = ast.parse(code)
+    imports: set[str] = set()
 
-    # filter out imports under is_flash_attn_2_available block for avoid import issues in cpu only environment
-    code = re.sub(
-        r"if is_flash_attn[a-zA-Z0-9_]+available\(\):\s*(from flash_attn\s*.*\s*)+",
-        "",
-        code,
-        flags=re.MULTILINE,
-    )
+    def visit(node: ast.AST, in_try_block: bool = False, in_flash_attn_block: bool = False) -> None:
+        if isinstance(node, ast.Try):
+            for child in node.body + node.handlers + node.orelse + node.finalbody:
+                visit(child, in_try_block=True, in_flash_attn_block=in_flash_attn_block)
+            return
 
-    # Imports of the form `import xxx` or `import xxx as yyy`
-    imports = re.findall(r"^\s*import\s+(\S+?)(?:\s+as\s+\S+)?\s*$", code, flags=re.MULTILINE)
-    # Imports of the form `from xxx import yyy`
-    imports += re.findall(r"^\s*from\s+(\S+)\s+import", code, flags=re.MULTILINE)
-    # Only keep the top-level module
-    imports = [imp.split(".")[0] for imp in imports if not imp.startswith(".")]
-    return [get_package_name(import_name) for import_name in set(imports)]
+        if isinstance(node, ast.If):
+            is_flash_attn_guard = (
+                isinstance(node.test, ast.Call)
+                and isinstance(node.test.func, ast.Name)
+                and re.fullmatch(r"is_flash_attn[a-zA-Z0-9_]*available", node.test.func.id) is not None
+            )
+            for child in node.body + node.orelse:
+                visit(
+                    child,
+                    in_try_block=in_try_block,
+                    in_flash_attn_block=in_flash_attn_block or is_flash_attn_guard,
+                )
+            return
+
+        if not in_try_block and not in_flash_attn_block:
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                imports.add(node.module.split(".")[0])
+
+        for child in ast.iter_child_nodes(node):
+            visit(child, in_try_block=in_try_block, in_flash_attn_block=in_flash_attn_block)
+
+    visit(tree)
+
+    return [get_package_name(import_name) for import_name in imports]
 
 
 class TypeHintParsingException(Exception):

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -292,6 +292,7 @@ class Tool(BaseTool):
     def to_dict(self) -> dict:
         """Returns a dictionary representing the tool"""
         class_name = self.__class__.__name__
+        requirements_sources: list[str] = []
         if type(self).__name__ == "SimpleTool":
             # Check that imports are self-contained
             source_code = get_source(self.forward).replace("@tool", "")
@@ -339,6 +340,7 @@ class Tool(BaseTool):
             forward_source_code = add_self_argument(forward_source_code)
             forward_source_code = forward_source_code.replace("@tool", "").strip()
             tool_code += "\n\n" + textwrap.indent(forward_source_code, "    ")
+            requirements_sources.extend([tool_code, forward_source_code])
 
         else:  # If the tool was not created by the @tool decorator, it was made by subclassing Tool
             if type(self).__name__ in [
@@ -353,8 +355,14 @@ class Tool(BaseTool):
             validate_tool_attributes(self.__class__)
 
             tool_code = "from typing import Any, Optional\n" + instance_to_source(self, base_cls=Tool)
+            requirements_sources.append(tool_code)
 
-        requirements = {el for el in get_imports(tool_code) if el not in sys.stdlib_module_names} | {"smolagents"}
+        requirements = {
+            el
+            for source in requirements_sources
+            for el in get_imports(source)
+            if el not in sys.stdlib_module_names
+        } | {"smolagents"}
 
         tool_dict = {"name": self.name, "code": tool_code, "requirements": sorted(requirements)}
 

--- a/tests/test_function_type_hints_utils.py
+++ b/tests/test_function_type_hints_utils.py
@@ -508,6 +508,13 @@ class TestGetCode:
         """,
                 [],
             ),
+            (
+                """
+        import IPython  # noqa: F401
+        from pandas import DataFrame  # type: ignore[import-not-found]
+        """,
+                ["IPython", "pandas"],
+            ),
         ],
     )
     def test_get_imports(self, code: str, expected: list[str]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -359,7 +359,7 @@ def test_e2e_function_tool_save(tmp_path):
                 return task"""
     )
     requirements = set((tmp_path / "requirements.txt").read_text().split())
-    assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
+    assert requirements == {"IPython", "smolagents"}
     assert (tmp_path / "app.py").read_text() == textwrap.dedent(
         """\
         from smolagents import launch_gradio_demo
@@ -417,7 +417,7 @@ def test_e2e_ipython_function_tool_save(tmp_path):
                 return task"""
     )
     requirements = set((tmp_path / "requirements.txt").read_text().split())
-    assert requirements == {"smolagents"}  # FIXME: IPython should be in the requirements
+    assert requirements == {"IPython", "smolagents"}
     assert (tmp_path / "app.py").read_text() == textwrap.dedent(
         """\
         from smolagents import launch_gradio_demo


### PR DESCRIPTION
## Summary

Fix tool export requirement detection when imports include inline comments.

Closes #2211.

## Changes

- parse imports via AST in `get_imports()` instead of regex
- keep excluding imports inside optional `try/except` blocks
- keep excluding flash-attn guarded imports
- include generated forward source when collecting requirements for `SimpleTool`
- add regression coverage for commented imports and function-tool save requirements

## Verification

- `python -m pytest tests/test_function_type_hints_utils.py -k 'test_get_imports'`
- `python -m pytest tests/test_utils.py -k 'function_tool_save'`
