### PR TITLE
fix: yield max steps action once in stream

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -604,8 +604,9 @@ You have been provided with these additional arguments, that you can access dire
                 self.step_number += 1
 
         if not returned_final_answer and self.step_number == max_steps + 1:
-            final_answer = self._handle_max_steps_reached(task)
-            yield action_step
+            max_steps_step = self._handle_max_steps_reached(task)
+            final_answer = max_steps_step.action_output
+            yield max_steps_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step
@@ -622,7 +623,7 @@ You have been provided with these additional arguments, that you can access dire
             memory_step.timing.end_time = time.time()
         self.step_callbacks.callback(memory_step, agent=self)
 
-    def _handle_max_steps_reached(self, task: str) -> Any:
+    def _handle_max_steps_reached(self, task: str) -> ActionStep:
         action_step_start_time = time.time()
         final_answer = self.provide_final_answer(task)
         final_memory_step = ActionStep(
@@ -634,7 +635,7 @@ You have been provided with these additional arguments, that you can access dire
         final_memory_step.action_output = final_answer.content
         self._finalize_step(final_memory_step)
         self.memory.steps.append(final_memory_step)
-        return final_answer.content
+        return final_memory_step
 
     def _generate_planning_step(
         self, task, is_first_step: bool, step: int

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -519,6 +519,35 @@ class TestAgent:
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
+    def test_stream_yields_max_steps_action_once(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=1,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+        action_steps = [step for step in steps if isinstance(step, ActionStep)]
+
+        assert [step.step_number for step in action_steps] == [1, 2]
+        assert type(action_steps[-1].error) is AgentMaxStepsError
+        assert isinstance(steps[-1], FinalAnswerStep)
+
+    def test_stream_handles_zero_max_steps(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=0,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+        action_steps = [step for step in steps if isinstance(step, ActionStep)]
+
+        assert len(action_steps) == 1
+        assert action_steps[0].step_number == 1
+        assert type(action_steps[0].error) is AgentMaxStepsError
+        assert isinstance(steps[-1], FinalAnswerStep)
+
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"


### PR DESCRIPTION
## Summary
- Yield the max-steps `ActionStep` created by `_handle_max_steps_reached` instead of re-yielding the previous action step
- Avoid the undefined `action_step` path when streaming with `max_steps=0`
- Add regression coverage for duplicate stream action steps and zero max steps

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_agents.py -k "stream_yields_max_steps_action_once or stream_handles_zero_max_steps"`
- `PYTHONPATH=src python3 -m pytest tests/test_agents.py -k "fails_max_steps or step_number or stream_yields_max_steps_action_once or stream_handles_zero_max_steps"`
- `python3 -m ruff check src/smolagents/agents.py tests/test_agents.py`

Fixes #1816