### PR TITLE
fix: block os.system on Windows executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -147,6 +147,7 @@ DANGEROUS_FUNCTIONS = [
     "builtins.globals",
     "builtins.locals",
     "builtins.__import__",
+    "nt.system",
     "os.popen",
     "os.system",
     "posix.system",


### PR DESCRIPTION
## Summary
- Add `nt.system` to `DANGEROUS_FUNCTIONS` so `os.system` is blocked on Windows
- Reuse the existing dangerous-function parametrized test coverage

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_local_python_executor.py -k dangerous_functions`
- `python3 -m ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py`

Fixes #2232