### PR TITLE
fix: make managed agent memory reset configurable

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -284,6 +284,7 @@ class MultiStepAgent(ABC):
         name (`str`, *optional*): Necessary for a managed agent only - the name by which this agent can be called.
         description (`str`, *optional*): Necessary for a managed agent only - the description of this agent.
         provide_run_summary (`bool`, *optional*): Whether to provide a run summary when called as a managed agent.
+        reset_on_managed_call (`bool`, default `True`): Whether to reset this agent's memory when it is called as a managed agent.
         final_answer_checks (`list[Callable]`, *optional*): List of validation functions to run before accepting a final answer.
             Each function should:
             - Take the final answer, the agent's memory, and the agent itself as arguments.
@@ -306,6 +307,7 @@ class MultiStepAgent(ABC):
         name: str | None = None,
         description: str | None = None,
         provide_run_summary: bool = False,
+        reset_on_managed_call: bool = True,
         final_answer_checks: list[Callable] | None = None,
         return_full_result: bool = False,
         logger: AgentLogger | None = None,
@@ -332,6 +334,7 @@ class MultiStepAgent(ABC):
         self.name = self._validate_name(name)
         self.description = description
         self.provide_run_summary = provide_run_summary
+        self.reset_on_managed_call = reset_on_managed_call
         self.final_answer_checks = final_answer_checks if final_answer_checks is not None else []
         self.return_full_result = return_full_result
         self.instructions = instructions
@@ -873,6 +876,7 @@ You have been provided with these additional arguments, that you can access dire
             self.prompt_templates["managed_agent"]["task"],
             variables=dict(name=self.name, task=task),
         )
+        kwargs.setdefault("reset", self.reset_on_managed_call)
         result = self.run(full_task, **kwargs)
         if isinstance(result, RunResult):
             report = result.output
@@ -1003,6 +1007,7 @@ You have been provided with these additional arguments, that you can access dire
             "planning_interval": self.planning_interval,
             "name": self.name,
             "description": self.description,
+            "reset_on_managed_call": self.reset_on_managed_call,
             "requirements": sorted(requirements),
         }
         return agent_dict
@@ -1053,6 +1058,7 @@ You have been provided with these additional arguments, that you can access dire
             "planning_interval": agent_dict.get("planning_interval"),
             "name": agent_dict.get("name"),
             "description": agent_dict.get("description"),
+            "reset_on_managed_call": agent_dict.get("reset_on_managed_call"),
         }
         # Filter out None values to use defaults from __init__
         agent_args = {k: v for k, v in agent_args.items() if v is not None}

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1547,7 +1547,12 @@ class TestMultiStepAgent:
         """Test that to_dict() and from_dict() work correctly for agents with managed agents."""
         # Create a managed agent
         managed_agent = CodeAgent(
-            tools=[], model=MagicMock(), name="managed_agent", description="A managed agent for testing", max_steps=5
+            tools=[],
+            model=MagicMock(),
+            name="managed_agent",
+            description="A managed agent for testing",
+            max_steps=5,
+            reset_on_managed_call=False,
         )
 
         # Create a main agent with the managed agent
@@ -1573,6 +1578,7 @@ class TestMultiStepAgent:
         assert managed_agent_dict["class"] == "CodeAgent"
         assert managed_agent_dict["description"] == "A managed agent for testing"
         assert managed_agent_dict["max_steps"] == 5
+        assert managed_agent_dict["reset_on_managed_call"] is False
 
         # Test round-trip: from_dict should recreate the agent
         # Mock the model class for the test
@@ -1593,6 +1599,7 @@ class TestMultiStepAgent:
         assert recreated_managed_agent.name == "managed_agent"
         assert recreated_managed_agent.description == "A managed agent for testing"
         assert recreated_managed_agent.max_steps == 5
+        assert recreated_managed_agent.reset_on_managed_call is False
 
     def test_from_dict_invalid_model_class(self):
         """Test that from_dict raises ValueError with helpful message for invalid model class."""
@@ -2119,6 +2126,33 @@ class TestCodeAgent:
                 "<summary_of_work>\n\nTest summary\n---\n</summary_of_work>"
             )
         assert result == expected_summary
+
+    @pytest.mark.parametrize(
+        ("reset_on_managed_call", "expected_reset"),
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_call_uses_reset_on_managed_call(self, reset_on_managed_call, expected_reset):
+        agent = CodeAgent(tools=[], model=MagicMock(), reset_on_managed_call=reset_on_managed_call)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Test output")
+
+        agent("Test request")
+
+        _, kwargs = agent.run.call_args
+        assert kwargs["reset"] is expected_reset
+
+    def test_call_allows_explicit_reset_override(self):
+        agent = CodeAgent(tools=[], model=MagicMock(), reset_on_managed_call=False)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Test output")
+
+        agent("Test request", reset=True)
+
+        _, kwargs = agent.run.call_args
+        assert kwargs["reset"] is True
 
     def test_code_agent_image_output(self):
         from PIL import Image


### PR DESCRIPTION
## Summary
- add an opt-in `reset_on_managed_call` setting for agents used as managed agents
- preserve the current default behavior by keeping the setting `True` unless users opt out
- pass the setting through `__call__` only when the caller did not explicitly provide `reset`
- persist the setting through `to_dict`/`from_dict`

Fixes #1695.

## Validation
- `PYTHONPATH=src uv run --python /opt/homebrew/bin/python3.12 --with pytest --with pytest-datadir --with requests --with rich --with jinja2 --with pillow --with huggingface-hub --with numpy --with mcp --with mcpadapt python -m pytest tests/test_agents.py -k "reset_on_managed_call or explicit_reset_override or multiagent_to_dict_from_dict_roundtrip or call_with_provide_run_summary"`
- `uv run --python /opt/homebrew/bin/python3.12 --with ruff ruff check src/smolagents/agents.py tests/test_agents.py`
- `uv run --python /opt/homebrew/bin/python3.12 --with ruff ruff format --check src/smolagents/agents.py tests/test_agents.py`