### PR TITLE
feat(tools): Add PerplexitySearchTool

### DIFF
--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -62,14 +62,14 @@ That's it! Your agent will use Python code to solve the task and return the resu
 
 ### Adding Tools
 
-Let's make our agent more capable by adding some tools:
+Let's make our agent more capable by adding some tools. When `PERPLEXITY_API_KEY` is set, [`PerplexitySearchTool`] is the recommended web search tool — it returns LLM-ready snippets from a single ranked index. Otherwise, fall back to [`DuckDuckGoSearchTool`].
 
 ```python
-from smolagents import CodeAgent, InferenceClientModel, DuckDuckGoSearchTool
+from smolagents import CodeAgent, InferenceClientModel, PerplexitySearchTool
 
 model = InferenceClientModel()
 agent = CodeAgent(
-    tools=[DuckDuckGoSearchTool()],
+    tools=[PerplexitySearchTool()],  # requires PERPLEXITY_API_KEY
     model=model,
 )
 

--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -11,6 +11,7 @@ The built-in tools can be categorized by their primary functions:
   - [`ApiWebSearchTool`]
   - [`DuckDuckGoSearchTool`]
   - [`GoogleSearchTool`]
+  - [`PerplexitySearchTool`]
   - [`WebSearchTool`]
   - [`WikipediaSearchTool`]
 - **Web Interaction**: Fetch and process content from specific web pages.
@@ -39,6 +40,10 @@ The built-in tools can be categorized by their primary functions:
 ## GoogleSearchTool
 
 [[autodoc]] smolagents.default_tools.GoogleSearchTool
+
+## PerplexitySearchTool
+
+[[autodoc]] smolagents.default_tools.PerplexitySearchTool
 
 ## PythonInterpreterTool
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -606,6 +606,141 @@ class WikipediaSearchTool(Tool):
             return f"Error fetching Wikipedia summary: {str(e)}"
 
 
+class PerplexitySearchTool(Tool):
+    """Web search tool that uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+    Returns ranked web search results for a query via `POST https://api.perplexity.ai/search`.
+    Authenticates via the `PERPLEXITY_API_KEY` environment variable (or `PPLX_API_KEY` as a fallback).
+    Supports Perplexity's domain and date/recency filters.
+
+    Args:
+        max_results (`int`, default `5`): Maximum number of results to return per query.
+        search_domain_filter (`list[str]`, *optional*): Restrict results to specific domains.
+            Use a leading `-` on a domain to exclude it (e.g. `["nytimes.com"]` or `["-pinterest.com"]`).
+            Allow and deny entries cannot be mixed.
+        search_recency_filter (`str`, *optional*): One of `"hour"`, `"day"`, `"week"`, `"month"`, `"year"`.
+        search_after_date_filter (`str`, *optional*): Only include pages published on or after this date,
+            formatted as `m/d/yyyy`.
+        search_before_date_filter (`str`, *optional*): Only include pages published on or before this date,
+            formatted as `m/d/yyyy`.
+        max_tokens_per_page (`int`, *optional*): Maximum tokens of context returned per result page.
+        endpoint (`str`, *optional*): Override the search endpoint URL.
+        api_key (`str`, *optional*): Perplexity API key. Falls back to `PERPLEXITY_API_KEY`,
+            then `PPLX_API_KEY` from the environment.
+
+    Examples:
+        ```python
+        >>> from smolagents import PerplexitySearchTool
+        >>> tool = PerplexitySearchTool(max_results=5, search_recency_filter="week")
+        >>> print(tool("latest open-source LLM releases"))
+        ```
+    """
+
+    name = "perplexity_search"
+    description = (
+        "Performs a web search via the Perplexity Search API for a query and returns the top results "
+        "as markdown with titles, URLs, and snippets."
+    )
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "string"
+
+    _ALLOWED_RECENCY = {"hour", "day", "week", "month", "year"}
+    _DEFAULT_ENDPOINT = "https://api.perplexity.ai/search"
+
+    def __init__(
+        self,
+        max_results: int = 5,
+        search_domain_filter: list[str] | None = None,
+        search_recency_filter: str | None = None,
+        search_after_date_filter: str | None = None,
+        search_before_date_filter: str | None = None,
+        max_tokens_per_page: int | None = None,
+        endpoint: str | None = None,
+        api_key: str | None = None,
+    ):
+        super().__init__()
+        import os
+
+        api_key = api_key or os.getenv("PERPLEXITY_API_KEY") or os.getenv("PPLX_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Missing API key. Set 'PERPLEXITY_API_KEY' (or 'PPLX_API_KEY') in your env variables "
+                "or pass `api_key`."
+            )
+
+        if search_recency_filter is not None and search_recency_filter not in self._ALLOWED_RECENCY:
+            raise ValueError(
+                f"Invalid `search_recency_filter` '{search_recency_filter}'. "
+                f"Choose one of {sorted(self._ALLOWED_RECENCY)}."
+            )
+
+        if search_domain_filter:
+            has_allow = any(not d.startswith("-") for d in search_domain_filter)
+            has_deny = any(d.startswith("-") for d in search_domain_filter)
+            if has_allow and has_deny:
+                raise ValueError(
+                    "`search_domain_filter` cannot mix allowlist and denylist entries. "
+                    "Use only positive domains or only `-domain.com` entries."
+                )
+
+        self.api_key = api_key
+        self.endpoint = endpoint or self._DEFAULT_ENDPOINT
+        self.max_results = max_results
+        self.search_domain_filter = search_domain_filter
+        self.search_recency_filter = search_recency_filter
+        self.search_after_date_filter = search_after_date_filter
+        self.search_before_date_filter = search_before_date_filter
+        self.max_tokens_per_page = max_tokens_per_page
+
+    def _build_payload(self, query: str) -> dict:
+        payload: dict = {"query": query, "max_results": self.max_results}
+        if self.search_domain_filter is not None:
+            payload["search_domain_filter"] = self.search_domain_filter
+        if self.search_recency_filter is not None:
+            payload["search_recency_filter"] = self.search_recency_filter
+        if self.search_after_date_filter is not None:
+            payload["search_after_date_filter"] = self.search_after_date_filter
+        if self.search_before_date_filter is not None:
+            payload["search_before_date_filter"] = self.search_before_date_filter
+        if self.max_tokens_per_page is not None:
+            payload["max_tokens_per_page"] = self.max_tokens_per_page
+        return payload
+
+    def forward(self, query: str) -> str:
+        import requests
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        response = requests.post(self.endpoint, headers=headers, json=self._build_payload(query))
+        response.raise_for_status()
+        data = response.json()
+        results = data.get("results") or []
+        if not results:
+            return f"No results found for '{query}'. Try a less restrictive query."
+        return self._format_results(results)
+
+    @staticmethod
+    def _format_results(results: list[dict]) -> str:
+        lines = []
+        for idx, result in enumerate(results, start=1):
+            title = result.get("title") or "Untitled"
+            url = result.get("url", "")
+            line = f"{idx}. [{title}]({url})"
+
+            date = result.get("date")
+            if date:
+                line += f"\nPublished: {date}"
+
+            snippet = result.get("snippet")
+            if snippet:
+                line += f"\n{snippet}"
+
+            lines.append(line)
+        return "## Search Results\n\n" + "\n\n".join(lines)
+
+
 class SpeechToTextTool(PipelineTool):
     default_checkpoint = "openai/whisper-large-v3-turbo"
     description = "This is a tool that transcribes an audio into text. It returns the transcribed text."
@@ -655,6 +790,7 @@ __all__ = [
     "WebSearchTool",
     "DuckDuckGoSearchTool",
     "GoogleSearchTool",
+    "PerplexitySearchTool",
     "VisitWebpageTool",
     "WikipediaSearchTool",
     "SpeechToTextTool",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 
-from smolagents import DuckDuckGoSearchTool
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smolagents import DuckDuckGoSearchTool, PerplexitySearchTool
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
@@ -33,3 +37,125 @@ class TestDuckDuckGoSearchTool(ToolTesterMixin):
     @require_run_all
     def test_agent_type_output(self):
         super().test_agent_type_output()
+
+
+def _mock_post(payload):
+    """Build a MagicMock that mimics `requests.post(...).json()` returning the given payload."""
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    post = MagicMock(return_value=response)
+    return post, response
+
+
+class TestPerplexitySearchTool:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        monkeypatch.delenv("PPLX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="PERPLEXITY_API_KEY"):
+            PerplexitySearchTool()
+
+    def test_pplx_api_key_fallback(self, monkeypatch):
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        monkeypatch.setenv("PPLX_API_KEY", "fallback-key")
+        tool = PerplexitySearchTool()
+        assert tool.api_key == "fallback-key"
+
+    def test_invalid_recency_filter_raises(self):
+        with pytest.raises(ValueError, match="Invalid `search_recency_filter`"):
+            PerplexitySearchTool(api_key="test-key", search_recency_filter="bogus")
+
+    def test_mixed_domain_filter_raises(self):
+        with pytest.raises(ValueError, match="cannot mix allowlist and denylist"):
+            PerplexitySearchTool(api_key="test-key", search_domain_filter=["nytimes.com", "-pinterest.com"])
+
+    def test_no_results_returns_empty_message(self):
+        tool = PerplexitySearchTool(api_key="test-key")
+        post, _ = _mock_post({"results": []})
+        with patch("requests.post", post):
+            out = tool("anything")
+        assert "No results found" in out
+
+    def test_formats_results(self):
+        tool = PerplexitySearchTool(api_key="test-key")
+        payload = {
+            "results": [
+                {
+                    "title": "First",
+                    "url": "https://a.example/",
+                    "snippet": "alpha snippet",
+                    "date": "2026-04-01",
+                },
+                {"title": "Second", "url": "https://b.example/", "snippet": "beta snippet"},
+            ]
+        }
+        post, _ = _mock_post(payload)
+        with patch("requests.post", post):
+            out = tool("hello")
+        assert "## Search Results" in out
+        assert "1. [First](https://a.example/)" in out
+        assert "Published: 2026-04-01" in out
+        assert "alpha snippet" in out
+        assert "2. [Second](https://b.example/)" in out
+        assert "beta snippet" in out
+
+    def test_request_authorization_header(self):
+        tool = PerplexitySearchTool(api_key="secret")
+        post, _ = _mock_post({"results": []})
+        with patch("requests.post", post):
+            tool("hello")
+        kwargs = post.call_args.kwargs
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+
+    def test_filter_passthrough(self):
+        tool = PerplexitySearchTool(
+            api_key="test-key",
+            max_results=3,
+            search_domain_filter=["nytimes.com"],
+            search_recency_filter="week",
+            search_after_date_filter="1/1/2026",
+            search_before_date_filter="12/31/2026",
+            max_tokens_per_page=512,
+        )
+        post, _ = _mock_post({"results": []})
+        with patch("requests.post", post):
+            tool("hello")
+        body = post.call_args.kwargs["json"]
+        assert body == {
+            "query": "hello",
+            "max_results": 3,
+            "search_domain_filter": ["nytimes.com"],
+            "search_recency_filter": "week",
+            "search_after_date_filter": "1/1/2026",
+            "search_before_date_filter": "12/31/2026",
+            "max_tokens_per_page": 512,
+        }
+
+    def test_omits_unset_filters(self):
+        tool = PerplexitySearchTool(api_key="test-key")
+        post, _ = _mock_post({"results": []})
+        with patch("requests.post", post):
+            tool("hello")
+        body = post.call_args.kwargs["json"]
+        assert set(body) == {"query", "max_results"}
+        assert body["query"] == "hello"
+        assert body["max_results"] == 5
+
+    def test_endpoint_default_and_override(self):
+        default_tool = PerplexitySearchTool(api_key="test-key")
+        assert default_tool.endpoint == "https://api.perplexity.ai/search"
+
+        custom_tool = PerplexitySearchTool(api_key="test-key", endpoint="https://example.com/search")
+        post, _ = _mock_post({"results": []})
+        with patch("requests.post", post):
+            custom_tool("hello")
+        assert post.call_args.args[0] == "https://example.com/search"
+
+    def test_raise_for_status_propagates_errors(self):
+        tool = PerplexitySearchTool(api_key="test-key")
+        response = MagicMock()
+        response.raise_for_status.side_effect = RuntimeError("boom")
+        with patch("requests.post", return_value=response):
+            with pytest.raises(RuntimeError, match="boom"):
+                tool("hello")


### PR DESCRIPTION
## Summary

Adds a built-in `PerplexitySearchTool` that wraps the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) (`POST https://api.perplexity.ai/search`), returning ranked web search results. The tool follows the existing provider patterns in `default_tools.py` (`ApiWebSearchTool`, `GoogleSearchTool`, `ExaSearchTool`, etc.) and exposes the Search API's filtering features:

- `max_results` (default 5)
- `search_domain_filter` — allow or deny lists (use `-domain.com` for negation; allow/deny cannot be mixed)
- `search_recency_filter` — `hour` / `day` / `week` / `month` / `year`
- `search_after_date_filter`, `search_before_date_filter` — `m/d/yyyy` cutoffs
- `max_tokens_per_page`

Authentication uses `PERPLEXITY_API_KEY` (falling back to `PPLX_API_KEY`) or an explicit `api_key` argument. No new third-party dependency — uses `requests` (already a transitive dep), matching `ApiWebSearchTool`.


## Usage

```python
from smolagents import CodeAgent, InferenceClientModel, PerplexitySearchTool

agent = CodeAgent(
    tools=[PerplexitySearchTool(max_results=5, search_recency_filter="week")],
    model=InferenceClientModel(),
)
agent.run("latest open-source LLM releases")
```

## Files changed

- `src/smolagents/default_tools.py` — new `PerplexitySearchTool` class; added to `__all__`
- `docs/source/en/reference/default_tools.md` — register the tool in the reference page
- `tests/test_search.py` — unit tests for API-key resolution, filter validation, request shape, and result formatting (mocks `requests.post`; no live API calls)

No `pyproject.toml` changes — `requests` is already available transitively.

## Test plan

- [x] `ruff check src/smolagents/default_tools.py tests/test_search.py` passes
- [x] `ruff format --check` passes for changed Python files
- [x] `pytest tests/test_search.py -k Perplexity` — all 11 new `TestPerplexitySearchTool` tests pass
- [ ] CI to confirm on the project's full matrix