### PR TITLE
fix: include tool return descriptions in prompts

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -275,7 +275,7 @@ def _parse_google_format_docstring(
     # Clean and store the sections
     description = description_match.group(1).strip() if description_match else None
     docstring_args = args_match.group(1).strip() if args_match else None
-    returns = returns_match.group(1).strip() if returns_match else None
+    returns = re.sub(r"\s*\n+\s*", " ", returns_match.group(1).strip()) if returns_match else None
 
     # Parsing the arguments into a dictionary
     if docstring_args is not None:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -119,6 +119,8 @@ class Tool(BaseTool):
       description for your tool.
     - **output_type** (`type`) -- The type of the tool output. This is used by `launch_gradio_demo`
       or to make a nice space from your tool, and also can be used in the generated description for your tool.
+    - **output_description** (`str`, *optional*) -- A natural-language description of the tool output. This is
+      included in generated prompts when provided, for example from the `Returns:` block of an `@tool` docstring.
     - **output_schema** (`Dict[str, Any]`, *optional*) -- The JSON schema defining the expected structure of the tool output.
       This can be included in system prompts to help agents understand the expected output format. Note: This is currently
       used for informational purposes only and does not perform actual output validation.
@@ -132,6 +134,7 @@ class Tool(BaseTool):
     description: str
     inputs: dict[str, dict[str, str | type | bool]]
     output_type: str
+    output_description: str | None = None
     output_schema: dict[str, Any] | None = None
 
     def __init__(self, *args, **kwargs):
@@ -162,6 +165,11 @@ class Tool(BaseTool):
         output_schema = getattr(self, "output_schema", None)
         if output_schema is not None and not isinstance(output_schema, dict):
             raise TypeError(f"Attribute output_schema should have type dict, got {type(output_schema)} instead.")
+        output_description = getattr(self, "output_description", None)
+        if output_description is not None and not isinstance(output_description, str):
+            raise TypeError(
+                f"Attribute output_description should have type str, got {type(output_description)} instead."
+            )
 
         # - Validate name
         if not is_valid_name(self.name):
@@ -280,14 +288,23 @@ class Tool(BaseTool):
         if has_schema:
             formatted_schema = json.dumps(self.output_schema, indent=4)
             indented_schema = textwrap.indent(formatted_schema, "        ")
-            returns_doc = f"\nReturns:\n    dict (structured output): This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:\n{indented_schema}"
+            output_description = getattr(self, "output_description", None)
+            output_description = f"{output_description} " if output_description else ""
+            returns_doc = f"\nReturns:\n    dict (structured output): {output_description}This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:\n{indented_schema}"
+            tool_doc += f"\n{returns_doc}"
+        elif output_description := getattr(self, "output_description", None):
+            returns_doc = f"\nReturns:\n    {self.output_type}: {output_description}"
             tool_doc += f"\n{returns_doc}"
 
         tool_doc = f'"""{tool_doc}\n"""'
         return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"
 
     def to_tool_calling_prompt(self) -> str:
-        return f"{self.name}: {self.description}\n    Takes inputs: {self.inputs}\n    Returns an output of type: {self.output_type}"
+        output_description = getattr(self, "output_description", None)
+        returns_prompt = f"Returns an output of type: {self.output_type}"
+        if output_description:
+            returns_prompt += f": {output_description}"
+        return f"{self.name}: {self.description}\n    Takes inputs: {self.inputs}\n    {returns_prompt}"
 
     def to_dict(self) -> dict:
         """Returns a dictionary representing the tool"""
@@ -318,9 +335,12 @@ class Tool(BaseTool):
             """
             ).strip()
 
+            if getattr(self, "output_description", None):
+                tool_code += f"\n    output_description = {json.dumps(self.output_description)}"
+
             # Add output_schema if it exists
             if hasattr(self, "output_schema") and self.output_schema is not None:
-                tool_code += f"\n                output_schema = {repr(self.output_schema)}"
+                tool_code += f"\n    output_schema = {repr(self.output_schema)}"
             import re
 
             def add_self_argument(source_code: str) -> str:
@@ -361,6 +381,8 @@ class Tool(BaseTool):
         # Add output_schema if it exists
         if hasattr(self, "output_schema") and self.output_schema is not None:
             tool_dict["output_schema"] = self.output_schema
+        if getattr(self, "output_description", None):
+            tool_dict["output_description"] = self.output_description
 
         return tool_dict
 
@@ -384,6 +406,8 @@ class Tool(BaseTool):
         # Set output_schema if it exists in the dictionary
         if "output_schema" in tool_dict:
             tool.output_schema = tool_dict["output_schema"]
+        if "output_description" in tool_dict:
+            tool.output_description = tool_dict["output_description"]
 
         return tool
 
@@ -1086,6 +1110,7 @@ def tool(tool_function: Callable) -> Tool:
     SimpleTool.description = tool_json_schema["description"]
     SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
     SimpleTool.output_type = tool_json_schema["return"]["type"]
+    SimpleTool.output_description = tool_json_schema["return"].get("description")
 
     # Set output_schema if it exists in the JSON schema
     if "output_schema" in tool_json_schema:
@@ -1152,6 +1177,7 @@ def tool(tool_function: Callable) -> Tool:
             description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
             inputs: dict[str, dict[str, str]] = {tool_json_schema["parameters"]["properties"]}
             output_type: str = "{tool_json_schema["return"]["type"]}"
+            output_description: str | None = {json.dumps(tool_json_schema["return"].get("description"))}
 
             def __init__(self):
                 self.is_initialized = True

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -187,6 +187,39 @@ class TestTool:
 
         assert coolfunc.output_type == "number"
 
+    def test_tool_decorator_preserves_returns_description(self):
+        @tool
+        def summarize(text: str) -> str:
+            """Summarize text.
+
+            Args:
+                text: Text to summarize.
+
+            Returns:
+                A concise summary with the main claims and caveats.
+            """
+            return text
+
+        assert summarize.output_description == "A concise summary with the main claims and caveats."
+        assert summarize.to_code_prompt() == (
+            "def summarize(text: string) -> string:\n"
+            '    """Summarize text.\n\n'
+            "    Args:\n"
+            "        text: Text to summarize.\n\n"
+            "    Returns:\n"
+            "        string: A concise summary with the main claims and caveats.\n"
+            '    """'
+        )
+        assert summarize.to_tool_calling_prompt() == (
+            "summarize: Summarize text.\n"
+            "    Takes inputs: {'text': {'type': 'string', 'description': 'Text to summarize.'}}\n"
+            "    Returns an output of type: string: A concise summary with the main claims and caveats."
+        )
+
+        roundtripped = Tool.from_dict(summarize.to_dict())
+        assert roundtripped.output_description == summarize.output_description
+        assert roundtripped.to_tool_calling_prompt() == summarize.to_tool_calling_prompt()
+
     def test_tool_init_vanilla(self):
         class HFModelDownloadsTool(Tool):
             name = "model_download_counter"


### PR DESCRIPTION
## Summary

Fixes #1511.

`@tool` already parsed the Google-style `Returns:` block into the generated JSON schema, but the description was dropped when constructing the `Tool` prompt surfaces. This carries that description onto `Tool.output_description`, includes it in both `to_code_prompt()` and `to_tool_calling_prompt()`, and preserves it through `to_dict()` / `from_dict()` roundtrips.

I also normalized multiline return descriptions the same way argument descriptions are normalized, so prompt output stays single-line when docstrings wrap text.

## Validation

- PYTHONPATH=src uv run --python /opt/homebrew/bin/python3.12 --with pytest --with pytest-datadir --with requests --with rich --with jinja2 --with pillow --with huggingface-hub --with numpy --with mcp --with mcpadapt python -m pytest tests/test_tools.py -k "returns_description or tool_to_code_prompt_output_format or tool_to_tool_calling_prompt_output_format or from_dict_roundtrip"
- uv run --python /opt/homebrew/bin/python3.12 --with ruff ruff check src/smolagents/_function_type_hints_utils.py src/smolagents/tools.py tests/test_tools.py
- uv run --python /opt/homebrew/bin/python3.12 --with ruff ruff format --check src/smolagents/_function_type_hints_utils.py src/smolagents/tools.py tests/test_tools.py
