### PR TITLE
fix: handle consecutive same-role messages with string content

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,7 +373,9 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            # Normalize string content to list format before merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:


### PR DESCRIPTION
Fixes #1972

**What broke**

`get_clean_message_list` raised `AssertionError` when two consecutive messages had the same role and the second one had plain string content:

```python
messages = [
    {"role": "system", "content": "Start with FOO"},
    {"role": "system", "content": "End with BAR"},  # crashes here
    {"role": "user",   "content": "Say hi"},
]
```

```
AssertionError: Error: wrong content: End with BAR
```

**Root cause**

When merging consecutive same-role messages, the code assumed `message.content` was already a list:
```python
assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

But `ChatMessage.from_dict` normalises string content to list format only for the first message added to `output_message_list`. A follow-up message with the same role goes through a different path that never did that conversion.

**Fix**

Normalise string content to `[{"type": "text", "text": ..}]` before merging, same as the rest of the function already does. Three lines changed, no behaviour change for the existing list-content path.