### PR TITLE
Security: sanitize tool outputs to prevent indirect prompt injection

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -92,6 +92,7 @@ from .utils import (
     is_valid_name,
     make_init_file,
     parse_code_blobs,
+    sanitize_tool_output,
     truncate_content,
 )
 
@@ -1398,7 +1399,7 @@ class ToolCallingAgent(MultiStepAgent):
                 self.state[observation_name] = tool_call_result
                 observation = f"Stored '{observation_name}' in memory."
             else:
-                observation = str(tool_call_result).strip()
+                observation = sanitize_tool_output(str(tool_call_result).strip())
             self.logger.log(
                 f"Observations: {observation.replace('[', '|')}",  # escape potential rich-tag-like components
                 level=LogLevel.INFO,
@@ -1731,7 +1732,7 @@ class CodeAgent(MultiStepAgent):
                     Text("Execution logs:", style="bold"),
                     Text(code_output.logs),
                 ]
-            observation = "Execution logs:\n" + code_output.logs
+            observation = "Execution logs:\n" + sanitize_tool_output(code_output.logs)
         except Exception as e:
             if hasattr(self.python_executor, "state") and "_print_outputs" in self.python_executor.state:
                 execution_logs = str(self.python_executor.state["_print_outputs"])
@@ -1740,7 +1741,7 @@ class CodeAgent(MultiStepAgent):
                         Text("Execution logs:", style="bold"),
                         Text(execution_logs),
                     ]
-                    memory_step.observations = "Execution logs:\n" + execution_logs
+                    memory_step.observations = "Execution logs:\n" + sanitize_tool_output(execution_logs)
                     self.logger.log(Group(*execution_outputs_console), level=LogLevel.INFO)
             error_msg = str(e)
             if "Import of " in error_msg and " is not allowed" in error_msg:
@@ -1752,7 +1753,7 @@ class CodeAgent(MultiStepAgent):
 
         truncated_output = truncate_content(str(code_output.output))
         observation += "Last output from code snippet:\n" + truncated_output
-        memory_step.observations = observation
+        memory_step.observations = sanitize_tool_output(observation)
 
         if not code_output.is_final_answer:
             execution_outputs_console += [

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Type
 
 from smolagents.models import ChatMessage, MessageRole, get_dict_from_nested_dataclasses
 from smolagents.monitoring import AgentLogger, LogLevel, Timing, TokenUsage
-from smolagents.utils import AgentError, make_json_serializable
+from smolagents.utils import AgentError, make_json_serializable, sanitize_tool_output
 
 
 if TYPE_CHECKING:
@@ -130,7 +130,7 @@ class ActionStep(MemoryStep):
                     content=[
                         {
                             "type": "text",
-                            "text": f"Observation:\n{self.observations}",
+                            "text": f"Observation:\n{sanitize_tool_output(self.observations)}",
                         }
                     ],
                 )

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -265,6 +265,20 @@ def truncate_content(content: str, max_length: int = MAX_LENGTH_TRUNCATE_CONTENT
         )
 
 
+def sanitize_tool_output(text: str) -> str:
+    """Sanitize tool output to prevent indirect prompt injection by escaping XML-like brackets.
+
+    Args:
+        text: Raw tool output string.
+
+    Returns:
+        Sanitized string with `<` and `>` escaped so they cannot be interpreted as structural tags.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    return text.replace("<", "\\<").replace(">", "\\>")
+
+
 class ImportFinder(ast.NodeVisitor):
     def __init__(self):
         self.packages = set()


### PR DESCRIPTION
Fixes a critical security finding: indirect prompt injection via unsanitized tool outputs.

- Added sanitize_tool_output() helper in utils.py that escapes XML-like brackets
- Applied it at three chokepoints: memory.py, agents.py process_tool_calls(), and agents.py _step_stream()

Tests pass (~60 passed).
