### PR TITLE
Add Tavily Search to default_tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ telemetry = [
   "opentelemetry-exporter-otlp",
   "openinference-instrumentation-smolagents>=0.1.15"  # Use new TokenUsage structure
 ]
+tavily = [
+  "tavily-python",
+]
 toolkit = [
   "ddgs>=9.0.0",  # DuckDuckGoSearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -340,33 +340,45 @@ class ApiWebSearchTool(Tool):
 
 
 class TavilySearchTool(Tool):
+    """Web search using the `Tavily <https://tavily.com>`_ API via ``tavily-python``.
+
+    Requires ``TAVILY_API_KEY`` in the environment. Install the SDK with
+    ``pip install tavily-python`` or ``pip install 'smolagents[tavily]'``.
+
+    All keyword arguments to this constructor (except ``client_source``) are forwarded to
+    ``TavilyClient.search(query, **kwargs)``. The SDK maps ``client_source`` to the
+    ``X-Client-Source`` HTTP header; it defaults to ``"smolagents"`` or the value of the
+    ``TAVILY_CLIENT_SOURCE`` environment variable when set.
+    See the `Tavily Python SDK <https://docs.tavily.com/sdk/python/reference>`_ for valid
+    ``search`` parameters (``max_results``, ``search_depth``, ``include_answer``, etc.).
+
+    Args:
+        client_source: Optional client identifier sent as ``X-Client-Source`` via the SDK.
+            If omitted, uses ``TAVILY_CLIENT_SOURCE`` from the environment, then ``"smolagents"``.
+        **kwargs: Arguments passed through to ``TavilyClient.search`` (except ``query``, which
+            you supply when calling the tool). ``None`` values are omitted.
+
+    Examples:
+        ```python
+        >>> import os
+        >>> os.environ["TAVILY_API_KEY"] = "tvly-..."  # doctest: +SKIP
+        >>> from smolagents import TavilySearchTool
+        >>> tool = TavilySearchTool(max_results=5, include_answer=True)
+        >>> result = tool("What is Hugging Face?")
+        >>> isinstance(result, dict) and "results" in result
+        True
+        ```
+    """
+
     name = "web_search"
-    description = "Performs a Tavily web search for your query and returns Tavily's structured response object."
+    description = (
+        "Performs a Tavily web search for your query and returns Tavily's structured response object. "
+        "Constructor keyword arguments are forwarded to the Tavily Python SDK ``search`` method (see Tavily docs)."
+    )
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "object"
 
-    def __init__(
-        self,
-        max_results: int = 5,
-        search_depth: str = "basic",
-        chunks_per_source: int = 3,
-        topic: str = "general",
-        time_range: str | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        include_answer: bool | str = False,
-        include_raw_content: bool | str = False,
-        include_images: bool = False,
-        include_image_descriptions: bool = False,
-        include_favicon: bool = False,
-        include_domains: list[str] | None = None,
-        exclude_domains: list[str] | None = None,
-        country: str | None = None,
-        auto_parameters: bool = False,
-        exact_match: bool = False,
-        include_usage: bool = False,
-        safe_search: bool = False,
-    ):
+    def __init__(self, client_source: str | None = None, **kwargs):
         super().__init__()
         import os
 
@@ -374,68 +386,31 @@ class TavilySearchTool(Tool):
         if self.api_key is None:
             raise ValueError("Missing API key. Make sure you have 'TAVILY_API_KEY' in your env variables.")
 
-        self.max_results = max_results
-        self.search_depth = search_depth
-        self.chunks_per_source = chunks_per_source
-        self.topic = topic
-        self.time_range = time_range
-        self.start_date = start_date
-        self.end_date = end_date
-        self.include_answer = include_answer
-        self.include_raw_content = include_raw_content
-        self.include_images = include_images
-        self.include_image_descriptions = include_image_descriptions
-        self.include_favicon = include_favicon
-        self.include_domains = include_domains or []
-        self.exclude_domains = exclude_domains or []
-        self.country = country
-        self.auto_parameters = auto_parameters
-        self.exact_match = exact_match
-        self.include_usage = include_usage
-        self.safe_search = safe_search
-
-    def _search(self, query: str, requests_module):
-        return requests_module.post(
-            "https://api.tavily.com/search",
-            headers={
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "query": query,
-                "max_results": self.max_results,
-                "search_depth": self.search_depth,
-                "chunks_per_source": self.chunks_per_source,
-                "topic": self.topic,
-                "time_range": self.time_range,
-                "start_date": self.start_date,
-                "end_date": self.end_date,
-                "include_answer": self.include_answer,
-                "include_raw_content": self.include_raw_content,
-                "include_images": self.include_images,
-                "include_image_descriptions": self.include_image_descriptions,
-                "include_favicon": self.include_favicon,
-                "include_domains": self.include_domains,
-                "exclude_domains": self.exclude_domains,
-                "country": self.country,
-                "auto_parameters": self.auto_parameters,
-                "exact_match": self.exact_match,
-                "include_usage": self.include_usage,
-                "safe_search": self.safe_search,
-            },
-        )
+        self._client_source = client_source or os.getenv("TAVILY_CLIENT_SOURCE") or "smolagents"
+        self._search_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     def forward(self, query: str) -> dict:
-        import requests
+        try:
+            from tavily import TavilyClient
+        except ImportError as err:
+            raise ImportError(
+                "The Tavily integration requires the tavily-python package. "
+                "Install it with: pip install tavily-python "
+                "or pip install 'smolagents[tavily]'."
+            ) from err
 
-        response = self._search(query, requests)
-        response.raise_for_status()
-        return response.json()
+        client = TavilyClient(api_key=self.api_key, client_source=self._client_source)
+        return client.search(query, **self._search_kwargs)
 
 
 class WebSearchTool(Tool):
     name = "web_search"
-    description = "Performs a web search for a query and returns search results. DuckDuckGo and Bing return markdown strings; Tavily returns Tavily's structured response object."
+    description = (
+        "Performs a web search for a query and returns search results. DuckDuckGo and Bing return markdown strings; "
+        "Tavily returns Tavily's structured response object. With engine='tavily', the ``client_source`` argument (or "
+        "``TAVILY_CLIENT_SOURCE``) sets the ``X-Client-Source`` header via the SDK; extra keyword arguments are "
+        "forwarded to the Tavily Python SDK ``search`` method (see Tavily docs)."
+    )
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "any"
 
@@ -443,46 +418,16 @@ class WebSearchTool(Tool):
         self,
         max_results: int = 10,
         engine: str = "duckduckgo",
-        search_depth: str = "basic",
-        chunks_per_source: int = 3,
-        topic: str = "general",
-        time_range: str | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        include_answer: bool | str = False,
-        include_raw_content: bool | str = False,
-        include_images: bool = False,
-        include_image_descriptions: bool = False,
-        include_favicon: bool = False,
-        include_domains: list[str] | None = None,
-        exclude_domains: list[str] | None = None,
-        country: str | None = None,
-        auto_parameters: bool = False,
-        exact_match: bool = False,
-        include_usage: bool = False,
-        safe_search: bool = False,
+        client_source: str | None = None,
+        **kwargs,
     ):
         super().__init__()
+        import os
+
         self.max_results = max_results
         self.engine = engine
-        self.search_depth = search_depth
-        self.chunks_per_source = chunks_per_source
-        self.topic = topic
-        self.time_range = time_range
-        self.start_date = start_date
-        self.end_date = end_date
-        self.include_answer = include_answer
-        self.include_raw_content = include_raw_content
-        self.include_images = include_images
-        self.include_image_descriptions = include_image_descriptions
-        self.include_favicon = include_favicon
-        self.include_domains = include_domains or []
-        self.exclude_domains = exclude_domains or []
-        self.country = country
-        self.auto_parameters = auto_parameters
-        self.exact_match = exact_match
-        self.include_usage = include_usage
-        self.safe_search = safe_search
+        self._tavily_client_source = client_source or os.getenv("TAVILY_CLIENT_SOURCE") or "smolagents"
+        self._tavily_search_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     def forward(self, query: str):
         if self.engine == "tavily":
@@ -592,43 +537,24 @@ class WebSearchTool(Tool):
     def search_tavily(self, query: str) -> dict:
         import os
 
-        import requests
-
         api_key = os.getenv("TAVILY_API_KEY")
         if api_key is None:
             raise ValueError("Missing API key. Make sure you have 'TAVILY_API_KEY' in your env variables.")
 
-        response = requests.post(
-            "https://api.tavily.com/search",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "query": query,
-                "max_results": self.max_results,
-                "search_depth": self.search_depth,
-                "chunks_per_source": self.chunks_per_source,
-                "topic": self.topic,
-                "time_range": self.time_range,
-                "start_date": self.start_date,
-                "end_date": self.end_date,
-                "include_answer": self.include_answer,
-                "include_raw_content": self.include_raw_content,
-                "include_images": self.include_images,
-                "include_image_descriptions": self.include_image_descriptions,
-                "include_favicon": self.include_favicon,
-                "include_domains": self.include_domains,
-                "exclude_domains": self.exclude_domains,
-                "country": self.country,
-                "auto_parameters": self.auto_parameters,
-                "exact_match": self.exact_match,
-                "include_usage": self.include_usage,
-                "safe_search": self.safe_search,
-            },
-        )
-        response.raise_for_status()
-        return response.json()
+        try:
+            from tavily import TavilyClient
+        except ImportError as err:
+            raise ImportError(
+                "The Tavily integration requires the tavily-python package. "
+                "Install it with: pip install tavily-python "
+                "or pip install 'smolagents[tavily]'."
+            ) from err
+
+        search_kwargs = {**self._tavily_search_kwargs, "max_results": self.max_results}
+        search_kwargs = {k: v for k, v in search_kwargs.items() if v is not None}
+
+        client = TavilyClient(api_key=api_key, client_source=self._tavily_client_source)
+        return client.search(query, **search_kwargs)
 
 
 class VisitWebpageTool(Tool):

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -339,18 +339,155 @@ class ApiWebSearchTool(Tool):
         )
 
 
+class TavilySearchTool(Tool):
+    name = "web_search"
+    description = "Performs a Tavily web search for your query and returns Tavily's structured response object."
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "object"
+
+    def __init__(
+        self,
+        max_results: int = 5,
+        search_depth: str = "basic",
+        chunks_per_source: int = 3,
+        topic: str = "general",
+        time_range: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        include_answer: bool | str = False,
+        include_raw_content: bool | str = False,
+        include_images: bool = False,
+        include_image_descriptions: bool = False,
+        include_favicon: bool = False,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        country: str | None = None,
+        auto_parameters: bool = False,
+        exact_match: bool = False,
+        include_usage: bool = False,
+        safe_search: bool = False,
+    ):
+        super().__init__()
+        import os
+
+        self.api_key = os.getenv("TAVILY_API_KEY")
+        if self.api_key is None:
+            raise ValueError("Missing API key. Make sure you have 'TAVILY_API_KEY' in your env variables.")
+
+        self.max_results = max_results
+        self.search_depth = search_depth
+        self.chunks_per_source = chunks_per_source
+        self.topic = topic
+        self.time_range = time_range
+        self.start_date = start_date
+        self.end_date = end_date
+        self.include_answer = include_answer
+        self.include_raw_content = include_raw_content
+        self.include_images = include_images
+        self.include_image_descriptions = include_image_descriptions
+        self.include_favicon = include_favicon
+        self.include_domains = include_domains or []
+        self.exclude_domains = exclude_domains or []
+        self.country = country
+        self.auto_parameters = auto_parameters
+        self.exact_match = exact_match
+        self.include_usage = include_usage
+        self.safe_search = safe_search
+
+    def _search(self, query: str, requests_module):
+        return requests_module.post(
+            "https://api.tavily.com/search",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": query,
+                "max_results": self.max_results,
+                "search_depth": self.search_depth,
+                "chunks_per_source": self.chunks_per_source,
+                "topic": self.topic,
+                "time_range": self.time_range,
+                "start_date": self.start_date,
+                "end_date": self.end_date,
+                "include_answer": self.include_answer,
+                "include_raw_content": self.include_raw_content,
+                "include_images": self.include_images,
+                "include_image_descriptions": self.include_image_descriptions,
+                "include_favicon": self.include_favicon,
+                "include_domains": self.include_domains,
+                "exclude_domains": self.exclude_domains,
+                "country": self.country,
+                "auto_parameters": self.auto_parameters,
+                "exact_match": self.exact_match,
+                "include_usage": self.include_usage,
+                "safe_search": self.safe_search,
+            },
+        )
+
+    def forward(self, query: str) -> dict:
+        import requests
+
+        response = self._search(query, requests)
+        response.raise_for_status()
+        return response.json()
+
+
 class WebSearchTool(Tool):
     name = "web_search"
-    description = "Performs a web search for a query and returns a string of the top search results formatted as markdown with titles, links, and descriptions."
+    description = "Performs a web search for a query and returns search results. DuckDuckGo and Bing return markdown strings; Tavily returns Tavily's structured response object."
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
-    output_type = "string"
+    output_type = "any"
 
-    def __init__(self, max_results: int = 10, engine: str = "duckduckgo"):
+    def __init__(
+        self,
+        max_results: int = 10,
+        engine: str = "duckduckgo",
+        search_depth: str = "basic",
+        chunks_per_source: int = 3,
+        topic: str = "general",
+        time_range: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        include_answer: bool | str = False,
+        include_raw_content: bool | str = False,
+        include_images: bool = False,
+        include_image_descriptions: bool = False,
+        include_favicon: bool = False,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        country: str | None = None,
+        auto_parameters: bool = False,
+        exact_match: bool = False,
+        include_usage: bool = False,
+        safe_search: bool = False,
+    ):
         super().__init__()
         self.max_results = max_results
         self.engine = engine
+        self.search_depth = search_depth
+        self.chunks_per_source = chunks_per_source
+        self.topic = topic
+        self.time_range = time_range
+        self.start_date = start_date
+        self.end_date = end_date
+        self.include_answer = include_answer
+        self.include_raw_content = include_raw_content
+        self.include_images = include_images
+        self.include_image_descriptions = include_image_descriptions
+        self.include_favicon = include_favicon
+        self.include_domains = include_domains or []
+        self.exclude_domains = exclude_domains or []
+        self.country = country
+        self.auto_parameters = auto_parameters
+        self.exact_match = exact_match
+        self.include_usage = include_usage
+        self.safe_search = safe_search
 
-    def forward(self, query: str) -> str:
+    def forward(self, query: str):
+        if self.engine == "tavily":
+            return self.search_tavily(query)
+
         results = self.search(query)
         if len(results) == 0:
             raise Exception("No results found! Try a less restrictive/shorter query.")
@@ -361,6 +498,8 @@ class WebSearchTool(Tool):
             return self.search_duckduckgo(query)
         elif self.engine == "bing":
             return self.search_bing(query)
+        elif self.engine == "tavily":
+            return self.search_tavily(query)
         else:
             raise ValueError(f"Unsupported engine: {self.engine}")
 
@@ -449,6 +588,47 @@ class WebSearchTool(Tool):
             for item in items[: self.max_results]
         ]
         return results
+
+    def search_tavily(self, query: str) -> dict:
+        import os
+
+        import requests
+
+        api_key = os.getenv("TAVILY_API_KEY")
+        if api_key is None:
+            raise ValueError("Missing API key. Make sure you have 'TAVILY_API_KEY' in your env variables.")
+
+        response = requests.post(
+            "https://api.tavily.com/search",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": query,
+                "max_results": self.max_results,
+                "search_depth": self.search_depth,
+                "chunks_per_source": self.chunks_per_source,
+                "topic": self.topic,
+                "time_range": self.time_range,
+                "start_date": self.start_date,
+                "end_date": self.end_date,
+                "include_answer": self.include_answer,
+                "include_raw_content": self.include_raw_content,
+                "include_images": self.include_images,
+                "include_image_descriptions": self.include_image_descriptions,
+                "include_favicon": self.include_favicon,
+                "include_domains": self.include_domains,
+                "exclude_domains": self.exclude_domains,
+                "country": self.country,
+                "auto_parameters": self.auto_parameters,
+                "exact_match": self.exact_match,
+                "include_usage": self.include_usage,
+                "safe_search": self.safe_search,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
 
 
 class VisitWebpageTool(Tool):
@@ -652,6 +832,7 @@ __all__ = [
     "PythonInterpreterTool",
     "FinalAnswerTool",
     "UserInputTool",
+    "TavilySearchTool",
     "WebSearchTool",
     "DuckDuckGoSearchTool",
     "GoogleSearchTool",

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,7 +22,9 @@ from smolagents.default_tools import (
     DuckDuckGoSearchTool,
     PythonInterpreterTool,
     SpeechToTextTool,
+    TavilySearchTool,
     VisitWebpageTool,
+    WebSearchTool,
     WikipediaSearchTool,
 )
 from smolagents.local_python_executor import ExecutionTimeoutError
@@ -41,6 +44,217 @@ class DefaultToolTests(unittest.TestCase):
     def test_ddgs_with_kwargs(self):
         result = DuckDuckGoSearchTool(timeout=20)("DeepSeek parent company")
         assert isinstance(result, str)
+
+
+class TestTavilySearchTool:
+    def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            TavilySearchTool()
+
+    @patch("requests.post")
+    def test_forward_formats_results(self, mock_post):
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "query": "What is Hugging Face?",
+                "answer": "Hugging Face builds open-source AI tooling.",
+                "images": [],
+                "results": [
+                    {
+                        "title": "Hugging Face",
+                        "url": "https://huggingface.co",
+                        "content": "Open-source AI models, datasets, and apps.",
+                    }
+                ],
+                "response_time": 1.23,
+            }
+            mock_post.return_value = mock_response
+
+            tool = TavilySearchTool(
+                max_results=3,
+                search_depth="advanced",
+                chunks_per_source=2,
+                topic="news",
+                time_range="week",
+                start_date="2025-01-01",
+                end_date="2025-12-31",
+                include_answer="advanced",
+                include_raw_content="markdown",
+                include_images=True,
+                include_image_descriptions=True,
+                include_favicon=True,
+                include_domains=["huggingface.co"],
+                exclude_domains=["example.com"],
+                country="united states",
+                auto_parameters=True,
+                exact_match=True,
+                include_usage=True,
+                safe_search=True,
+            )
+
+            result = tool("What is Hugging Face?")
+
+        mock_post.assert_called_once_with(
+            "https://api.tavily.com/search",
+            headers={
+                "Authorization": "Bearer tvly-test",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": "What is Hugging Face?",
+                "max_results": 3,
+                "search_depth": "advanced",
+                "chunks_per_source": 2,
+                "topic": "news",
+                "time_range": "week",
+                "start_date": "2025-01-01",
+                "end_date": "2025-12-31",
+                "include_answer": "advanced",
+                "include_raw_content": "markdown",
+                "include_images": True,
+                "include_image_descriptions": True,
+                "include_favicon": True,
+                "include_domains": ["huggingface.co"],
+                "exclude_domains": ["example.com"],
+                "country": "united states",
+                "auto_parameters": True,
+                "exact_match": True,
+                "include_usage": True,
+                "safe_search": True,
+            },
+        )
+        mock_response.raise_for_status.assert_called_once()
+        assert result["query"] == "What is Hugging Face?"
+        assert result["answer"] == "Hugging Face builds open-source AI tooling."
+        assert result["results"][0]["url"] == "https://huggingface.co"
+        assert result["results"][0]["content"] == "Open-source AI models, datasets, and apps."
+
+    @patch("requests.post")
+    def test_forward_handles_empty_results(self, mock_post):
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "query": "No results expected",
+                "answer": "",
+                "images": [],
+                "results": [],
+                "response_time": 0.5,
+            }
+            mock_post.return_value = mock_response
+
+            tool = TavilySearchTool()
+
+            result = tool("No results expected")
+
+        assert result["results"] == []
+
+
+class TestWebSearchToolTavilyEngine:
+    def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            WebSearchTool(engine="tavily")("What is Hugging Face?")
+
+    @patch("requests.post")
+    def test_forward_formats_results(self, mock_post):
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "query": "What is Hugging Face?",
+                "answer": "Hugging Face builds open-source AI tooling.",
+                "images": [],
+                "results": [
+                    {
+                        "title": "Hugging Face",
+                        "url": "https://huggingface.co",
+                        "content": "Open-source AI models, datasets, and apps.",
+                    }
+                ],
+                "response_time": 1.23,
+            }
+            mock_post.return_value = mock_response
+
+            tool = WebSearchTool(
+                engine="tavily",
+                max_results=3,
+                search_depth="advanced",
+                chunks_per_source=2,
+                topic="news",
+                time_range="week",
+                start_date="2025-01-01",
+                end_date="2025-12-31",
+                include_answer="advanced",
+                include_raw_content="markdown",
+                include_images=True,
+                include_image_descriptions=True,
+                include_favicon=True,
+                include_domains=["huggingface.co"],
+                exclude_domains=["example.com"],
+                country="united states",
+                auto_parameters=True,
+                exact_match=True,
+                include_usage=True,
+                safe_search=True,
+            )
+
+            result = tool("What is Hugging Face?")
+
+        mock_post.assert_called_once_with(
+            "https://api.tavily.com/search",
+            headers={
+                "Authorization": "Bearer tvly-test",
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": "What is Hugging Face?",
+                "max_results": 3,
+                "search_depth": "advanced",
+                "chunks_per_source": 2,
+                "topic": "news",
+                "time_range": "week",
+                "start_date": "2025-01-01",
+                "end_date": "2025-12-31",
+                "include_answer": "advanced",
+                "include_raw_content": "markdown",
+                "include_images": True,
+                "include_image_descriptions": True,
+                "include_favicon": True,
+                "include_domains": ["huggingface.co"],
+                "exclude_domains": ["example.com"],
+                "country": "united states",
+                "auto_parameters": True,
+                "exact_match": True,
+                "include_usage": True,
+                "safe_search": True,
+            },
+        )
+        mock_response.raise_for_status.assert_called_once()
+        assert result["query"] == "What is Hugging Face?"
+        assert result["answer"] == "Hugging Face builds open-source AI tooling."
+        assert result["results"][0]["url"] == "https://huggingface.co"
+        assert result["results"][0]["content"] == "Open-source AI models, datasets, and apps."
+
+    @patch("requests.post")
+    def test_forward_handles_empty_results(self, mock_post):
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "query": "No results expected",
+                "answer": "",
+                "images": [],
+                "results": [],
+                "response_time": 0.5,
+            }
+            mock_post.return_value = mock_response
+
+            tool = WebSearchTool(engine="tavily")
+
+            result = tool("No results expected")
+
+        assert result["results"] == []
 
 
 class TestPythonInterpreterTool(ToolTesterMixin):

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -53,25 +53,26 @@ class TestTavilySearchTool:
         with pytest.raises(ValueError, match="TAVILY_API_KEY"):
             TavilySearchTool()
 
-    @patch("requests.post")
-    def test_forward_formats_results(self, mock_post):
-        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "query": "What is Hugging Face?",
-                "answer": "Hugging Face builds open-source AI tooling.",
-                "images": [],
-                "results": [
-                    {
-                        "title": "Hugging Face",
-                        "url": "https://huggingface.co",
-                        "content": "Open-source AI models, datasets, and apps.",
-                    }
-                ],
-                "response_time": 1.23,
-            }
-            mock_post.return_value = mock_response
+    @patch("tavily.TavilyClient")
+    def test_forward_formats_results(self, mock_client_cls):
+        response_payload = {
+            "query": "What is Hugging Face?",
+            "answer": "Hugging Face builds open-source AI tooling.",
+            "images": [],
+            "results": [
+                {
+                    "title": "Hugging Face",
+                    "url": "https://huggingface.co",
+                    "content": "Open-source AI models, datasets, and apps.",
+                }
+            ],
+            "response_time": 1.23,
+        }
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = response_payload
+        mock_client_cls.return_value = mock_instance
 
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
             tool = TavilySearchTool(
                 max_results=3,
                 search_depth="advanced",
@@ -96,54 +97,74 @@ class TestTavilySearchTool:
 
             result = tool("What is Hugging Face?")
 
-        mock_post.assert_called_once_with(
-            "https://api.tavily.com/search",
-            headers={
-                "Authorization": "Bearer tvly-test",
-                "Content-Type": "application/json",
-            },
-            json={
-                "query": "What is Hugging Face?",
-                "max_results": 3,
-                "search_depth": "advanced",
-                "chunks_per_source": 2,
-                "topic": "news",
-                "time_range": "week",
-                "start_date": "2025-01-01",
-                "end_date": "2025-12-31",
-                "include_answer": "advanced",
-                "include_raw_content": "markdown",
-                "include_images": True,
-                "include_image_descriptions": True,
-                "include_favicon": True,
-                "include_domains": ["huggingface.co"],
-                "exclude_domains": ["example.com"],
-                "country": "united states",
-                "auto_parameters": True,
-                "exact_match": True,
-                "include_usage": True,
-                "safe_search": True,
-            },
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="smolagents")
+        mock_instance.search.assert_called_once_with(
+            "What is Hugging Face?",
+            max_results=3,
+            search_depth="advanced",
+            chunks_per_source=2,
+            topic="news",
+            time_range="week",
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            include_answer="advanced",
+            include_raw_content="markdown",
+            include_images=True,
+            include_image_descriptions=True,
+            include_favicon=True,
+            include_domains=["huggingface.co"],
+            exclude_domains=["example.com"],
+            country="united states",
+            auto_parameters=True,
+            exact_match=True,
+            include_usage=True,
+            safe_search=True,
         )
-        mock_response.raise_for_status.assert_called_once()
         assert result["query"] == "What is Hugging Face?"
         assert result["answer"] == "Hugging Face builds open-source AI tooling."
         assert result["results"][0]["url"] == "https://huggingface.co"
         assert result["results"][0]["content"] == "Open-source AI models, datasets, and apps."
 
-    @patch("requests.post")
-    def test_forward_handles_empty_results(self, mock_post):
-        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "query": "No results expected",
-                "answer": "",
-                "images": [],
-                "results": [],
-                "response_time": 0.5,
-            }
-            mock_post.return_value = mock_response
+    @patch("tavily.TavilyClient")
+    def test_client_source_from_argument(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {"query": "q", "results": []}
+        mock_client_cls.return_value = mock_instance
 
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            tool = TavilySearchTool(client_source="my_integration")
+            tool("q")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="my_integration")
+
+    @patch("tavily.TavilyClient")
+    def test_client_source_from_env(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {"query": "q", "results": []}
+        mock_client_cls.return_value = mock_instance
+
+        with patch.dict(
+            "os.environ",
+            {"TAVILY_API_KEY": "tvly-test", "TAVILY_CLIENT_SOURCE": "from_env"},
+        ):
+            tool = TavilySearchTool()
+            tool("q")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="from_env")
+
+    @patch("tavily.TavilyClient")
+    def test_forward_handles_empty_results(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {
+            "query": "No results expected",
+            "answer": "",
+            "images": [],
+            "results": [],
+            "response_time": 0.5,
+        }
+        mock_client_cls.return_value = mock_instance
+
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
             tool = TavilySearchTool()
 
             result = tool("No results expected")
@@ -158,25 +179,25 @@ class TestWebSearchToolTavilyEngine:
         with pytest.raises(ValueError, match="TAVILY_API_KEY"):
             WebSearchTool(engine="tavily")("What is Hugging Face?")
 
-    @patch("requests.post")
-    def test_forward_formats_results(self, mock_post):
-        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "query": "What is Hugging Face?",
-                "answer": "Hugging Face builds open-source AI tooling.",
-                "images": [],
-                "results": [
-                    {
-                        "title": "Hugging Face",
-                        "url": "https://huggingface.co",
-                        "content": "Open-source AI models, datasets, and apps.",
-                    }
-                ],
-                "response_time": 1.23,
-            }
-            mock_post.return_value = mock_response
+    @patch("tavily.TavilyClient")
+    def test_forward_formats_results(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {
+            "query": "What is Hugging Face?",
+            "answer": "Hugging Face builds open-source AI tooling.",
+            "images": [],
+            "results": [
+                {
+                    "title": "Hugging Face",
+                    "url": "https://huggingface.co",
+                    "content": "Open-source AI models, datasets, and apps.",
+                }
+            ],
+            "response_time": 1.23,
+        }
+        mock_client_cls.return_value = mock_instance
 
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
             tool = WebSearchTool(
                 engine="tavily",
                 max_results=3,
@@ -202,54 +223,58 @@ class TestWebSearchToolTavilyEngine:
 
             result = tool("What is Hugging Face?")
 
-        mock_post.assert_called_once_with(
-            "https://api.tavily.com/search",
-            headers={
-                "Authorization": "Bearer tvly-test",
-                "Content-Type": "application/json",
-            },
-            json={
-                "query": "What is Hugging Face?",
-                "max_results": 3,
-                "search_depth": "advanced",
-                "chunks_per_source": 2,
-                "topic": "news",
-                "time_range": "week",
-                "start_date": "2025-01-01",
-                "end_date": "2025-12-31",
-                "include_answer": "advanced",
-                "include_raw_content": "markdown",
-                "include_images": True,
-                "include_image_descriptions": True,
-                "include_favicon": True,
-                "include_domains": ["huggingface.co"],
-                "exclude_domains": ["example.com"],
-                "country": "united states",
-                "auto_parameters": True,
-                "exact_match": True,
-                "include_usage": True,
-                "safe_search": True,
-            },
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="smolagents")
+        mock_instance.search.assert_called_once_with(
+            "What is Hugging Face?",
+            max_results=3,
+            search_depth="advanced",
+            chunks_per_source=2,
+            topic="news",
+            time_range="week",
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            include_answer="advanced",
+            include_raw_content="markdown",
+            include_images=True,
+            include_image_descriptions=True,
+            include_favicon=True,
+            include_domains=["huggingface.co"],
+            exclude_domains=["example.com"],
+            country="united states",
+            auto_parameters=True,
+            exact_match=True,
+            include_usage=True,
+            safe_search=True,
         )
-        mock_response.raise_for_status.assert_called_once()
         assert result["query"] == "What is Hugging Face?"
         assert result["answer"] == "Hugging Face builds open-source AI tooling."
         assert result["results"][0]["url"] == "https://huggingface.co"
         assert result["results"][0]["content"] == "Open-source AI models, datasets, and apps."
 
-    @patch("requests.post")
-    def test_forward_handles_empty_results(self, mock_post):
-        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "query": "No results expected",
-                "answer": "",
-                "images": [],
-                "results": [],
-                "response_time": 0.5,
-            }
-            mock_post.return_value = mock_response
+    @patch("tavily.TavilyClient")
+    def test_client_source_from_argument(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {"query": "q", "results": []}
+        mock_client_cls.return_value = mock_instance
 
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
+            WebSearchTool(engine="tavily", client_source="my_integration")("q")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="my_integration")
+
+    @patch("tavily.TavilyClient")
+    def test_forward_handles_empty_results(self, mock_client_cls):
+        mock_instance = MagicMock()
+        mock_instance.search.return_value = {
+            "query": "No results expected",
+            "answer": "",
+            "images": [],
+            "results": [],
+            "response_time": 0.5,
+        }
+        mock_client_cls.return_value = mock_instance
+
+        with patch.dict("os.environ", {"TAVILY_API_KEY": "tvly-test"}):
             tool = WebSearchTool(engine="tavily")
 
             result = tool("No results expected")

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -7,6 +7,7 @@ from smolagents.default_tools import (
     DuckDuckGoSearchTool,
     GoogleSearchTool,
     SpeechToTextTool,
+    TavilySearchTool,
     VisitWebpageTool,
     WebSearchTool,
 )
@@ -18,7 +19,7 @@ UNDEFINED_VARIABLE = "undefined_variable"
 
 
 @pytest.mark.parametrize(
-    "tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, VisitWebpageTool, WebSearchTool]
+    "tool_class", [DuckDuckGoSearchTool, GoogleSearchTool, SpeechToTextTool, TavilySearchTool, VisitWebpageTool, WebSearchTool]
 )
 def test_validate_tool_attributes_with_default_tools(tool_class):
     assert validate_tool_attributes(tool_class) is None, f"failed for {tool_class.name} tool"


### PR DESCRIPTION
This PR adds support for the Tavily search API.

What changed

Introduces TavilySearchTool, which calls https://api.tavily.com/search and returns Tavily’s JSON object (query, results, optional answer, etc.). Extends WebSearchTool with engine="tavily" on the same endpoint, reusing the same request parameters (depth, include_answer, domains, and other Tavily options). WebSearchTool’s output_type is set to "any" because DuckDuckGo/Bing return markdown strings while Tavily returns a structured object. Exports TavilySearchTool in __all__.
Adds unit tests that mock requests.post (no real API calls, no TAVILY_API_KEY required in CI). Extends test_tool_validation to include TavilySearchTool. Usage

Set TAVILY_API_KEY in the environment.
Either TavilySearchTool() or WebSearchTool(engine="tavily") for the same API; pick one depending on whether you want a dedicated tool or the unified WebSearchTool interface. Testing

pytest for the new Tavily test classes and updated validation test. Locally verified against the live API with TAVILY_API_KEY (optional; not required for CI).