### PR TITLE
fix(executor): propagate contextvars context into timeout ThreadPoolExecutor worker

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -23,6 +23,7 @@ import math
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Mapping
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
@@ -304,9 +305,14 @@ def timeout(timeout_seconds: int):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            # Copy the current contextvars context so that OpenTelemetry (and any
+            # other contextvars-based state, e.g. trace spans) is propagated into
+            # the worker thread.  Without this, tool spans created inside the
+            # executor have no parent and appear as root spans.  See issue #1961.
+            ctx = contextvars.copy_context()
             # Create a new ThreadPoolExecutor for each call to avoid threading issues
             with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(func, *args, **kwargs)
+                future = executor.submit(ctx.run, func, *args, **kwargs)
                 try:
                     result = future.result(timeout=timeout_seconds)
                     return result


### PR DESCRIPTION
## Summary

Tool spans created during code execution appear as root spans in OpenTelemetry tracing UIs instead of being nested under the agent step span.

## Root cause

The `timeout()` decorator in `local_python_executor.py` runs the wrapped function in a `ThreadPoolExecutor` worker thread:

```python
future = executor.submit(func, *args, **kwargs)
```

`ThreadPoolExecutor.submit` does not inherit `contextvars` context from the calling thread.  OpenTelemetry stores the current span in a `contextvars` context variable, so when a tool runs inside the worker thread, the OTel context is empty and any spans created become parentless root spans.

## Fix

Capture the calling thread's context with `contextvars.copy_context()` before submitting, then use `ctx.run` as the callable:

```python
ctx = contextvars.copy_context()
future = executor.submit(ctx.run, func, *args, **kwargs)
```

This is the standard Python pattern for propagating contextvars into ThreadPoolExecutor workers.  The tool span parent chain is restored:
`CodeAgent.run -> Step N -> tool_span`

Fixes #1961