### PR TITLE
fix: preserve managed agent dict config

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1594,6 +1594,44 @@ class TestMultiStepAgent:
         assert recreated_managed_agent.description == "A managed agent for testing"
         assert recreated_managed_agent.max_steps == 5
 
+    def test_from_dict_kwargs_do_not_override_managed_agents(self):
+        managed_agent = CodeAgent(
+            tools=[],
+            model=MagicMock(),
+            name="pytest_agent",
+            description="A managed agent with custom imports",
+            max_steps=5,
+            additional_authorized_imports=["pytest"],
+        )
+        main_agent = CodeAgent(
+            tools=[],
+            managed_agents=[managed_agent],
+            model=MagicMock(),
+            name="main_agent",
+            description="Main agent with managed agents",
+            max_steps=10,
+        )
+        agent_dict = main_agent.to_dict()
+
+        mock_model_class = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_model_class.from_dict.return_value = mock_model_instance
+
+        with patch.dict("smolagents.models.MODEL_REGISTRY", {"MagicMock": mock_model_class}):
+            recreated_agent = CodeAgent.from_dict(
+                agent_dict,
+                max_steps=30,
+                additional_authorized_imports=["numpy"],
+            )
+
+        recreated_managed_agent = recreated_agent.managed_agents["pytest_agent"]
+
+        assert recreated_agent.max_steps == 30
+        assert "numpy" in recreated_agent.authorized_imports
+        assert recreated_managed_agent.max_steps == 5
+        assert "pytest" in recreated_managed_agent.authorized_imports
+        assert "numpy" not in recreated_managed_agent.authorized_imports
+
     def test_from_dict_invalid_model_class(self):
         """Test that from_dict raises ValueError with helpful message for invalid model class."""
         agent_dict = {


### PR DESCRIPTION
## Summary
- Stop passing parent `from_dict` override kwargs into managed agent deserialization
- Preserve managed agent-specific settings such as `max_steps` and authorized imports during roundtrip restore
- Add regression coverage showing parent overrides still apply to the parent but not to the managed agent

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_agents.py -k "multiagent_to_dict_from_dict_roundtrip or from_dict_kwargs_do_not_override_managed_agents"`
- `PYTHONPATH=src python3 -m pytest tests/test_agents.py -k from_dict`
- `python3 -m ruff check src/smolagents/agents.py tests/test_agents.py`

Fixes #1849