### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -10,6 +10,7 @@ The built-in tools can be categorized by their primary functions:
 - **Information Retrieval**: Search and retrieve information from the web and specific knowledge sources.
   - [`ApiWebSearchTool`]
   - [`DuckDuckGoSearchTool`]
+  - [`ExaSearchTool`]
   - [`GoogleSearchTool`]
   - [`WebSearchTool`]
   - [`WikipediaSearchTool`]
@@ -31,6 +32,10 @@ The built-in tools can be categorized by their primary functions:
 ## DuckDuckGoSearchTool
 
 [[autodoc]] smolagents.default_tools.DuckDuckGoSearchTool
+
+## ExaSearchTool
+
+[[autodoc]] smolagents.default_tools.ExaSearchTool
 
 ## FinalAnswerTool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ telemetry = [
 ]
 toolkit = [
   "ddgs>=9.0.0",  # DuckDuckGoSearchTool
+  "exa-py>=2.0.0",  # ExaSearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool
 ]
 transformers = [

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -606,6 +606,168 @@ class WikipediaSearchTool(Tool):
             return f"Error fetching Wikipedia summary: {str(e)}"
 
 
+class ExaSearchTool(Tool):
+    """Web search tool that performs AI-powered searches using the Exa API.
+
+    Exa returns semantically relevant pages with optional content retrieval (text, highlights, summary).
+    The tool exposes Exa's filtering features: search type, category, domain include/exclude lists,
+    text include/exclude lists, and published-date ranges.
+
+    Args:
+        max_results (`int`, default `10`): Maximum number of search results to return.
+        search_type (`str`, default `"auto"`): One of "auto", "neural", "fast", "deep-lite", "deep",
+            "deep-reasoning", or "instant".
+        category (`str`, *optional*): Restrict results to a category (e.g. "company", "research paper",
+            "news", "personal site", "financial report", "people").
+        include_domains (`list[str]`, *optional*): Restrict results to specific domains.
+        exclude_domains (`list[str]`, *optional*): Exclude results from specific domains.
+        include_text (`list[str]`, *optional*): Strings that must appear in the page text.
+        exclude_text (`list[str]`, *optional*): Strings that must not appear in the page text.
+        start_published_date (`str`, *optional*): ISO 8601 date; only return content published after this.
+        end_published_date (`str`, *optional*): ISO 8601 date; only return content published before this.
+        contents (`str` or `dict`, default `"highlights"`): Content mode for each result. Pass a string
+            shortcut (`"text"`, `"highlights"`, or `"summary"`) or a dict with the full Exa contents
+            options (e.g. `{"text": {"maxCharacters": 1000}, "highlights": True, "summary": {"query": "..."}}`).
+        api_key (`str`, *optional*): Exa API key. Falls back to the `EXA_API_KEY` environment variable.
+
+    Examples:
+        ```python
+        >>> from smolagents import ExaSearchTool
+        >>> web_search_tool = ExaSearchTool(max_results=5, category="research paper")
+        >>> results = web_search_tool("recent advances in retrieval-augmented generation")
+        >>> print(results)
+        ```
+    """
+
+    name = "web_search"
+    description = (
+        "Performs an Exa AI-powered web search for a query and returns the top results as markdown "
+        "with titles, URLs, snippets, and (when available) author and published date."
+    )
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "string"
+
+    _CONTENT_SHORTCUTS = {
+        "text": {"text": True},
+        "highlights": {"highlights": True},
+        "summary": {"summary": True},
+    }
+
+    def __init__(
+        self,
+        max_results: int = 10,
+        search_type: str = "auto",
+        category: str | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        include_text: list[str] | None = None,
+        exclude_text: list[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        contents: str | dict | None = "highlights",
+        api_key: str | None = None,
+    ):
+        super().__init__()
+        import os
+
+        try:
+            from exa_py import Exa
+        except ImportError as e:
+            raise ImportError(
+                "You must install package `exa-py` to run this tool: for instance run `pip install exa-py`."
+            ) from e
+
+        api_key = api_key or os.getenv("EXA_API_KEY")
+        if not api_key:
+            raise ValueError("Missing API key. Set 'EXA_API_KEY' in your env variables or pass `api_key`.")
+
+        self.client = Exa(api_key=api_key)
+        # Tag requests so Exa can attribute API usage to this integration.
+        self.client.headers["x-exa-integration"] = "smolagents"
+
+        self.max_results = max_results
+        self.search_type = search_type
+        self.category = category
+        self.include_domains = include_domains
+        self.exclude_domains = exclude_domains
+        self.include_text = include_text
+        self.exclude_text = exclude_text
+        self.start_published_date = start_published_date
+        self.end_published_date = end_published_date
+
+        if contents is None:
+            self.contents = None
+        elif isinstance(contents, str):
+            if contents not in self._CONTENT_SHORTCUTS:
+                raise ValueError(
+                    f"Invalid `contents` shortcut '{contents}'. "
+                    f"Choose one of {sorted(self._CONTENT_SHORTCUTS)} or pass a dict."
+                )
+            self.contents = self._CONTENT_SHORTCUTS[contents]
+        else:
+            self.contents = contents
+
+    def forward(self, query: str) -> str:
+        kwargs: dict = {"num_results": self.max_results, "type": self.search_type}
+        if self.contents is not None:
+            kwargs["contents"] = self.contents
+        if self.category is not None:
+            kwargs["category"] = self.category
+        if self.include_domains is not None:
+            kwargs["include_domains"] = self.include_domains
+        if self.exclude_domains is not None:
+            kwargs["exclude_domains"] = self.exclude_domains
+        if self.include_text is not None:
+            kwargs["include_text"] = self.include_text
+        if self.exclude_text is not None:
+            kwargs["exclude_text"] = self.exclude_text
+        if self.start_published_date is not None:
+            kwargs["start_published_date"] = self.start_published_date
+        if self.end_published_date is not None:
+            kwargs["end_published_date"] = self.end_published_date
+
+        response = self.client.search(query, **kwargs)
+        results = getattr(response, "results", None) or []
+        if not results:
+            return f"No results found for '{query}'. Try a less restrictive query."
+        return self._format_results(results)
+
+    @staticmethod
+    def _extract_snippet(result) -> str:
+        highlights = getattr(result, "highlights", None)
+        if highlights:
+            return " … ".join(highlights)
+        summary = getattr(result, "summary", None)
+        if summary:
+            return summary
+        text = getattr(result, "text", None)
+        if text:
+            return text[:500].rstrip() + ("…" if len(text) > 500 else "")
+        return ""
+
+    def _format_results(self, results) -> str:
+        snippets = []
+        for idx, result in enumerate(results, start=1):
+            title = getattr(result, "title", None) or "Untitled"
+            url = getattr(result, "url", "")
+            line = f"{idx}. [{title}]({url})"
+
+            published_date = getattr(result, "published_date", None)
+            if published_date:
+                line += f"\nPublished: {published_date}"
+
+            author = getattr(result, "author", None)
+            if author:
+                line += f"\nAuthor: {author}"
+
+            snippet = self._extract_snippet(result)
+            if snippet:
+                line += f"\n{snippet}"
+
+            snippets.append(line)
+        return "## Search Results\n\n" + "\n\n".join(snippets)
+
+
 class SpeechToTextTool(PipelineTool):
     default_checkpoint = "openai/whisper-large-v3-turbo"
     description = "This is a tool that transcribes an audio into text. It returns the transcribed text."
@@ -654,6 +816,7 @@ __all__ = [
     "UserInputTool",
     "WebSearchTool",
     "DuckDuckGoSearchTool",
+    "ExaSearchTool",
     "GoogleSearchTool",
     "VisitWebpageTool",
     "WikipediaSearchTool",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 
-from smolagents import DuckDuckGoSearchTool
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolagents import DuckDuckGoSearchTool, ExaSearchTool
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
@@ -33,3 +38,145 @@ class TestDuckDuckGoSearchTool(ToolTesterMixin):
     @require_run_all
     def test_agent_type_output(self):
         super().test_agent_type_output()
+
+
+def _make_exa_result(
+    title="Example Title",
+    url="https://example.com/",
+    published_date=None,
+    author=None,
+    text=None,
+    summary=None,
+    highlights=None,
+):
+    return SimpleNamespace(
+        title=title,
+        url=url,
+        published_date=published_date,
+        author=author,
+        text=text,
+        summary=summary,
+        highlights=highlights,
+    )
+
+
+def _make_exa_client(results):
+    """Build a fake Exa client whose `.search()` returns a SimpleNamespace with `results`."""
+    client = MagicMock()
+    client.headers = {}
+    client.search.return_value = SimpleNamespace(results=results)
+    return client
+
+
+class TestExaSearchTool:
+    def _build_tool(self, results, **tool_kwargs):
+        fake_client = _make_exa_client(results)
+        # `from exa_py import Exa` runs inside ExaSearchTool.__init__; patch the source
+        # module so the constructor receives our fake.
+        with patch("exa_py.Exa", return_value=fake_client):
+            tool = ExaSearchTool(api_key="test-key", **tool_kwargs)
+        return tool, fake_client
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="EXA_API_KEY"):
+            with patch("exa_py.Exa"):
+                ExaSearchTool()
+
+    def test_integration_header_set(self):
+        _tool, client = self._build_tool([])
+        assert client.headers["x-exa-integration"] == "smolagents"
+
+    def test_invalid_contents_shortcut_raises(self):
+        with patch("exa_py.Exa", return_value=_make_exa_client([])):
+            with pytest.raises(ValueError, match="Invalid `contents` shortcut"):
+                ExaSearchTool(api_key="test-key", contents="bogus")
+
+    def test_no_results_returns_empty_message(self):
+        tool, _ = self._build_tool([])
+        out = tool("anything")
+        assert isinstance(out, str)
+        assert "No results found" in out
+
+    def test_formats_highlights_when_present(self):
+        results = [
+            _make_exa_result(
+                title="Hugging Face",
+                url="https://huggingface.co/",
+                published_date="2024-01-15",
+                author="HF Team",
+                highlights=["Open-source AI platform.", "Hub for models and datasets."],
+                text="Full page text",
+                summary="A summary",
+            )
+        ]
+        tool, _ = self._build_tool(results)
+        out = tool("hugging face")
+        assert "[Hugging Face](https://huggingface.co/)" in out
+        assert "Published: 2024-01-15" in out
+        assert "Author: HF Team" in out
+        # Highlights take precedence over summary/text.
+        assert "Open-source AI platform." in out
+        assert "Hub for models and datasets." in out
+        assert "A summary" not in out
+        assert "Full page text" not in out
+
+    def test_falls_back_to_summary_when_no_highlights(self):
+        results = [_make_exa_result(summary="Short summary text", text="Full text")]
+        tool, _ = self._build_tool(results)
+        out = tool("query")
+        assert "Short summary text" in out
+        assert "Full text" not in out
+
+    def test_falls_back_to_text_when_no_highlights_or_summary(self):
+        long_text = "x" * 600
+        results = [_make_exa_result(text=long_text)]
+        tool, _ = self._build_tool(results)
+        out = tool("query")
+        # First 500 chars of text plus an ellipsis appear in the output.
+        assert "x" * 500 in out
+        assert "…" in out
+
+    def test_handles_result_with_no_content(self):
+        results = [_make_exa_result(title="Bare", url="https://bare.example/")]
+        tool, _ = self._build_tool(results)
+        out = tool("query")
+        assert "[Bare](https://bare.example/)" in out
+
+    def test_forward_passes_filters_to_client(self):
+        results = [_make_exa_result()]
+        tool, client = self._build_tool(
+            results,
+            max_results=3,
+            search_type="neural",
+            category="research paper",
+            include_domains=["arxiv.org"],
+            exclude_domains=["spam.example"],
+            include_text=["transformer"],
+            exclude_text=["draft"],
+            start_published_date="2024-01-01",
+            end_published_date="2024-12-31",
+            contents="text",
+        )
+        tool("transformer architectures")
+        client.search.assert_called_once()
+        args, kwargs = client.search.call_args
+        assert args == ("transformer architectures",)
+        assert kwargs["num_results"] == 3
+        assert kwargs["type"] == "neural"
+        assert kwargs["category"] == "research paper"
+        assert kwargs["include_domains"] == ["arxiv.org"]
+        assert kwargs["exclude_domains"] == ["spam.example"]
+        assert kwargs["include_text"] == ["transformer"]
+        assert kwargs["exclude_text"] == ["draft"]
+        assert kwargs["start_published_date"] == "2024-01-01"
+        assert kwargs["end_published_date"] == "2024-12-31"
+        assert kwargs["contents"] == {"text": True}
+
+    def test_custom_contents_dict_passed_through(self):
+        results = [_make_exa_result()]
+        custom = {"text": {"maxCharacters": 200}, "highlights": True}
+        tool, client = self._build_tool(results, contents=custom)
+        tool("query")
+        _, kwargs = client.search.call_args
+        assert kwargs["contents"] == custom


### PR DESCRIPTION
## Summary

Adds a new built-in search provider, `ExaSearchTool`, that uses the [Exa API](https://exa.ai) for semantic web search. The tool follows the existing provider patterns in `default_tools.py` (`ApiWebSearchTool`, `GoogleSearchTool`, etc.) and exposes Exa's filtering features:

- Search type (`auto`, `neural`, `fast`, `deep-lite`, `deep`, `deep-reasoning`, `instant`)
- Category filter (`company`, `research paper`, `news`, `personal site`, `financial report`, `people`)
- Domain include/exclude lists
- Text include/exclude lists
- Published-date ranges
- Content modes: `text`, `highlights`, `summary`, or a custom contents dict combining them

Authentication uses the `EXA_API_KEY` environment variable (or an explicit `api_key` argument).

## Usage

```python
from smolagents import CodeAgent, InferenceClientModel, ExaSearchTool

agent = CodeAgent(
    tools=[ExaSearchTool(max_results=5, category="research paper")],
    model=InferenceClientModel(),
)
agent.run("recent advances in retrieval-augmented generation")
```

For richer responses, pass a custom contents dict that combines multiple Exa content types simultaneously:

```python
ExaSearchTool(
    contents={"text": {"maxCharacters": 1000}, "highlights": True},
    include_domains=["arxiv.org"],
    start_published_date="2024-01-01",
)
```

## Files changed

- `src/smolagents/default_tools.py` — new `ExaSearchTool` class; added to `__all__`
- `pyproject.toml` — add `exa-py>=2.0.0` to the `toolkit` optional-dependencies group
- `docs/source/en/reference/default_tools.md` — register the tool in the reference page
- `tests/test_search.py` — unit tests for parsing, filter passthrough, content fallbacks, error states

## Test plan

- [x] `ruff check src/ tests/test_search.py` passes
- [x] `ruff format --check` passes for changed Python files
- [x] `pytest tests/test_search.py` — all 9 new `TestExaSearchTool` tests pass (no live API calls; uses a hardcoded JSON-shaped fixture and a mocked `exa_py.Exa`)
- [x] `pytest tests/test_import.py` — `smolagents` still imports cleanly with no extras installed
- [ ] CI to confirm on the project's full matrix