### PR TITLE
fix: normalize string content in get_clean_message_list before same-role merge

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -372,8 +372,14 @@ def get_clean_message_list(
                     else:
                         element["image"] = encode_image_base64(element["image"])
 
+        # Normalize string content to list format so the merge logic below works correctly.
+        # Raw dicts with string content (e.g. {"role": "system", "content": "..."}) arrive here
+        # with message.content still a str after ChatMessage.from_dict(), which would cause the
+        # assertion to fail for consecutive same-role messages.
+        if isinstance(message.content, str):
+            message.content = [{"type": "text", "text": message.content}]
+
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,34 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_string_content_in_dict():
+    # Raw dicts with string content should not raise AssertionError when two
+    # consecutive messages share the same role (issue #1972).
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "system", "content": "Always respond in English."},
+        {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert result[0]["content"] == [{"type": "text", "text": "You are a helpful assistant.
+Always respond in English."}]
+    assert result[1]["role"] == "user"
+
+
+def test_get_clean_message_list_string_content_flatten():
+    # Same scenario but with flatten_messages_as_text=True.
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "system", "content": "Be accurate."},
+    ]
+    result = get_clean_message_list(messages, flatten_messages_as_text=True)
+    assert len(result) == 1
+    assert result[0]["content"] == "Be concise.
+Be accurate."
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
Fixes #1972.

**Problem**

`get_clean_message_list` merges consecutive messages that share the same role. The merge path (line 376) assumed `message.content` is always a list:

```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

When the caller passes raw dicts like `{"role": "system", "content": "some text"}`, `ChatMessage.from_dict()` preserves the string value as-is. If two such dicts with the same role appear back-to-back, the assertion fires and raises `AssertionError`.

This is a common pattern - layered system prompts from different sources, or user messages split across multiple dicts.

**Fix**

Normalize string content to list format immediately before the merge check:

```python
if isinstance(message.content, str):
    message.content = [{"type": "text", "text": message.content}]
```

This is a pure normalization - string content is valid input from OpenAI-compatible APIs and should not require callers to pre-convert it. The fix handles both the merge path and the first-occurrence path consistently.

**Tests**

Added two regression tests in `tests/test_models.py`:
- `test_get_clean_message_list_string_content_in_dict`: two consecutive system dicts with string content, verifies they are merged correctly
- `test_get_clean_message_list_string_content_flatten`: same with `flatten_messages_as_text=True`
