### PR TITLE
fix(models): use .get() for tool_calls in AmazonBedrockModel to avoid KeyError on text-only responses

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -601,6 +601,33 @@ class TestAmazonBedrockModel:
 
         assert model.client == MockBoto3.return_value
 
+    def test_generate_text_only_response_no_tool_calls_key(self):
+        # Bedrock's converse API omits "tool_calls" from message when the model
+        # returns plain text. This should not raise a KeyError (#1941).
+        model_id = "us.amazon.nova-pro-v1:0"
+        bedrock_response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "Hello, how can I help?"}],
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 8},
+        }
+
+        mock_boto3 = MagicMock()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.converse.return_value = bedrock_response
+
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            model = AmazonBedrockModel(model_id=model_id)
+            message = model.generate([{"role": "user", "content": "Hi"}])
+
+        assert message.content == "Hello, how can I help?"
+        assert message.tool_calls is None
+
 
 class TestAzureOpenAIModel:
     def test_client_kwargs_passed_correctly(self):


### PR DESCRIPTION
## Summary

`AmazonBedrockModel.generate()` raises `KeyError: 'tool_calls'` whenever the
Bedrock `converse` API returns a plain-text response (i.e. `stopReason` is
`end_turn` rather than `tool_use`). The Bedrock converse response dict does not
include a `tool_calls` key unless the model made a native tool call; the
previous code accessed `response["output"]["message"]["tool_calls"]` directly,
which crashes on every non-tool-call turn.

Fix: replace the direct dict access with `.get("tool_calls")`.
`ChatMessage.__post_init__` already handles `tool_calls=None` correctly (early
return), so no further changes are needed.

## Issue

Closes #1941

## Local verification

```
=== LOCAL_TEST_PASSED ===

$ cd /tmp/smola-fix
$ PYTHONPATH=/tmp/smola-fix/src python -m pytest \
    tests/test_models.py::TestAmazonBedrockModel::test_generate_text_only_response_no_tool_calls_key \
    -v
============================== test session starts ==============================
collected 1 item

tests/test_models.py::TestAmazonBedrockModel::test_generate_text_only_response_no_tool_calls_key PASSED

============================== 1 passed in 0.06s ===============================
```

## Risk

**Low.** Single-character change (`.get()` vs `[]`). The only observable
difference is that `ChatMessage.tool_calls` is now `None` instead of raising
`KeyError` when Bedrock returns a text-only response — which is the correct
behaviour and matches how all other model backends handle a missing
`tool_calls` field.
