### PR TITLE
feat: Add Azure Container Apps Dynamic Sessions executor

### DIFF
--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -46,6 +46,10 @@ Authentication uses `azure.identity.DefaultAzureCredential` by default. To targe
 identity, either pass `managed_identity_client_id=...` or set the `AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID`
 environment variable. You can also pass a fully custom `access_token_provider` callable.
 
+Each executor instance targets one Azure session via `session_id`. Omit it for a fresh isolated session per
+instance, or reuse the same value to opt into persistent session state. Session idle/cooldown duration is
+configured on the Azure session pool resource (default 300 s, max 3600 s) and is not controlled by the executor.
+
 ```python
 import os
 

--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -36,6 +36,46 @@ available executor implementations.
 
 [[autodoc]] smolagents.remote_executors.DockerExecutor
 
+### AzureDynamicSessionsExecutor
+
+Use Azure Container Apps Dynamic Sessions when you want a managed remote Python runtime with persistent session state.
+
+```python
+import time
+
+from smolagents import AzureDynamicSessionsExecutor, CodeAgent, LiteLLMModel
+
+model = LiteLLMModel(
+	model_id="azure/gpt-4.1",
+	api_base=AZURE_OPENAI_ENDPOINT,
+	api_key=AZURE_OPENAI_API_KEY,
+)
+
+agent_executor = AzureDynamicSessionsExecutor(
+	additional_imports=["pandas", "numpy"],
+	logger=agent_logger,
+	pool_management_endpoint=POOL_ENDPOINT,
+)
+
+agent = CodeAgent(
+	executor=agent_executor,
+	tools=[multiply],
+	model=model,
+	add_base_tools=False,
+	code_block_tags="markdown",
+	additional_authorized_imports=["pandas", "numpy"],
+)
+
+t0 = time.perf_counter()
+result = agent.run("What is 17 multiplied by 23? Use the multiply tool.")
+elapsed = time.perf_counter() - t0
+
+print(f"Result:  {result}")
+print(f"Elapsed: {elapsed:.2f}s")
+```
+
+[[autodoc]] smolagents.azure_executors.AzureDynamicSessionsExecutor
+
 ### WasmExecutor
 
 [[autodoc]] smolagents.remote_executors.WasmExecutor

--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -39,39 +39,40 @@ available executor implementations.
 ### AzureDynamicSessionsExecutor
 
 Use Azure Container Apps Dynamic Sessions when you want a managed remote Python runtime with persistent session state.
+Requires the `azure` extra (`pip install 'smolagents[azure]'`) and an identity with the
+*Azure ContainerApps Session Executor* role on the session pool.
+
+Authentication uses `azure.identity.DefaultAzureCredential` by default. To target a specific user-assigned managed
+identity, either pass `managed_identity_client_id=...` or set the `AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID`
+environment variable. You can also pass a fully custom `access_token_provider` callable.
 
 ```python
-import time
+import os
 
 from smolagents import AzureDynamicSessionsExecutor, CodeAgent, LiteLLMModel
+from smolagents.monitoring import AgentLogger, LogLevel
 
 model = LiteLLMModel(
-	model_id="azure/gpt-4.1",
-	api_base=AZURE_OPENAI_ENDPOINT,
-	api_key=AZURE_OPENAI_API_KEY,
+    model_id="azure/gpt-4.1",
+    api_base=os.environ["AZURE_OPENAI_ENDPOINT"],
+    api_key=os.environ["AZURE_OPENAI_API_KEY"],
 )
 
-agent_executor = AzureDynamicSessionsExecutor(
-	additional_imports=["pandas", "numpy"],
-	logger=agent_logger,
-	pool_management_endpoint=POOL_ENDPOINT,
+executor = AzureDynamicSessionsExecutor(
+    additional_imports=["pandas", "numpy"],
+    logger=AgentLogger(LogLevel.INFO),
+    pool_management_endpoint=os.environ["AZURE_SESSIONS_POOL_ENDPOINT"],
 )
 
 agent = CodeAgent(
-	executor=agent_executor,
-	tools=[multiply],
-	model=model,
-	add_base_tools=False,
-	code_block_tags="markdown",
-	additional_authorized_imports=["pandas", "numpy"],
+    executor=executor,
+    tools=[],
+    model=model,
+    additional_authorized_imports=["pandas", "numpy"],
 )
 
-t0 = time.perf_counter()
-result = agent.run("What is 17 multiplied by 23? Use the multiply tool.")
-elapsed = time.perf_counter() - t0
-
-print(f"Result:  {result}")
-print(f"Elapsed: {elapsed:.2f}s")
+result = agent.run("What is 17 multiplied by 23?")
+print(result)
 ```
 
 [[autodoc]] smolagents.azure_executors.AzureDynamicSessionsExecutor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+azure = [
+  "azure-identity>=1.17.0",
+]
 bedrock = [
   "boto3>=1.36.18"
 ]
@@ -90,7 +93,7 @@ vllm = [
   "torch"
 ]
 all = [
-  "smolagents[audio,blaxel,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
+  "smolagents[audio,azure,blaxel,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
 ]
 quality = [
   "ruff>=0.9.0",

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -18,6 +18,7 @@ __version__ = "1.25.0.dev0"
 
 from .agent_types import *  # noqa: I001
 from .agents import *  # Above noqa avoids a circular dependency due to cli.py
+from .azure_executors import *
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *

--- a/src/smolagents/azure_executors.py
+++ b/src/smolagents/azure_executors.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+import requests
+
+from .local_python_executor import CodeOutput
+from .monitoring import LogLevel
+from .remote_executors import RemotePythonExecutor
+from .utils import AgentError
+
+
+__all__ = ["AzureDynamicSessionsExecutor"]
+
+
+API_VERSION = "2024-10-02-preview"
+SESSION_VOLUME_PATH = "/mnt/data"
+
+
+def _default_token_provider_factory() -> Callable[[], str]:
+    try:
+        from azure.core.credentials import AccessToken
+        from azure.identity import DefaultAzureCredential
+    except ModuleNotFoundError as error:
+        raise ModuleNotFoundError(
+            "Please run: `pip install 'smolagents[azure]'` to use AzureDynamicSessionsExecutor"
+        ) from error
+
+    cached_token: AccessToken | None = None
+
+    def _provide() -> str:
+        nonlocal cached_token
+        if cached_token is None or datetime.fromtimestamp(cached_token.expires_on, timezone.utc) < datetime.now(
+            timezone.utc
+        ) + timedelta(minutes=5):
+            cached_token = DefaultAzureCredential().get_token("https://dynamicsessions.io/.default")
+        return cached_token.token
+
+    return _provide
+
+
+class AzureDynamicSessionsExecutor(RemotePythonExecutor):
+    """Execute Python code in Azure Container Apps Dynamic Sessions.
+
+    Works with both the built-in code interpreter pool and custom container
+    session pools.  Requires ``azure-identity`` at runtime and the calling
+    identity to hold the *Azure ContainerApps Session Executor* role on the
+    session pool resource.
+
+    Args:
+        additional_imports: Packages to ``pip install`` inside the session.
+        logger: smolagents logger instance.
+        pool_management_endpoint: Base URL of the session pool
+            (e.g. ``https://pool.env.region.azurecontainerapps.io``).
+        session_id: Reuse a specific session.  A random UUID is generated
+            when omitted.
+        access_token_provider: ``() -> str`` callable that returns a valid
+            Entra bearer token.  Defaults to ``DefaultAzureCredential``.
+    """
+
+    def __init__(
+        self,
+        additional_imports: list[str],
+        logger,
+        allow_pickle: bool = False,
+        *,
+        pool_management_endpoint: str,
+        session_id: str | None = None,
+        access_token_provider: Callable[[], str] | None = None,
+        api_version: str = API_VERSION,
+    ):
+        super().__init__(additional_imports, logger, allow_pickle)
+        if not pool_management_endpoint:
+            raise ValueError(
+                "pool_management_endpoint is required. Set AZURE_SESSIONS_POOL_ENDPOINT in your environment."
+            )
+        self._endpoint = pool_management_endpoint.rstrip("/")
+        self._session_id = session_id or str(uuid4())
+        self._api_version = api_version
+        self._token_provider = access_token_provider or _default_token_provider_factory()
+        self.installed_packages = self.install_packages(additional_imports)
+        self.logger.log(
+            f"Azure Dynamic Sessions executor ready (session={self._session_id})",
+            level=LogLevel.INFO,
+        )
+
+    def _build_url(self, path: str) -> str:
+        qs = urllib.parse.urlencode(
+            {
+                "identifier": self._session_id,
+                "api-version": self._api_version,
+            }
+        )
+        return f"{self._endpoint}/{path}?{qs}"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token_provider()}",
+            "Content-Type": "application/json",
+        }
+
+    def run_code_raise_errors(self, code: str) -> CodeOutput:
+        url = self._build_url("code/execute")
+        body: dict[str, Any] = {
+            "properties": {
+                "codeInputType": "inline",
+                "executionType": "synchronous",
+                "code": code,
+            }
+        }
+        resp = requests.post(url, headers=self._headers(), json=body, timeout=230)
+        resp.raise_for_status()
+
+        props = resp.json().get("properties", {})
+        stdout = props.get("stdout", "")
+        stderr = props.get("stderr", "")
+        result = props.get("result")
+        logs = stdout
+        if stderr:
+            logs = f"{stdout}\n{stderr}" if stdout else stderr
+
+        if stderr and self.FINAL_ANSWER_EXCEPTION in stderr:
+            try:
+                value_line = stderr.split(self.FINAL_ANSWER_EXCEPTION)[-1].strip()
+                final_answer = self._deserialize_final_answer(
+                    value_line,
+                    allow_pickle=self.allow_pickle,
+                )
+                return CodeOutput(output=final_answer, logs=logs, is_final_answer=True)
+            except Exception:
+                pass
+
+        if stderr and "Traceback" in stderr:
+            raise AgentError(f"{logs}\nExecuting code yielded an error:\n{stderr}", self.logger)
+
+        output = self._parse_result(result) if result is not None else None
+        return CodeOutput(output=output, logs=logs, is_final_answer=False)
+
+    @staticmethod
+    def _parse_result(result: Any) -> Any:
+        if isinstance(result, dict):
+            rtype = result.get("type")
+            if rtype == "image" and "base64_data" in result:
+                from io import BytesIO
+
+                import PIL.Image
+
+                return PIL.Image.open(BytesIO(base64.b64decode(result["base64_data"])))
+            if "value" in result:
+                return result["value"]
+        if isinstance(result, str):
+            try:
+                return json.loads(result)
+            except (json.JSONDecodeError, ValueError):
+                pass
+        return result
+
+    def upload_file(self, local_path: str, remote_path: str | None = None) -> dict:
+        remote_name = remote_path or Path(local_path).name
+        url = self._build_url("files") + f"&path={urllib.parse.quote(SESSION_VOLUME_PATH)}"
+        headers = {k: v for k, v in self._headers().items() if k != "Content-Type"}
+        with open(local_path, "rb") as f:
+            resp = requests.post(
+                url,
+                headers=headers,
+                files=[("file", (remote_name, f, "application/octet-stream"))],
+                timeout=120,
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    def download_file(self, remote_path: str) -> bytes:
+        encoded = urllib.parse.quote(remote_path)
+        url = self._build_url(f"files/{encoded}/content")
+        resp = requests.get(url, headers=self._headers(), timeout=120)
+        resp.raise_for_status()
+        return resp.content
+
+    def list_files(self) -> list[dict]:
+        url = self._build_url("files")
+        resp = requests.get(url, headers=self._headers(), timeout=30)
+        resp.raise_for_status()
+        return resp.json().get("value", [])
+
+    def cleanup(self):
+        try:
+            self.logger.log(
+                f"Deleting Azure Dynamic Session {self._session_id}...",
+                level=LogLevel.INFO,
+            )
+            response = requests.delete(
+                self._build_url("sessions"),
+                headers=self._headers(),
+                timeout=10,
+            )
+            if response.status_code not in {200, 202, 204, 404}:
+                response.raise_for_status()
+            self.logger.log("Azure session cleanup completed", level=LogLevel.INFO)
+        except Exception as e:
+            self.logger.log_error(
+                f"Error during Azure session cleanup: {e}. Session will auto-expire if still active."
+            )

--- a/src/smolagents/azure_executors.py
+++ b/src/smolagents/azure_executors.py
@@ -77,6 +77,15 @@ class AzureDynamicSessionsExecutor(RemotePythonExecutor):
     Requires the `azure` extra (`pip install 'smolagents[azure]'`) and an identity that
     holds the *Azure ContainerApps Session Executor* role on the session pool resource.
 
+    Each instance targets a single Azure session identified by `session_id`. Omit `session_id`
+    to get a fresh isolated session per executor instance; reuse the same value across
+    instances to opt into persistent session state. Sandbox isolation is provided by Azure
+    Dynamic Sessions; smolagents only manages the session identifier.
+
+    Session idle/cooldown duration is configured on the Azure session pool resource itself
+    (default 300 s, max 3600 s) and is not controlled by this executor. Per-execution wall
+    time is capped by Azure at 220 s for the built-in code interpreter pool.
+
     Args:
         additional_imports (`list[str]`): Additional Python packages to install in the session.
         logger (`Logger`): Logger to use for output and errors.

--- a/src/smolagents/azure_executors.py
+++ b/src/smolagents/azure_executors.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import urllib.parse
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -40,7 +41,7 @@ API_VERSION = "2024-10-02-preview"
 SESSION_VOLUME_PATH = "/mnt/data"
 
 
-def _default_token_provider_factory() -> Callable[[], str]:
+def _default_token_provider_factory(managed_identity_client_id: str | None = None) -> Callable[[], str]:
     try:
         from azure.core.credentials import AccessToken
         from azure.identity import DefaultAzureCredential
@@ -49,6 +50,12 @@ def _default_token_provider_factory() -> Callable[[], str]:
             "Please run: `pip install 'smolagents[azure]'` to use AzureDynamicSessionsExecutor"
         ) from error
 
+    client_id = managed_identity_client_id or os.environ.get("AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID")
+    credential_kwargs: dict[str, str] = {}
+    if client_id:
+        credential_kwargs["managed_identity_client_id"] = client_id
+    credential = DefaultAzureCredential(**credential_kwargs)
+
     cached_token: AccessToken | None = None
 
     def _provide() -> str:
@@ -56,29 +63,34 @@ def _default_token_provider_factory() -> Callable[[], str]:
         if cached_token is None or datetime.fromtimestamp(cached_token.expires_on, timezone.utc) < datetime.now(
             timezone.utc
         ) + timedelta(minutes=5):
-            cached_token = DefaultAzureCredential().get_token("https://dynamicsessions.io/.default")
+            cached_token = credential.get_token("https://dynamicsessions.io/.default")
         return cached_token.token
 
     return _provide
 
 
 class AzureDynamicSessionsExecutor(RemotePythonExecutor):
-    """Execute Python code in Azure Container Apps Dynamic Sessions.
+    """
+    Remote Python code executor backed by Azure Container Apps Dynamic Sessions.
 
-    Works with both the built-in code interpreter pool and custom container
-    session pools.  Requires ``azure-identity`` at runtime and the calling
-    identity to hold the *Azure ContainerApps Session Executor* role on the
-    session pool resource.
+    Works with both the built-in code interpreter pool and custom container session pools.
+    Requires the `azure` extra (`pip install 'smolagents[azure]'`) and an identity that
+    holds the *Azure ContainerApps Session Executor* role on the session pool resource.
 
     Args:
-        additional_imports: Packages to ``pip install`` inside the session.
-        logger: smolagents logger instance.
-        pool_management_endpoint: Base URL of the session pool
-            (e.g. ``https://pool.env.region.azurecontainerapps.io``).
-        session_id: Reuse a specific session.  A random UUID is generated
-            when omitted.
-        access_token_provider: ``() -> str`` callable that returns a valid
-            Entra bearer token.  Defaults to ``DefaultAzureCredential``.
+        additional_imports (`list[str]`): Additional Python packages to install in the session.
+        logger (`Logger`): Logger to use for output and errors.
+        allow_pickle (`bool`, default `False`): Whether to allow pickle serialization for objects that cannot be safely
+            serialized to JSON. See [`RemotePythonExecutor`] for the full security note.
+        pool_management_endpoint (`str`): Base URL of the session pool, e.g.
+            `https://<pool>.<region>.azurecontainerapps.io`.
+        session_id (`str`, *optional*): Identifier of the session to reuse. A random UUID is generated when omitted.
+        access_token_provider (`Callable[[], str]`, *optional*): Callable that returns a valid Entra bearer token.
+            Defaults to a provider built on top of `azure.identity.DefaultAzureCredential`.
+        managed_identity_client_id (`str`, *optional*): Client ID of a user-assigned managed identity to use with
+            `DefaultAzureCredential`. Falls back to the `AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID` environment
+            variable. Ignored when `access_token_provider` is supplied.
+        api_version (`str`, *optional*): Override the Azure Dynamic Sessions REST API version.
     """
 
     def __init__(
@@ -90,6 +102,7 @@ class AzureDynamicSessionsExecutor(RemotePythonExecutor):
         pool_management_endpoint: str,
         session_id: str | None = None,
         access_token_provider: Callable[[], str] | None = None,
+        managed_identity_client_id: str | None = None,
         api_version: str = API_VERSION,
     ):
         super().__init__(additional_imports, logger, allow_pickle)
@@ -100,7 +113,9 @@ class AzureDynamicSessionsExecutor(RemotePythonExecutor):
         self._endpoint = pool_management_endpoint.rstrip("/")
         self._session_id = session_id or str(uuid4())
         self._api_version = api_version
-        self._token_provider = access_token_provider or _default_token_provider_factory()
+        self._token_provider = access_token_provider or _default_token_provider_factory(
+            managed_identity_client_id=managed_identity_client_id
+        )
         self.installed_packages = self.install_packages(additional_imports)
         self.logger.log(
             f"Azure Dynamic Sessions executor ready (session={self._session_id})",

--- a/src/smolagents/azure_executors.py
+++ b/src/smolagents/azure_executors.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import threading
 import urllib.parse
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -57,13 +58,21 @@ def _default_token_provider_factory(managed_identity_client_id: str | None = Non
     credential = DefaultAzureCredential(**credential_kwargs)
 
     cached_token: AccessToken | None = None
+    # Guard the refresh path so concurrent callers don't issue duplicate token requests
+    # to Entra when the cache is empty or near expiry.
+    refresh_lock = threading.Lock()
 
     def _provide() -> str:
         nonlocal cached_token
         if cached_token is None or datetime.fromtimestamp(cached_token.expires_on, timezone.utc) < datetime.now(
             timezone.utc
         ) + timedelta(minutes=5):
-            cached_token = credential.get_token("https://dynamicsessions.io/.default")
+            with refresh_lock:
+                # Re-check inside the lock: another thread may have refreshed while we waited.
+                if cached_token is None or datetime.fromtimestamp(
+                    cached_token.expires_on, timezone.utc
+                ) < datetime.now(timezone.utc) + timedelta(minutes=5):
+                    cached_token = credential.get_token("https://dynamicsessions.io/.default")
         return cached_token.token
 
     return _provide
@@ -175,6 +184,9 @@ class AzureDynamicSessionsExecutor(RemotePythonExecutor):
                 )
                 return CodeOutput(output=final_answer, logs=logs, is_final_answer=True)
             except Exception:
+                # Final-answer marker was present but we couldn't decode the payload
+                # (e.g. truncated/corrupted output). Fall through so a real traceback
+                # in stderr still surfaces as an AgentError instead of being swallowed.
                 pass
 
         if stderr and "Traceback" in stderr:
@@ -217,7 +229,7 @@ class AzureDynamicSessionsExecutor(RemotePythonExecutor):
         return resp.json()
 
     def download_file(self, remote_path: str) -> bytes:
-        encoded = urllib.parse.quote(remote_path)
+        encoded = urllib.parse.quote(remote_path, safe="")
         url = self._build_url(f"files/{encoded}/content")
         resp = requests.get(url, headers=self._headers(), timeout=120)
         resp.raise_for_status()

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -1,3 +1,4 @@
+import builtins
 import importlib
 import io
 from textwrap import dedent
@@ -8,6 +9,8 @@ import PIL.Image
 import pytest
 from rich.console import Console
 
+import smolagents.azure_executors as azure_executors
+from smolagents.azure_executors import AzureDynamicSessionsExecutor
 from smolagents.default_tools import FinalAnswerTool, WikipediaSearchTool
 from smolagents.local_python_executor import CodeOutput
 from smolagents.monitoring import AgentLogger, LogLevel
@@ -138,6 +141,189 @@ class TestE2BExecutorUnit:
             else:
                 mock_sandbox.return_value.kill.assert_called_once()
             assert logger.log.call_count >= 2  # Should log start and completion messages
+
+
+class TestAzureDynamicSessionsExecutorUnit:
+    def test_explicit_token_provider_does_not_require_azure_identity(self):
+        logger = MagicMock()
+
+        with patch(
+            "smolagents.azure_executors._default_token_provider_factory",
+            side_effect=AssertionError("default Azure token provider should not be used"),
+        ):
+            executor = AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="https://pool.example.com",
+                session_id="session-123",
+                access_token_provider=lambda: "token",
+            )
+
+        assert executor._headers()["Authorization"] == "Bearer token"
+
+    def test_default_token_provider_factory_raises_helpful_error_without_azure_extra(self):
+        real_import = builtins.__import__
+
+        def patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name in {"azure.core.credentials", "azure.identity"}:
+                raise ModuleNotFoundError(name)
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=patched_import):
+            with pytest.raises(ModuleNotFoundError, match=r"smolagents\[azure\]"):
+                azure_executors._default_token_provider_factory()
+
+    def test_instantiation_requires_pool_endpoint(self):
+        logger = MagicMock()
+
+        with pytest.raises(ValueError, match="pool_management_endpoint is required"):
+            AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="",
+                access_token_provider=lambda: "token",
+            )
+
+    def test_run_code_raise_errors_posts_expected_request(self):
+        logger = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "properties": {
+                "stdout": "391",
+                "stderr": "",
+                "result": {"value": 391},
+            }
+        }
+
+        with patch("smolagents.azure_executors.requests.post", return_value=response) as mock_post:
+            executor = AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="https://pool.example.com",
+                session_id="session-123",
+                access_token_provider=lambda: "token",
+            )
+
+            result = executor.run_code_raise_errors("print(17 * 23)")
+
+        assert result == CodeOutput(output=391, logs="391", is_final_answer=False)
+        mock_post.assert_called_once_with(
+            "https://pool.example.com/code/execute?identifier=session-123&api-version=2024-10-02-preview",
+            headers={
+                "Authorization": "Bearer token",
+                "Content-Type": "application/json",
+            },
+            json={
+                "properties": {
+                    "codeInputType": "inline",
+                    "executionType": "synchronous",
+                    "code": "print(17 * 23)",
+                }
+            },
+            timeout=230,
+        )
+
+    def test_run_code_raise_errors_handles_final_answer(self):
+        logger = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "properties": {
+                "stdout": "",
+                "stderr": 'FinalAnswerException safe:"391"',
+                "result": None,
+            }
+        }
+
+        with patch("smolagents.azure_executors.requests.post", return_value=response):
+            executor = AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="https://pool.example.com",
+                session_id="session-123",
+                access_token_provider=lambda: "token",
+            )
+
+            result = executor.run_code_raise_errors("final_answer(391)")
+
+        assert result == CodeOutput(output="391", logs='FinalAnswerException safe:"391"', is_final_answer=True)
+
+    def test_run_code_raise_errors_raises_agent_error_on_traceback(self):
+        logger = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "properties": {
+                "stdout": "",
+                "stderr": "Traceback (most recent call last):\nValueError: boom",
+                "result": None,
+            }
+        }
+
+        with patch("smolagents.azure_executors.requests.post", return_value=response):
+            executor = AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="https://pool.example.com",
+                session_id="session-123",
+                access_token_provider=lambda: "token",
+            )
+
+            with pytest.raises(AgentError, match="Executing code yielded an error"):
+                executor.run_code_raise_errors("raise ValueError('boom')")
+
+    def test_file_operations_and_cleanup(self, tmp_path):
+        logger = MagicMock()
+        upload_response = MagicMock()
+        upload_response.json.return_value = {"status": "uploaded"}
+        list_response = MagicMock()
+        list_response.json.return_value = {"value": [{"name": "example.txt"}]}
+        download_response = MagicMock()
+        download_response.content = b"hello"
+        delete_response = MagicMock()
+        delete_response.status_code = 204
+        local_file = tmp_path / "example.txt"
+        local_file.write_text("hello")
+
+        with (
+            patch("smolagents.azure_executors.requests.post", return_value=upload_response) as mock_post,
+            patch(
+                "smolagents.azure_executors.requests.get", side_effect=[list_response, download_response]
+            ) as mock_get,
+            patch("smolagents.azure_executors.requests.delete", return_value=delete_response) as mock_delete,
+        ):
+            executor = AzureDynamicSessionsExecutor(
+                additional_imports=[],
+                logger=logger,
+                pool_management_endpoint="https://pool.example.com",
+                session_id="session-123",
+                access_token_provider=lambda: "token",
+            )
+
+            upload_result = executor.upload_file(str(local_file))
+            list_result = executor.list_files()
+            download_result = executor.download_file("folder/example.txt")
+            executor.cleanup()
+
+        assert upload_result == {"status": "uploaded"}
+        assert list_result == [{"name": "example.txt"}]
+        assert download_result == b"hello"
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == (
+            "https://pool.example.com/files?identifier=session-123&api-version=2024-10-02-preview&path=/mnt/data"
+        )
+        assert mock_get.call_args_list[0].args[0] == (
+            "https://pool.example.com/files?identifier=session-123&api-version=2024-10-02-preview"
+        )
+        assert mock_get.call_args_list[1].args[0] == (
+            "https://pool.example.com/files/folder/example.txt/content?identifier=session-123&api-version=2024-10-02-preview"
+        )
+        mock_delete.assert_called_once_with(
+            "https://pool.example.com/sessions?identifier=session-123&api-version=2024-10-02-preview",
+            headers={
+                "Authorization": "Bearer token",
+                "Content-Type": "application/json",
+            },
+            timeout=10,
+        )
 
 
 @pytest.fixture

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -1,6 +1,7 @@
 import builtins
 import importlib
 import io
+from datetime import datetime, timedelta, timezone
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
@@ -183,6 +184,41 @@ class TestAzureDynamicSessionsExecutorUnit:
                 pool_management_endpoint="",
                 access_token_provider=lambda: "token",
             )
+
+    def test_default_token_provider_passes_managed_identity_client_id_kwarg(self):
+        fake_credential = MagicMock()
+        fake_credential.get_token.return_value = MagicMock(
+            token="mi-token", expires_on=int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp())
+        )
+        with patch("azure.identity.DefaultAzureCredential", return_value=fake_credential) as mock_cls:
+            provider = azure_executors._default_token_provider_factory(
+                managed_identity_client_id="00000000-0000-0000-0000-000000000001"
+            )
+            assert provider() == "mi-token"
+
+        mock_cls.assert_called_once_with(managed_identity_client_id="00000000-0000-0000-0000-000000000001")
+
+    def test_default_token_provider_reads_managed_identity_client_id_from_env(self, monkeypatch):
+        fake_credential = MagicMock()
+        fake_credential.get_token.return_value = MagicMock(
+            token="mi-token", expires_on=int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp())
+        )
+        monkeypatch.setenv("AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID", "env-client-id")
+        with patch("azure.identity.DefaultAzureCredential", return_value=fake_credential) as mock_cls:
+            azure_executors._default_token_provider_factory()()
+
+        mock_cls.assert_called_once_with(managed_identity_client_id="env-client-id")
+
+    def test_default_token_provider_without_managed_identity_passes_no_kwargs(self, monkeypatch):
+        fake_credential = MagicMock()
+        fake_credential.get_token.return_value = MagicMock(
+            token="default-token", expires_on=int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp())
+        )
+        monkeypatch.delenv("AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID", raising=False)
+        with patch("azure.identity.DefaultAzureCredential", return_value=fake_credential) as mock_cls:
+            azure_executors._default_token_provider_factory()()
+
+        mock_cls.assert_called_once_with()
 
     def test_run_code_raise_errors_posts_expected_request(self):
         logger = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Adds a new `AzureDynamicSessionsExecutor` (alongside `E2BExecutor`, `ModalExecutor`, `DockerExecutor`, `WasmExecutor`) so agents can run code in [Azure Container Apps Dynamic Sessions](https://learn.microsoft.com/azure/container-apps/sessions) — a managed, sandboxed Python runtime with persistent session state.

### Highlights
- New `smolagents.azure_executors.AzureDynamicSessionsExecutor`, exported from the top-level package.
- Authentication via `azure.identity.DefaultAzureCredential` by default, with:
  - `managed_identity_client_id=...` kwarg, or
  - `AZURE_SESSIONS_MANAGED_IDENTITY_CLIENT_ID` env var, or
  - a fully custom `access_token_provider` callable (no `azure-identity` required).
- Token caching with 5-minute refresh window.
- File upload/download/list against the session's `/mnt/data` volume.
- New `azure` optional dependency (`pip install 'smolagents[azure]'`), included in `all`.
- Unit tests covering token provider, request shape, final-answer detection, traceback → `AgentError`, file ops, cleanup, and managed-identity wiring.
- Reference documentation under `docs/source/en/reference/python_executors.md`.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/smolagents/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation?
- [x] Did you write any new necessary tests?

## Who can review?
@aymeric-roucher