### PR TITLE
fix: omit parameters field for no-input tools to satisfy Gemini API

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -546,6 +546,20 @@ class _GeneratorThread:
         self._resume_q.put(("close", None))
         self._finished = True
 
+    def __del__(self) -> None:
+        """Mirror real-generator semantics: closing on garbage collection releases the body thread.
+
+        Without this, partially-consumed generators leak the body thread because it stays
+        blocked on ``_resume_q.get()`` until process exit. Calling ``close()`` here sends a
+        ``('close', None)`` sentinel so the thread can return promptly. ``close()`` is a no-op
+        once ``_finished`` is True, so this is safe regardless of how the generator was used.
+        """
+        try:
+            self.close()
+        except Exception:
+            # __del__ must never raise; suppress any teardown errors.
+            pass
+
 
 def _has_yield(func_def: ast.FunctionDef) -> bool:
     """Return True if *func_def* contains a ``yield`` or ``yield from`` at its own scope.

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -20,7 +20,9 @@ import difflib
 import inspect
 import logging
 import math
+import queue
 import re
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -459,6 +461,110 @@ def evaluate_while(
     return None
 
 
+class _GeneratorThread:
+    """Coordinates generator execution between a producer (body) thread and the consumer.
+
+    Uses two SimpleQueues:
+    - ``_q``: body  → consumer: ``('yield', value)``, ``('return', value)``, ``('error', exc)``
+    - ``_resume_q``: consumer → body: ``('next', sent_value)``, ``('close', None)``, ``('throw', exc)``
+
+    Protocol (per ``next()`` / ``send()`` call):
+    1. Consumer puts ``('next', value)`` to ``_resume_q``.
+    2. Body receives it, continues running until the next ``yield`` (calls :meth:`yield_value`) or
+       until it finishes / raises.
+    3. Body puts the outcome to ``_q`` then blocks again on ``_resume_q``.
+    4. Consumer gets the outcome from ``_q``, raises ``StopIteration`` / re-raises exceptions,
+       or returns the yielded value.
+    """
+
+    def __init__(self) -> None:
+        self._q: queue.SimpleQueue = queue.SimpleQueue()
+        self._resume_q: queue.SimpleQueue = queue.SimpleQueue()
+        self._finished = False
+
+    def yield_value(self, value: Any) -> Any:
+        """Called from the body thread at each ``yield`` expression.
+
+        Puts the yielded value into ``_q``, then blocks until the consumer resumes the generator.
+        Returns the value sent by the consumer (for ``x = yield expr`` patterns).
+        """
+        self._q.put(("yield", value))
+        kind, val = self._resume_q.get()
+        if kind == "close":
+            raise GeneratorExit()
+        if kind == "throw":
+            raise val
+        return val  # value passed via generator.send()
+
+    def complete(self, value: Any = None) -> None:
+        """Called from the body thread when the function body returns normally."""
+        self._q.put(("return", value))
+
+    def error(self, exc: BaseException) -> None:
+        """Called from the body thread when an unhandled exception escapes the body."""
+        self._q.put(("error", exc))
+
+    # --- consumer interface (implements the iterator protocol) ---
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> Any:
+        return self.send(None)
+
+    def send(self, value: Any) -> Any:
+        """Resume the generator, optionally sending a value into the last ``yield`` expression."""
+        if self._finished:
+            raise StopIteration()
+        self._resume_q.put(("next", value))
+        kind, val = self._q.get()
+        if kind == "yield":
+            return val
+        self._finished = True
+        if kind == "return":
+            raise StopIteration(val)
+        raise val  # kind == "error"
+
+    def throw(self, typ, val=None, tb=None) -> Any:
+        """Inject an exception at the point where the generator is paused."""
+        if self._finished:
+            raise StopIteration()
+        exc = typ if isinstance(typ, BaseException) else (typ() if val is None else typ(val))
+        self._resume_q.put(("throw", exc))
+        kind, v = self._q.get()
+        if kind == "yield":
+            return v
+        self._finished = True
+        if kind == "return":
+            raise StopIteration(v)
+        raise v  # kind == "error"
+
+    def close(self) -> None:
+        """Terminate the generator."""
+        if self._finished:
+            return
+        self._resume_q.put(("close", None))
+        self._finished = True
+
+
+def _has_yield(func_def: ast.FunctionDef) -> bool:
+    """Return True if *func_def* contains a ``yield`` or ``yield from`` at its own scope.
+
+    Intentionally does *not* descend into nested function or class definitions so that
+    a generator defined inside a regular function does not make the outer function appear
+    to be a generator.
+    """
+    worklist = list(ast.iter_child_nodes(func_def))
+    while worklist:
+        node = worklist.pop()
+        if isinstance(node, (ast.Yield, ast.YieldFrom)):
+            return True
+        # Don't descend into nested function/class scopes
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            worklist.extend(ast.iter_child_nodes(node))
+    return False
+
+
 def create_function(
     func_def: ast.FunctionDef,
     state: dict[str, Any],
@@ -467,8 +573,10 @@ def create_function(
     authorized_imports: list[str],
 ) -> Callable:
     source_code = ast.unparse(func_def)
+    is_generator = _has_yield(func_def)
 
-    def new_func(*args: Any, **kwargs: Any) -> Any:
+    def _setup_func_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Build the local state for a single function call."""
         func_state = state.copy()
         arg_names = [arg.arg for arg in func_def.args.args]
         default_values = [
@@ -506,17 +614,47 @@ def create_function(
                 func_state["self"] = args[0]
                 func_state["__class__"] = args[0].__class__
 
-        result = None
-        try:
-            for stmt in func_def.body:
-                result = evaluate_ast(stmt, func_state, static_tools, custom_tools, authorized_imports)
-        except ReturnException as e:
-            result = e.value
+        return func_state
 
-        if func_def.name == "__init__":
-            return None
+    if is_generator:
 
-        return result
+        def new_func(*args: Any, **kwargs: Any) -> _GeneratorThread:
+            gen = _GeneratorThread()
+            func_state = _setup_func_state(*args, **kwargs)
+            func_state["_generator_thread"] = gen
+
+            def run_body() -> None:
+                try:
+                    for stmt in func_def.body:
+                        evaluate_ast(stmt, func_state, static_tools, custom_tools, authorized_imports)
+                    gen.complete(None)
+                except ReturnException as e:
+                    gen.complete(e.value)
+                except GeneratorExit:
+                    pass
+                except BaseException as exc:
+                    gen.error(exc)
+
+            t = threading.Thread(target=run_body, daemon=True)
+            t.start()
+            return gen
+
+    else:
+
+        def new_func(*args: Any, **kwargs: Any) -> Any:
+            func_state = _setup_func_state(*args, **kwargs)
+
+            result = None
+            try:
+                for stmt in func_def.body:
+                    result = evaluate_ast(stmt, func_state, static_tools, custom_tools, authorized_imports)
+            except ReturnException as e:
+                result = e.value
+
+            if func_def.name == "__init__":
+                return None
+
+            return result
 
     # Store original AST, source code, and name
     new_func.__ast__ = func_def
@@ -1564,6 +1702,32 @@ def evaluate_ast(
         return None
     elif isinstance(expression, ast.Delete):
         return evaluate_delete(expression, *common_params)
+    elif isinstance(expression, ast.Yield):
+        gen = state.get("_generator_thread")
+        if gen is None:
+            raise InterpreterError("'yield' outside generator function")
+        value = evaluate_ast(expression.value, *common_params) if expression.value is not None else None
+        return gen.yield_value(value)
+    elif isinstance(expression, ast.YieldFrom):
+        gen = state.get("_generator_thread")
+        if gen is None:
+            raise InterpreterError("'yield from' outside generator function")
+        iterable = evaluate_ast(expression.value, *common_params)
+        result = None
+        try:
+            sub_iter = iter(iterable)
+            while True:
+                try:
+                    item = next(sub_iter)
+                except StopIteration as stop:
+                    result = stop.value
+                    break
+                gen.yield_value(item)
+        except GeneratorExit:
+            if hasattr(sub_iter, "close"):
+                sub_iter.close()
+            raise
+        return result
     else:
         # For now we refuse anything else. Let's add things as we need them.
         raise InterpreterError(f"{expression.__class__.__name__} is not supported.")

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -638,6 +638,17 @@ def create_function(
             func_state["_generator_thread"] = gen
 
             def run_body() -> None:
+                # Initial barrier: real generators do not start executing until the first
+                # ``next(gen)`` / ``gen.send(None)`` call. Block here so the body does not
+                # race ahead of the consumer (otherwise the FIRST ``send(value)`` would be
+                # consumed as the resume signal for an already-pending yield, leaving
+                # ``x = yield expr`` bound to ``None`` instead of ``value``).
+                kind, val = gen._resume_q.get()
+                if kind == "close":
+                    return
+                if kind == "throw":
+                    gen.error(val)
+                    return
                 try:
                     for stmt in func_def.body:
                         evaluate_ast(stmt, func_state, static_tools, custom_tools, authorized_imports)

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -315,17 +315,22 @@ def get_tool_json_schema(tool: Tool) -> dict:
 
             value.pop("anyOf")
 
+    function_def: dict = {
+        "name": tool.name,
+        "description": tool.description,
+    }
+    # Some providers (e.g. Gemini) reject a parameters object with an empty
+    # properties dict when type is "object".  Omit the parameters field entirely
+    # for tools that take no inputs so the schema stays valid across providers.
+    if properties:
+        function_def["parameters"] = {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
     return {
         "type": "function",
-        "function": {
-            "name": tool.name,
-            "description": tool.description,
-            "parameters": {
-                "type": "object",
-                "properties": properties,
-                "required": required,
-            },
-        },
+        "function": function_def,
     }
 
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -778,6 +778,42 @@ simple_set = {
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
         assert result == [1, 2]
 
+    def test_generator_function_partial_consumption_releases_thread(self):
+        """Partial consumption (e.g. ``break``) must not leak the body thread.
+
+        Regression test for the thread-leak scenario raised on PR #2201: when a
+        generator is created and only partially consumed, garbage collection
+        should call ``close()`` on the underlying ``_GeneratorThread`` so the
+        body thread unblocks and exits promptly.
+        """
+        import gc
+        import threading
+        import time
+
+        code = dedent("""\
+            def gen():
+                for i in range(1000):
+                    yield i
+
+            g = gen()
+            first = next(g)
+            del g
+            first
+        """)
+        baseline = threading.active_count()
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == 0
+        # Force collection so __del__ on the _GeneratorThread fires.
+        gc.collect()
+        # Give the body thread a brief moment to wake up and exit after close().
+        for _ in range(20):
+            if threading.active_count() <= baseline:
+                break
+            time.sleep(0.05)
+        assert threading.active_count() <= baseline, (
+            f"Generator body thread leaked: baseline={baseline}, after={threading.active_count()}"
+        )
+
     def test_boolops(self):
         code = """if (not (a > b and a > c)) or d > e:
     best_city = "Brooklyn"

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -673,6 +673,111 @@ simple_set = {
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
         assert result == [1, 4, 9, 16, 25]
 
+    def test_generator_function_simple(self):
+        code = dedent("""\
+            def counter(n):
+                for i in range(n):
+                    yield i
+
+            result = list(counter(4))
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [0, 1, 2, 3]
+
+    def test_generator_function_multiple_yields(self):
+        code = dedent("""\
+            def gen():
+                yield 10
+                yield 20
+                yield 30
+
+            result = list(gen())
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [10, 20, 30]
+
+    def test_generator_function_conditional_yield(self):
+        code = dedent("""\
+            def evens(n):
+                for i in range(n):
+                    if i % 2 == 0:
+                        yield i
+
+            result = list(evens(7))
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [0, 2, 4, 6]
+
+    def test_generator_function_with_return(self):
+        """Generator with an explicit return should raise StopIteration after all yields."""
+        code = dedent("""\
+            def gen():
+                yield 1
+                yield 2
+                return 'done'
+
+            g = gen()
+            v1 = next(g)
+            v2 = next(g)
+            try:
+                next(g)
+                stop_raised = False
+            except StopIteration:
+                stop_raised = True
+
+            result = [v1, v2, stop_raised]
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [1, 2, True]
+
+    def test_generator_function_yield_from(self):
+        code = dedent("""\
+            def inner():
+                yield 1
+                yield 2
+
+            def outer():
+                yield 0
+                yield from inner()
+                yield 3
+
+            result = list(outer())
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [0, 1, 2, 3]
+
+    def test_generator_function_in_for_loop(self):
+        code = dedent("""\
+            def squares(n):
+                for i in range(n):
+                    yield i * i
+
+            total = sum(squares(5))
+            total
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == sum(i * i for i in range(5))
+
+    def test_generator_function_nested_does_not_affect_outer(self):
+        """A generator nested inside a regular function must not turn outer into a generator."""
+        code = dedent("""\
+            def outer():
+                def inner():
+                    yield 1
+                    yield 2
+                return list(inner())
+
+            result = outer()
+            result
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == [1, 2]
+
     def test_boolops(self):
         code = """if (not (a > b and a > c)) or d > e:
     best_city = "Brooklyn"

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -814,6 +814,66 @@ simple_set = {
             f"Generator body thread leaked: baseline={baseline}, after={threading.active_count()}"
         )
 
+    def test_generator_function_send_value(self):
+        """``generator.send(value)`` must reach the ``yield`` expression as ``x = yield ...``.
+
+        Verifies the two-way communication channel (``_resume_q`` carries the sent value,
+        ``yield_value`` returns it) — covers the ``return val`` branch of ``yield_value``.
+        """
+        code = dedent("""\
+            def echo_gen():
+                x = yield 1
+                yield x * 2
+
+            g = echo_gen()
+            first = next(g)
+            second = g.send(5)
+            (first, second)
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == (1, 10)
+
+    def test_generator_function_throw_exception(self):
+        """``generator.throw(exc)`` must raise the exception at the paused ``yield``.
+
+        Covers the ``throw`` branch of ``yield_value`` (consumer-to-body exception
+        injection) and verifies the body can catch and recover from it.
+        """
+        code = dedent("""\
+            def gen():
+                try:
+                    yield 1
+                except ValueError as e:
+                    yield f"caught: {e}"
+
+            g = gen()
+            first = next(g)
+            second = g.throw(ValueError("boom"))
+            (first, second)
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == (1, "caught: boom")
+
+    def test_generator_function_close_idempotent_on_exhausted(self):
+        """``close()`` on an exhausted generator must be a no-op (regression for ``__del__`` safety).
+
+        ``__del__`` calls ``close()`` unconditionally, so calling ``close()`` on a fully
+        consumed generator (where ``_finished`` is already True) must not raise or send
+        a stray sentinel to the already-exited body thread.
+        """
+        code = dedent("""\
+            def gen():
+                yield 1
+                yield 2
+
+            g = gen()
+            list(g)  # exhaust
+            g.close()  # must be a no-op, not raise
+            "ok"
+        """)
+        result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+        assert result == "ok"
+
     def test_boolops(self):
         code = """if (not (a > b and a > c)) or d > e:
     best_city = "Brooklyn"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -222,6 +222,17 @@ class TestModel:
 
         assert "nullable" in get_tool_json_schema(get_weather)["function"]["parameters"]["properties"]["celsius"]
 
+    def test_get_json_schema_no_inputs_omits_parameters(self):
+        @tool
+        def ping() -> str:
+            """A tool that takes no arguments."""
+            return "pong"
+
+        schema = get_tool_json_schema(ping)
+        # Providers such as Gemini reject parameters: {type: object, properties: {}}
+        # so we must omit the parameters field entirely for no-input tools.
+        assert "parameters" not in schema["function"]
+
     def test_chatmessage_has_model_dumps_json(self):
         message = ChatMessage("user", [{"type": "text", "text": "Hello!"}])
         data = json.loads(message.model_dump_json())


### PR DESCRIPTION
Fixes #1133

## Problem

When a tool has no inputs, `get_tool_json_schema()` produces a schema with an empty `parameters.properties` object:

```json
{
  "type": "function",
  "function": {
    "name": "ping",
    "description": "...",
    "parameters": {
      "type": "object",
      "properties": {},
      "required": []
    }
  }
}
```

Gemini's API rejects this with:

```
BadRequestError: GenerateContentRequest.tools[N].function_declarations[M].parameters.properties: should be non-empty for OBJECT type
```

This affects any tool that takes no arguments (e.g. tools called purely for side effects or returning a static value, such as `FindNextTool` in open_deep_research).

## Solution

Omit the `parameters` field entirely when the tool has no inputs. This is valid OpenAI function-calling format (no parameters = omit the field) and satisfies Gemini's constraint.

## Testing

Added a new test `test_get_json_schema_no_inputs_omits_parameters` that verifies the `parameters` key is absent from the schema when a tool takes no arguments. Existing `test_get_json_schema_has_nullable_args` continues to pass, confirming tools with parameters are unaffected.