### PR TITLE
fix(agents): Persist ThreadPoolExecutor in ToolCallingAgent

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1255,7 +1255,21 @@ class ToolCallingAgent(MultiStepAgent):
                 "`stream_outputs` is set to True, but the model class implements no `generate_stream` method."
             )
         # Tool calling setup
-        self.max_tool_threads = max_tool_threads
+        # Create persistent ThreadPoolExecutor for reuse across agent loops
+        self._max_tool_threads = max_tool_threads
+        self._tool_executor: ThreadPoolExecutor | None = None
+
+    def _get_tool_executor(self) -> ThreadPoolExecutor:
+        """Get or create the persistent ThreadPoolExecutor for parallel tool execution."""
+        if self._tool_executor is None:
+            self._tool_executor = ThreadPoolExecutor(self._max_tool_threads)
+        return self._tool_executor
+
+    def cleanup(self):
+        """Clean up resources used by the agent, such as the persistent ThreadPoolExecutor."""
+        if self._tool_executor is not None:
+            self._tool_executor.shutdown(wait=True)
+            self._tool_executor = None
 
     @property
     def tools_and_managed_agents(self):
@@ -1422,16 +1436,16 @@ class ToolCallingAgent(MultiStepAgent):
             outputs[tool_output.id] = tool_output
             yield tool_output
         else:
-            # If multiple tool calls, process them in parallel
-            with ThreadPoolExecutor(self.max_tool_threads) as executor:
-                futures = []
-                for tool_call in parallel_calls.values():
-                    ctx = copy_context()
-                    futures.append(executor.submit(ctx.run, process_single_tool_call, tool_call))
-                for future in as_completed(futures):
-                    tool_output = future.result()
-                    outputs[tool_output.id] = tool_output
-                    yield tool_output
+            # If multiple tool calls, process them in parallel using persistent executor
+            executor = self._get_tool_executor()
+            futures = []
+            for tool_call in parallel_calls.values():
+                ctx = copy_context()
+                futures.append(executor.submit(ctx.run, process_single_tool_call, tool_call))
+            for future in as_completed(futures):
+                tool_output = future.result()
+                outputs[tool_output.id] = tool_output
+                yield tool_output
 
         memory_step.tool_calls = [parallel_calls[k] for k in sorted(parallel_calls.keys())]
         memory_step.observations = memory_step.observations or ""

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2088,6 +2088,93 @@ class TestToolCallingAgent:
                     for tool_call in test_case["tool_calls"]
                 ]
 
+    def test_tool_executor_is_persistent(self, test_tool):
+        """Test that ThreadPoolExecutor is reused across multiple process_tool_calls calls."""
+        agent = ToolCallingAgent(tools=[test_tool], model=MagicMock())
+        assert agent._tool_executor is None, "Executor should be None before first use"
+
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value1"}),
+                ),
+                ChatMessageToolCall(
+                    id="call_2",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
+                ),
+            ],
+        )
+        memory_step = ActionStep(step_number=1, timing="mock_timing", model_output="")
+
+        # First call - executor should be created and cached
+        list(agent.process_tool_calls(chat_message, memory_step))
+        assert agent._tool_executor is not None
+        first_executor = agent._tool_executor
+
+        # Second call - executor should be reused
+        memory_step2 = ActionStep(step_number=2, timing="mock_timing", model_output="")
+        list(agent.process_tool_calls(chat_message, memory_step2))
+        assert agent._tool_executor is first_executor, "Executor should be reused across calls"
+
+    def test_tool_executor_max_threads(self, test_tool):
+        """Test that max_tool_threads parameter is respected."""
+        agent = ToolCallingAgent(tools=[test_tool], model=MagicMock(), max_tool_threads=4)
+        assert agent._max_tool_threads == 4
+
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value1"}),
+                ),
+                ChatMessageToolCall(
+                    id="call_2",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
+                ),
+            ],
+        )
+        memory_step = ActionStep(step_number=1, timing="mock_timing", model_output="")
+        list(agent.process_tool_calls(chat_message, memory_step))
+
+        assert agent._tool_executor is not None
+        assert agent._tool_executor._max_workers == 4
+
+    def test_tool_executor_cleanup(self, test_tool):
+        """Test that cleanup() properly shuts down and clears the executor."""
+        agent = ToolCallingAgent(tools=[test_tool], model=MagicMock(), max_tool_threads=2)
+
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value1"}),
+                ),
+                ChatMessageToolCall(
+                    id="call_2",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
+                ),
+            ],
+        )
+        memory_step = ActionStep(step_number=1, timing="mock_timing", model_output="")
+        list(agent.process_tool_calls(chat_message, memory_step))
+        assert agent._tool_executor is not None
+
+        agent.cleanup()
+        assert agent._tool_executor is None, "Executor should be None after cleanup"
+
 
 class TestCodeAgent:
     def test_code_agent_instructions(self):


### PR DESCRIPTION
## Summary
Persist ThreadPoolExecutor as a class instance in ToolCallingAgent to avoid creating/destroying it on each parallel tool call, reducing overhead in large-scale deployments.  
Closes #2222

## Problem
ThreadPoolExecutor was created and destroyed on every iteration in `process_tool_calls`, causing performance overhead.

## Solution
- Add `_tool_executor` for persistent executor reuse
- Add `_get_tool_executor()` for lazy initialization
- Add `cleanup()` method for proper resource release

## Testing
- 17 passed in TestToolCallingAgent
- 98 passed in test_agents.py
- 953 passed in full test suite