### PR TITLE
fix(agents): prevent parent authorized_imports from leaking into managed agents on from_dict

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1032,6 +1032,20 @@ You have been provided with these additional arguments, that you can access dire
         for tool_info in agent_dict["tools"]:
             tools.append(Tool.from_code(tool_info["code"]))
         # Load managed agents
+        # Do not propagate CodeAgent-specific kwargs (authorized_imports, executor
+        # config, etc.) to managed agents: each agent carries its own configuration
+        # in its serialized dict.  Generic overrides (model=, max_steps=, ...) are
+        # still forwarded so callers can inject a new model tree-wide.  Without this
+        # filter the parent's additional_authorized_imports leaks into every managed
+        # agent and overwrites the child's own import allowlist.  See issue #1849.
+        _MANAGED_AGENT_EXCLUDED_KWARGS = frozenset({
+            "additional_authorized_imports",
+            "executor_type",
+            "executor_kwargs",
+            "max_print_outputs_length",
+            "code_block_tags",
+        })
+        managed_agent_kwargs = {k: v for k, v in kwargs.items() if k not in _MANAGED_AGENT_EXCLUDED_KWARGS}
         managed_agents = []
         for managed_agent_dict in agent_dict["managed_agents"]:
             agent_class = AGENT_REGISTRY.get(managed_agent_dict["class"])
@@ -1040,7 +1054,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict, **managed_agent_kwargs)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {
@@ -1790,6 +1804,7 @@ class CodeAgent(MultiStepAgent):
         """
         # Add CodeAgent-specific parameters to kwargs
         code_agent_kwargs = {
+            "additional_authorized_imports": agent_dict.get("authorized_imports"),
             "executor_type": agent_dict.get("executor_type"),
             "executor_kwargs": agent_dict.get("executor_kwargs"),
             "max_print_outputs_length": agent_dict.get("max_print_outputs_length"),
@@ -1797,14 +1812,8 @@ class CodeAgent(MultiStepAgent):
         }
         # Filter out None values
         code_agent_kwargs = {k: v for k, v in code_agent_kwargs.items() if v is not None}
-        # Update with any additional kwargs (e.g. model= override passed by the caller)
+        # Update with any additional kwargs
         code_agent_kwargs.update(kwargs)
-        # authorized_imports is agent-specific: always restore from the serialized dict
-        # last so that parent-agent kwargs propagated via MultiStepAgent.from_dict()
-        # cannot overwrite a managed agent's own import allowlist.  See issue #1849.
-        own_imports = agent_dict.get("authorized_imports")
-        if own_imports is not None:
-            code_agent_kwargs["additional_authorized_imports"] = own_imports
         # Call the parent class's from_dict method
         return super().from_dict(agent_dict, **code_agent_kwargs)
 

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1790,7 +1790,6 @@ class CodeAgent(MultiStepAgent):
         """
         # Add CodeAgent-specific parameters to kwargs
         code_agent_kwargs = {
-            "additional_authorized_imports": agent_dict.get("authorized_imports"),
             "executor_type": agent_dict.get("executor_type"),
             "executor_kwargs": agent_dict.get("executor_kwargs"),
             "max_print_outputs_length": agent_dict.get("max_print_outputs_length"),
@@ -1798,8 +1797,14 @@ class CodeAgent(MultiStepAgent):
         }
         # Filter out None values
         code_agent_kwargs = {k: v for k, v in code_agent_kwargs.items() if v is not None}
-        # Update with any additional kwargs
+        # Update with any additional kwargs (e.g. model= override passed by the caller)
         code_agent_kwargs.update(kwargs)
+        # authorized_imports is agent-specific: always restore from the serialized dict
+        # last so that parent-agent kwargs propagated via MultiStepAgent.from_dict()
+        # cannot overwrite a managed agent's own import allowlist.  See issue #1849.
+        own_imports = agent_dict.get("authorized_imports")
+        if own_imports is not None:
+            code_agent_kwargs["additional_authorized_imports"] = own_imports
         # Call the parent class's from_dict method
         return super().from_dict(agent_dict, **code_agent_kwargs)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2343,6 +2343,66 @@ print("Ok, calculation done!")""")
         assert agent.additional_authorized_imports == ["requests"]
         assert agent.executor_kwargs == {"max_print_outputs_length": 5_000}
 
+    def test_from_dict_managed_agent_authorized_imports_not_leaked(self):
+        """Managed agents must reconstruct with their own authorized_imports, not the parent's.
+
+        Regression test for https://github.com/huggingface/smolagents/issues/1849.
+
+        When a CodeAgent with managed sub-agents is deserialized, CodeAgent.from_dict()
+        builds code_agent_kwargs that includes the parent's additional_authorized_imports
+        and passes them via super().from_dict(). Without the fix, MultiStepAgent.from_dict()
+        forwards those kwargs unchanged to every managed agent, overwriting the child's
+        own import allowlist.
+        """
+        mock_model_class = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_model_class.from_dict.return_value = mock_model_instance
+
+        child_agent_dict = {
+            "class": "CodeAgent",
+            "model": {"class": "InferenceClientModel", "data": {"model_id": "child/model"}},
+            "tools": [],
+            "managed_agents": {},
+            "authorized_imports": ["sympy", "math"],  # child's own imports
+            "executor_type": "local",
+            "executor_kwargs": {},
+        }
+        parent_agent_dict = {
+            "class": "CodeAgent",
+            "model": {"class": "InferenceClientModel", "data": {"model_id": "parent/model"}},
+            "tools": [],
+            "managed_agents": [child_agent_dict],
+            "authorized_imports": ["numpy", "pandas"],  # parent's own imports
+            "executor_type": "local",
+            "executor_kwargs": {},
+        }
+
+        with patch.dict(
+            "smolagents.models.MODEL_REGISTRY",
+            {"InferenceClientModel": mock_model_class},
+        ):
+            parent = CodeAgent.from_dict(parent_agent_dict)
+
+        # Parent should have its own imports
+        assert "numpy" in parent.authorized_imports
+        assert "pandas" in parent.authorized_imports
+
+        assert len(parent.managed_agents) == 1
+        child = list(parent.managed_agents.values())[0]
+
+        # Child must retain its own imports, not the parent's
+        assert "sympy" in child.authorized_imports, (
+            "Child agent lost its 'sympy' import after from_dict(). "
+            "Parent's authorized_imports were incorrectly propagated to the child."
+        )
+        assert "math" in child.authorized_imports
+        assert "numpy" not in child.authorized_imports, (
+            "Parent's 'numpy' import leaked into the child agent's authorized_imports."
+        )
+        assert "pandas" not in child.authorized_imports, (
+            "Parent's 'pandas' import leaked into the child agent's authorized_imports."
+        )
+
     def test_custom_final_answer_with_custom_inputs(self):
         class CustomFinalAnswerToolWithCustomInputs(FinalAnswerTool):
             inputs = {


### PR DESCRIPTION
## Summary

When a `CodeAgent` with managed sub-agents is deserialized via `from_dict()`, the parent agent's `additional_authorized_imports` overwrites every child agent's own import allowlist. Reproducer from issue #1849:

```python
sub_agent = CodeAgent(
    tools=[], model=model,
    additional_authorized_imports=['sympy'],
    name='sympy_agent',
)
main_agent = CodeAgent(
    tools=[], model=model,
    additional_authorized_imports=['numpy'],
    managed_agents=[sub_agent],
)
restored = CodeAgent.from_dict(main_agent.to_dict())
# 'sympy' not in restored.managed_agents['sympy_agent'].authorized_imports  <- BUG
```

## Root cause

`CodeAgent.from_dict()` builds `code_agent_kwargs` containing `additional_authorized_imports` from the current agent's serialized dict, then calls `super().from_dict(agent_dict, **code_agent_kwargs)`. `MultiStepAgent.from_dict()` forwarded those kwargs unchanged to every managed agent via `agent_class.from_dict(managed_agent_dict, **kwargs)`. Because the parent's `additional_authorized_imports` is in kwargs, it overwrites the child's own value.

## Fix

In `MultiStepAgent.from_dict()`, filter out CodeAgent-specific keys (`additional_authorized_imports`, `executor_type`, `executor_kwargs`, `max_print_outputs_length`, `code_block_tags`) before passing kwargs to managed agents. Generic overrides like `model=` are still forwarded tree-wide.

This preserves the existing behavior where callers can do `from_dict(d, model=new_model)` to inject a model into the whole agent tree, while ensuring each agent's import allowlist is always reconstructed from its own serialized data.

## Test

Added `test_from_dict_managed_agent_authorized_imports_not_leaked` in `TestCodeAgent` that verifies a child agent with `['sympy', 'math']` imports retains them after a parent with `['numpy', 'pandas']` is deserialized.

Fixes #1849