### PR TITLE
fix(executor): support tuple unpacking in `with` statement optional_vars

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1246,7 +1246,7 @@ def evaluate_with(
         enter_result = context_expr.__enter__()
         contexts.append(context_expr)
         if item.optional_vars:
-            state[item.optional_vars.id] = enter_result
+            set_value(item.optional_vars, enter_result, state, static_tools, custom_tools, authorized_imports)
 
     try:
         for stmt in with_node.body:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1216,6 +1216,88 @@ with RaisingExit():
         with pytest.raises(InterpreterError, match="from __exit__"):
             evaluate_python_code(code, {}, state={})
 
+    def test_with_tuple_unpacking(self):
+        """Test that 'with X() as (a, b)' correctly unpacks the tuple."""
+        code = """
+class MultiVal:
+    def __enter__(self):
+        return (10, 20)
+    def __exit__(self, *args):
+        return False
+
+with MultiVal() as (a, b):
+    result = a + b
+result
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == 30
+
+    def test_with_nested_tuple_unpacking(self):
+        """Test that 'with X() as (a, (b, c))' correctly unpacks nested tuples."""
+        code = """
+class NestedVal:
+    def __enter__(self):
+        return (1, (2, 3))
+    def __exit__(self, *args):
+        return False
+
+with NestedVal() as (a, (b, c)):
+    result = a + b + c
+result
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == 6
+
+    def test_with_multiple_cms_tuple_unpacking(self):
+        """Test multiple context managers each with tuple unpacking."""
+        code = """
+class Pair:
+    def __init__(self, v):
+        self.v = v
+    def __enter__(self):
+        return self.v
+    def __exit__(self, *args):
+        return False
+
+with Pair((1, 2)) as (a, b), Pair((3, 4)) as (c, d):
+    result = a + b + c + d
+result
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == 10
+
+    def test_with_tuple_unpacking_exception_suppressed(self):
+        """Test that exception suppression works correctly with tuple unpacking."""
+        code = """
+class SuppressExc:
+    def __enter__(self):
+        return (1, 2)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return True
+
+with SuppressExc() as (a, b):
+    raise ValueError("test")
+result = "suppressed"
+result
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == "suppressed"
+
+    def test_with_tuple_unpacking_exception_propagates(self):
+        """Test that exceptions propagate when __exit__ returns False with tuple unpacking."""
+        code = """
+class NoSuppress:
+    def __enter__(self):
+        return (5, 6)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+with NoSuppress() as (a, b):
+    raise ValueError("boom")
+"""
+        with pytest.raises(InterpreterError, match="boom"):
+            evaluate_python_code(code, {}, state={})
+
     def test_default_arg_in_function(self):
         code = """
 def f(a, b=333, n=1000):


### PR DESCRIPTION
## Summary

- `evaluate_with()` assumed `item.optional_vars` is always an `ast.Name` node and accessed `.id` directly
- When using tuple unpacking like `with X() as (a, b):`, `optional_vars` is an `ast.Tuple` which has no `.id`, causing `AttributeError: 'Tuple' object has no attribute 'id'`
- Replaced direct `state[item.optional_vars.id] = enter_result` with a call to the existing `set_value()` helper, which already handles `ast.Name`, `ast.Tuple` (including nesting), `ast.Subscript`, and `ast.Attribute` targets

Fixes #2090

## Real-world example

A `CodeAgent` with `sqlite3` authorized — the LLM generates a common `(conn, cursor)` pattern:

```python
import sqlite3

class DBSession:
    def __init__(self):
        self.conn = sqlite3.connect(":memory:")
    def __enter__(self):
        return (self.conn, self.conn.cursor())
    def __exit__(self, *args):
        self.conn.close()

with DBSession() as (conn, cursor):      # ← crashes without this fix
    cursor.execute("CREATE TABLE users (name TEXT, age INT)")
    cursor.execute("INSERT INTO users VALUES ('Alice', 30)")
    cursor.execute("SELECT * FROM users")
    results = cursor.fetchall()
```

**Before:** `AttributeError: 'Tuple' object has no attribute 'id'`
**After:** `[('Alice', 30)]`

## Test plan

- [x] `test_with_tuple_unpacking` — `with X() as (a, b)`
- [x] `test_with_nested_tuple_unpacking` — `with X() as (a, (b, c))`
- [x] `test_with_multiple_cms_tuple_unpacking` — multiple context managers with tuple unpack
- [x] `test_with_tuple_unpacking_exception_suppressed` — exception suppression still works
- [x] `test_with_tuple_unpacking_exception_propagates` — exception propagation still works
- [x] All 9 pre-existing `with`-statement tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)