### PR TITLE
fix: block Windows os.system alias

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -147,6 +147,7 @@ DANGEROUS_FUNCTIONS = [
     "builtins.globals",
     "builtins.locals",
     "builtins.__import__",
+    "nt.system",
     "os.popen",
     "os.system",
     "posix.system",

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -33,6 +33,7 @@ from smolagents.local_python_executor import (
     LocalPythonExecutor,
     PrintContainer,
     check_import_authorized,
+    check_safer_result,
     evaluate_boolop,
     evaluate_condition,
     evaluate_delete,
@@ -2533,6 +2534,14 @@ class TestLocalPythonExecutorSecurity:
             error_match = f".*Forbidden access to function: {dangerous_function_name}.*"
         with pytest.raises(InterpreterError, match=error_match):
             executor(f"import {dangerous_module_name}; {dangerous_function}")
+
+    def test_vulnerability_windows_nt_system_alias(self):
+        def system():
+            pass
+
+        system.__module__ = "nt"
+        with pytest.raises(InterpreterError, match="Forbidden access to function: system"):
+            check_safer_result(system)
 
     @pytest.mark.parametrize(
         "additional_authorized_imports, expected_error",


### PR DESCRIPTION
Fixes #2232

## Summary
- block the Windows `nt.system` implementation behind `os.system` in the local Python executor safety denylist
- add a platform-independent regression test that simulates the `nt.system` alias returned on Windows

## Tests
- `uv run --extra test pytest tests/test_local_python_executor.py -k "dangerous_functions or nt_system_alias"`
- `uv run --no-dev --with ruff ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py`
