### PR TITLE
Add inner_tool_calls to ActionStep for CodeAgent tool tracking

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1722,6 +1722,30 @@ class CodeAgent(MultiStepAgent):
         memory_step.tool_calls = [tool_call]
 
         ### Execute action ###
+        inner_tool_calls: list[ToolCall] = []
+        original_static_tools: dict[str, Callable] = {}
+        agent_tool_names = set(self.tools.keys()) | set(self.managed_agents.keys())
+
+        if hasattr(self.python_executor, "static_tools") and self.python_executor.static_tools:
+            for tool_name in agent_tool_names & set(self.python_executor.static_tools.keys()):
+                original_tool = self.python_executor.static_tools[tool_name]
+                original_static_tools[tool_name] = original_tool
+
+                def make_tool_call_wrapper(name: str, tool: Callable) -> Callable:
+                    def tool_call_wrapper(*args, **kwargs):
+                        inner_tool_calls.append(
+                            ToolCall(
+                                name=name,
+                                arguments=kwargs if kwargs else (args[0] if len(args) == 1 else list(args)),
+                                id=f"call_{len(self.memory.steps)}_{len(inner_tool_calls)}",
+                            )
+                        )
+                        return tool(*args, **kwargs)
+
+                    return tool_call_wrapper
+
+                self.python_executor.static_tools[tool_name] = make_tool_call_wrapper(tool_name, original_tool)
+
         self.logger.log_code(title="Executing parsed code:", content=code_action, level=LogLevel.INFO)
         try:
             code_output = self.python_executor(code_action)
@@ -1749,6 +1773,11 @@ class CodeAgent(MultiStepAgent):
                     level=LogLevel.INFO,
                 )
             raise AgentExecutionError(error_msg, self.logger)
+        finally:
+            for tool_name, original_tool in original_static_tools.items():
+                self.python_executor.static_tools[tool_name] = original_tool
+            if inner_tool_calls:
+                memory_step.inner_tool_calls = inner_tool_calls
 
         truncated_output = truncate_content(str(code_output.output))
         observation += "Last output from code snippet:\n" + truncated_output

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -53,6 +53,7 @@ class ActionStep(MemoryStep):
     timing: Timing
     model_input_messages: list[ChatMessage] | None = None
     tool_calls: list[ToolCall] | None = None
+    inner_tool_calls: list[ToolCall] | None = None
     error: AgentError | None = None
     model_output_message: ChatMessage | None = None
     model_output: str | list[dict[str, Any]] | None = None
@@ -74,6 +75,7 @@ class ActionStep(MemoryStep):
             if self.model_input_messages
             else None,
             "tool_calls": [tc.dict() for tc in self.tool_calls] if self.tool_calls else [],
+            "inner_tool_calls": [tc.dict() for tc in self.inner_tool_calls] if self.inner_tool_calls else [],
             "error": self.error.dict() if self.error else None,
             "model_output_message": make_json_serializable(get_dict_from_nested_dataclasses(self.model_output_message))
             if self.model_output_message

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -232,6 +232,31 @@ final_answer(7.2904)
             )
 
 
+class FakeCodeModelCallsTool(Model):
+    def generate(self, messages, stop_sequences=None):
+        prompt = str(messages)
+        if "fake_db_result" not in prompt:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="""
+Thought: I should query the database tool.
+<code>
+fake_db_result = fake_db_tool(query="SELECT 1")
+</code>
+""",
+            )
+        else:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="""
+Thought: I can now answer with the tool result.
+<code>
+final_answer(fake_db_result)
+</code>
+""",
+            )
+
+
 class FakeCodeModelImageGeneration(Model):
     def generate(self, messages, stop_sequences=None):
         prompt = str(messages)
@@ -472,6 +497,51 @@ class TestAgent:
         assert agent.memory.steps[2].tool_calls == [
             ToolCall(name="python_interpreter", arguments="final_answer(7.2904)", id="call_2")
         ]
+
+    def test_code_agent_inner_tool_calls_populated(self):
+        @tool
+        def fake_db_tool(query: str) -> str:
+            """
+            Run a fake database query.
+
+            Args:
+                query: SQL query to execute.
+            """
+            return "result"
+
+        agent = CodeAgent(tools=[fake_db_tool], model=FakeCodeModelCallsTool())
+        output = agent.run("Query the database.")
+
+        assert output == "result"
+        assert agent.memory.steps[1].inner_tool_calls == [
+            ToolCall(name="fake_db_tool", arguments={"query": "SELECT 1"}, id="call_1_0")
+        ]
+        assert agent.memory.steps[1].tool_calls[0].name == "python_interpreter"
+
+    def test_code_agent_inner_tool_calls_in_get_full_steps(self):
+        @tool
+        def fake_db_tool(query: str) -> str:
+            """
+            Run a fake database query.
+
+            Args:
+                query: SQL query to execute.
+            """
+            return "result"
+
+        agent = CodeAgent(tools=[fake_db_tool], model=FakeCodeModelCallsTool())
+        agent.run("Query the database.")
+
+        first_action_step = agent.memory.get_full_steps()[1]
+        assert "inner_tool_calls" in first_action_step
+        assert first_action_step["inner_tool_calls"][0]["function"]["name"] == "fake_db_tool"
+        assert first_action_step["inner_tool_calls"][0]["function"]["arguments"] == {"query": "SELECT 1"}
+
+    def test_code_agent_no_tool_call_leaves_inner_tool_calls_none(self):
+        agent = CodeAgent(tools=[], model=FakeCodeModel())
+        agent.run("What is 2 multiplied by 3.6452?")
+
+        assert agent.memory.steps[1].inner_tool_calls is None
 
     def test_additional_args_added_to_task(self):
         agent = CodeAgent(tools=[], model=FakeCodeModel())

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -83,6 +83,9 @@ def test_action_step_dict():
         },
     }
 
+    assert "inner_tool_calls" in action_step_dict
+    assert action_step_dict["inner_tool_calls"] == []
+
     assert "timing" in action_step_dict
     assert action_step_dict["timing"] == {"start_time": 0.0, "end_time": 1.0, "duration": 1.0}
 


### PR DESCRIPTION
Closes #1724                                                                                                                                         
                                                                                                                                                       
  ## What changed                                                                                                                                      
  Added a new `inner_tool_calls: list[ToolCall] | None = None` field to `ActionStep`.                                                                  
  When `CodeAgent` executes a code step, each agent tool in the executor's `static_tools`                                                              
  dict is temporarily wrapped to intercept and record individual tool invocations as                                                                   
  `ToolCall` objects. The wrappers are restored in a `finally` block, and the collected                                                                
  calls are assigned to `memory_step.inner_tool_calls` after execution completes.                                                                      
                                                                                                                                                       
  ## Why                                                                                                                                               
  `CodeAgent` routes all tool use through generated Python code, so                                                                                    
  `agent.memory.get_full_steps()` only exposes a single synthetic `python_interpreter`                                                                 
  ToolCall containing the entire code blob — the actual tool names and kwargs are invisible                                                            
  at the memory layer. This makes it impossible to inspect or test which tools were called
  and with what arguments without monkey-patching.                                                                                                     
                                                                                                                                                       
  The existing `tool_calls` field is left unchanged for backward compatibility.
  `inner_tool_calls` is a net-new field that contains structured `{name, arguments}` records                                                           
  for each tool invoked during the step. It is `None` for steps where no agent tools were called.   