### PR TITLE
fix(models): handle string content when merging consecutive same-role messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,6 +373,14 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+            # Normalize string content to list before merging consecutive same-role messages.
+            # String content is valid (e.g. {"role": "system", "content": "..."}) but the
+            # merge logic below assumes list format.  Without this guard, two consecutive
+            # system messages with string content raise AssertionError.  See issue #1972.
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
+            if isinstance(output_message_list[-1]["content"], str):
+                output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]


### PR DESCRIPTION
## Summary

`get_clean_message_list` raises `AssertionError` when the input contains two or more consecutive messages with the same role (e.g. two system messages) and those messages have plain string content.

Reproducer from issue #1972:

```python
messages = [
    {"role": "system", "content": "Start every reply with FOO"},
    {"role": "system", "content": "End every reply with BAR"},
    {"role": "user", "content": "Say hello"},
]
LiteLLMModel(...)(messages)  # AssertionError
```

## Root cause

`ChatMessage.content` is `str | list[dict] | None`.  When messages are passed as plain dicts with a string `"content"` field, `from_dict` stores content as a `str`.  The merge branch (hit when two consecutive messages share the same role) immediately asserts `isinstance(message.content, list)` without handling the string case, causing the crash.

## Fix

Before attempting the merge, normalize both the incoming `message.content` and the previously-stored `output_message_list[-1]["content"]` to `[{"type": "text", "text": ...}]` if either is a string.  The existing list-based merge logic then handles all cases uniformly, and consecutive string-content system messages are concatenated with a newline.

No behavior change for callers that already pass list-format content.

Fixes #1972