### PR TITLE
docs: add Groq via LiteLLMModel example to using_different_models

### DIFF
--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -78,6 +78,43 @@ model = OpenAIModel(
 )
 ```
 
+## Using Groq Models
+
+[Groq](https://groq.com/) provides very fast inference for open-source models like Llama and Mixtral.
+You can use [`LiteLLMModel`] to access Groq.
+
+First, install the required dependencies:
+```bash
+pip install 'smolagents[litellm]'
+```
+
+Then, [get a Groq API key](https://console.groq.com/keys) and set it in your code:
+```python
+GROQ_API_KEY = <YOUR-GROQ-API-KEY>
+```
+
+Now, you can initialize a Groq model using the `LiteLLMModel` class with the `groq/` prefix:
+```python
+from smolagents import LiteLLMModel
+
+model = LiteLLMModel(
+    model_id="groq/llama-3.3-70b-versatile",
+    api_key=GROQ_API_KEY,
+)
+```
+
+Then use it with any agent:
+```python
+from smolagents import CodeAgent
+
+agent = CodeAgent(model=model, tools=[])
+agent.run("Calculate the 10th Fibonacci number.")
+```
+
+Other popular Groq models include `groq/llama-3.1-8b-instant` (fastest, lowest latency) and
+`groq/mixtral-8x7b-32768` (large context window). See the full list at
+[console.groq.com/docs/models](https://console.groq.com/docs/models).
+
 ## Using xAI's Grok Models
 
 xAI's Grok models can be accessed through [`LiteLLMModel`].


### PR DESCRIPTION
Adds a "Using Groq Models" section to `docs/source/en/examples/using_different_models.md`.

Closes #2163

## What is added

- Install step (`smolagents[litellm]`)
- API key setup
- `LiteLLMModel` initialization with the `groq/` prefix
- Minimal `CodeAgent` usage example
- Note on popular Groq models and link to the Groq model catalog

## Why

Groq is a widely used inference provider known for very fast open-source model inference. The doc page already covers Gemini, OpenRouter, and xAI but not Groq. Issue #2163 specifically requested this.

The implementation follows the same pattern as the existing xAI Grok section: `LiteLLMModel` with the provider prefix and an API key.