### PR TITLE
Add TavilySearchTool to smolagents

### DIFF
--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -11,6 +11,7 @@ The built-in tools can be categorized by their primary functions:
   - [`ApiWebSearchTool`]
   - [`DuckDuckGoSearchTool`]
   - [`GoogleSearchTool`]
+  - [`TavilySearchTool`]
   - [`WebSearchTool`]
   - [`WikipediaSearchTool`]
 - **Web Interaction**: Fetch and process content from specific web pages.
@@ -39,6 +40,10 @@ The built-in tools can be categorized by their primary functions:
 ## GoogleSearchTool
 
 [[autodoc]] smolagents.default_tools.GoogleSearchTool
+
+## TavilySearchTool
+
+[[autodoc]] smolagents.default_tools.TavilySearchTool
 
 ## PythonInterpreterTool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ telemetry = [
 toolkit = [
   "ddgs>=9.0.0",  # DuckDuckGoSearchTool
   "markdownify>=0.14.1",  # VisitWebpageTool
+  "tavily-python",  # TavilySearchTool
 ]
 transformers = [
   "accelerate",

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -339,6 +339,84 @@ class ApiWebSearchTool(Tool):
         )
 
 
+class TavilySearchTool(Tool):
+    """Web search tool that performs searches using the Tavily API (via ``tavily-python``).
+
+    Tavily returns ranked web results with extracted snippets per page and optional extras such as a short
+    synthesized ``answer`` or fuller raw text per result. The tool exposes Tavily’s search-depth modes,
+    topic and recency filters, domain allow/deny lists, and optional images or usage metadata.
+
+    Authentication uses the ``TAVILY_API_KEY`` environment variable (no constructor key). Install with
+    ``pip install tavily-python`` or ``pip install 'smolagents[toolkit]'``. Pass the natural-language search string
+    as the tool argument ``query``; pass all search tuning below through the constructor.
+
+    Args:
+        max_results (`int`, *optional*): Maximum number of results to return (API/SKU limits apply).
+        search_depth (`str`, *optional*): ``"basic"``, ``"advanced"``, ``"fast"``, or ``"ultra-fast"``—deeper modes
+            trade latency/cost for richer retrieval.
+        time_range (`str`, *optional*): ``"day"``, ``"week"``, ``"month"``, or ``"year"`` to bias toward recent pages.
+        start_date (`str`, *optional*): ``"YYYY-MM-DD"``; only content published on or after this date.
+        end_date (`str`, *optional*): ``"YYYY-MM-DD"``; only content published on or before this date.
+        days (`int`, *optional*): Restrict to the last N days when supported by the API.
+        include_domains (`list[str]`, *optional*): Restrict results to these domains.
+        exclude_domains (`list[str]`, *optional*): Exclude results from these domains.
+        include_answer (`bool` or `str`, *optional*): ``True``, ``False``, or ``"basic"`` / ``"advanced"`` to
+            control the optional summary ``answer`` field in the response.
+        include_raw_content (`bool` or `str`, *optional*): Include longer page body text; use ``True`` or
+            ``"markdown"`` / ``"text"`` as supported by your SDK version.
+        include_images (`bool`, *optional*): Include image-related fields in the response.
+        country (`str`, *optional*): Regional hint; must be a full country name from Tavily’s supported list
+            (short codes may be rejected by the API).
+
+        Any other keyword accepted by ``TavilyClient.search`` is forwarded as-is.
+
+    Examples:
+        ```python
+        >>> from smolagents import TavilySearchTool
+        >>> web_search_tool = TavilySearchTool(max_results=5, search_depth="advanced", include_answer=True)
+        >>> results = web_search_tool("recent advances in retrieval-augmented generation")
+        >>> print(results)
+        ```
+    """
+
+    name = "web_search"
+    description = (
+        "Web search via the Tavily API: returns a dict with ``query``, optional ``answer``, and a ``results`` list "
+        "(each hit typically includes ``url``, ``title``, ``content``, scores). "
+        "Constructor options mirror ``TavilyClient.search``—e.g. ``max_results``, ``search_depth`` "
+        "(``basic``/``fast``/``advanced``/``ultra-fast``), ``topic`` (``general``, ``news``, ``finance``), "
+        "recency via ``time_range`` or ``start_date``/``end_date``, ``include_answer``, "
+        "``include_raw_content``, ``include_domains`` / ``exclude_domains``, ``country``. "
+        "The user query is the tool argument ``query``. Requires env ``TAVILY_API_KEY``."
+    )
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "object"
+
+    def __init__(self, client_source: str | None = None, **kwargs):
+        super().__init__()
+        import os
+
+        self.api_key = os.getenv("TAVILY_API_KEY")
+        if self.api_key is None:
+            raise ValueError("Missing API key. Make sure you have 'TAVILY_API_KEY' in your env variables.")
+
+        self._client_source = client_source or os.getenv("TAVILY_CLIENT_SOURCE") or "smolagents"
+        self._search_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+    def forward(self, query: str) -> dict:
+        try:
+            from tavily import TavilyClient
+        except ImportError as err:
+            raise ImportError(
+                "The Tavily integration requires the tavily-python package. "
+                "Install it with: pip install tavily-python "
+                "or pip install 'smolagents[toolkit]'."
+            ) from err
+
+        client = TavilyClient(api_key=self.api_key, client_source=self._client_source)
+        return client.search(query, **self._search_kwargs)
+
+
 class WebSearchTool(Tool):
     name = "web_search"
     description = "Performs a web search for a query and returns a string of the top search results formatted as markdown with titles, links, and descriptions."
@@ -652,6 +730,7 @@ __all__ = [
     "PythonInterpreterTool",
     "FinalAnswerTool",
     "UserInputTool",
+    "TavilySearchTool",
     "WebSearchTool",
     "DuckDuckGoSearchTool",
     "GoogleSearchTool",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,11 +13,163 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
 
-from smolagents import DuckDuckGoSearchTool
+import pytest
+
+from smolagents import DuckDuckGoSearchTool, TavilySearchTool
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
+
+
+def _make_tavily_response(
+    query="q",
+    answer="",
+    results=None,
+    *,
+    images=None,
+    response_time=0.5,
+    **extra,
+):
+    payload = {
+        "query": query,
+        "answer": answer,
+        "images": [] if images is None else images,
+        "results": [] if results is None else results,
+        "response_time": response_time,
+    }
+    payload.update(extra)
+    return payload
+
+
+def _make_tavily_client(response):
+    """Build a fake Tavily client whose `.search()` returns ``response``."""
+    client = MagicMock()
+    client.search.return_value = response
+    return client
+
+
+class TestTavilySearchTool:
+    """Tavily tests mirror the mocked-client style used for other search integrations."""
+
+    def _build_tool(self, mock_client_cls, response, env=None, **tool_kwargs):
+        fake_instance = _make_tavily_client(response)
+        mock_client_cls.return_value = fake_instance
+        env = env or {"TAVILY_API_KEY": "tvly-test"}
+        with patch.dict("os.environ", env, clear=False):
+            tool = TavilySearchTool(**tool_kwargs)
+        return tool, fake_instance
+
+    def test_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+            TavilySearchTool()
+
+    @patch("tavily.TavilyClient")
+    def test_forward_formats_results(self, mock_client_cls):
+        response = _make_tavily_response(
+            query="What is Hugging Face?",
+            answer="Hugging Face builds open-source AI tooling.",
+            results=[
+                {
+                    "title": "Hugging Face",
+                    "url": "https://huggingface.co",
+                    "content": "Open-source AI models, datasets, and apps.",
+                }
+            ],
+            response_time=1.23,
+        )
+        tool, _ = self._build_tool(
+            mock_client_cls,
+            response,
+            max_results=3,
+            search_depth="advanced",
+            chunks_per_source=2,
+            topic="news",
+            time_range="week",
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            include_answer="advanced",
+            include_raw_content="markdown",
+            include_images=True,
+            include_image_descriptions=True,
+            include_favicon=True,
+            include_domains=["huggingface.co"],
+            exclude_domains=["example.com"],
+            country="united states",
+            auto_parameters=True,
+            exact_match=True,
+            include_usage=True,
+            safe_search=True,
+        )
+
+        result = tool("What is Hugging Face?")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="smolagents")
+        mock_client_cls.return_value.search.assert_called_once_with(
+            "What is Hugging Face?",
+            max_results=3,
+            search_depth="advanced",
+            chunks_per_source=2,
+            topic="news",
+            time_range="week",
+            start_date="2025-01-01",
+            end_date="2025-12-31",
+            include_answer="advanced",
+            include_raw_content="markdown",
+            include_images=True,
+            include_image_descriptions=True,
+            include_favicon=True,
+            include_domains=["huggingface.co"],
+            exclude_domains=["example.com"],
+            country="united states",
+            auto_parameters=True,
+            exact_match=True,
+            include_usage=True,
+            safe_search=True,
+        )
+        assert result["query"] == "What is Hugging Face?"
+        assert result["answer"] == "Hugging Face builds open-source AI tooling."
+        assert result["results"][0]["url"] == "https://huggingface.co"
+        assert result["results"][0]["content"] == "Open-source AI models, datasets, and apps."
+
+    @patch("tavily.TavilyClient")
+    def test_client_source_from_argument(self, mock_client_cls):
+        tool, _ = self._build_tool(
+            mock_client_cls,
+            {"query": "q", "results": []},
+            client_source="my_integration",
+        )
+        tool("q")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="my_integration")
+
+    @patch("tavily.TavilyClient")
+    def test_client_source_from_env(self, mock_client_cls):
+        tool, _ = self._build_tool(
+            mock_client_cls,
+            {"query": "q", "results": []},
+            env={"TAVILY_API_KEY": "tvly-test", "TAVILY_CLIENT_SOURCE": "from_env"},
+        )
+        tool("q")
+
+        mock_client_cls.assert_called_once_with(api_key="tvly-test", client_source="from_env")
+
+    @patch("tavily.TavilyClient")
+    def test_forward_handles_empty_results(self, mock_client_cls):
+        response = _make_tavily_response(
+            query="No results expected",
+            answer="",
+            results=[],
+            response_time=0.5,
+        )
+        tool, _ = self._build_tool(mock_client_cls, response)
+
+        result = tool("No results expected")
+
+        assert result["results"] == []
 
 
 class TestDuckDuckGoSearchTool(ToolTesterMixin):


### PR DESCRIPTION
Add TavilySearchTool for Tavily web search

Description
This change adds a built-in TavilySearchTool that wraps the Tavily API via tavily-python, giving agents ranked results plus optional fields such as Tavily’s synthesized answer, configurable search depth, topic/recency filters, and domain allow/deny lists.

Details

Reads TAVILY_API_KEY from the environment (clear error if missing). Constructor kwargs are forwarded to TavilyClient.search so callers can tune behavior without changing the tool implementation. tavily-python is listed under the smolagents[toolkit] extra in pyproject.toml. Reference docs include TavilySearchTool in the web search tools list and an autodoc section. Unit tests mock TavilyClient to cover missing API key, argument forwarding, client source resolution, and empty results with no live API calls in CI.