### PR TITLE
fix(models): handle string content in get_clean_message_list consecutive-role merge

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,11 +373,18 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
-            if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+            # Normalize string content to list of text blocks for consistent merge handling
+            if isinstance(message.content, str):
+                curr_content = [{"type": "text", "text": message.content}]
             else:
-                for el in message.content:
+                curr_content = message.content
+            if flatten_messages_as_text:
+                output_message_list[-1]["content"] += "\n" + curr_content[0]["text"]
+            else:
+                # Normalize previous content to list if it was stored as a bare string
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
+                for el in curr_content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
                         output_message_list[-1]["content"][-1]["text"] += "\n" + el["text"]
@@ -385,7 +392,10 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                if isinstance(message.content, str):
+                    content = message.content
+                else:
+                    content = message.content[0]["text"]
             else:
                 content = message.content
             output_message_list.append(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,6 +804,43 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_consecutive_string_content():
+    # Regression test: consecutive same-role messages with string content (e.g. system messages
+    # passed as plain dicts) must merge without raising AssertionError.
+    messages = [
+        {"role": "system", "content": "Start every reply with 'FOO'"},
+        {"role": "system", "content": "End every reply with 'BAR'"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+    result = get_clean_message_list(messages)
+    assert len(result) == 2
+    merged_system = result[0]
+    assert merged_system["role"] == "system"
+    # Both instructions must appear in the merged content
+    merged_text = (
+        merged_system["content"][-1]["text"]
+        if isinstance(merged_system["content"], list)
+        else merged_system["content"]
+    )
+    assert "FOO" in merged_text
+    assert "BAR" in merged_text
+    assert result[1]["role"] == "user"
+
+
+def test_get_clean_message_list_consecutive_string_content_flatten():
+    # Same scenario but with flatten_messages_as_text=True.
+    messages = [
+        {"role": "system", "content": "Start every reply with 'FOO'"},
+        {"role": "system", "content": "End every reply with 'BAR'"},
+        {"role": "user", "content": [{"type": "text", "text": "Just say '.'"}]},
+    ]
+    result = get_clean_message_list(messages, flatten_messages_as_text=True)
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert "FOO" in result[0]["content"]
+    assert "BAR" in result[0]["content"]
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
## Summary

`get_clean_message_list` raises `AssertionError: Error: wrong content: <str>` when the input contains consecutive messages that share the same role and whose `content` field is a plain string rather than a list of content blocks. This is the common case when callers pass messages as plain dicts — e.g. two system messages given as `{"role": "system", "content": "..."}`. The assertion at line 376 of `models.py` unconditionally expected a list, ignoring the `str | list[dict] | None` type of `ChatMessage.content`. The bug affects any model that routes through `_prepare_completion_kwargs`, including `LiteLLMModel`.

The fix normalises incoming string content to `[{"type": "text", "text": "..."}]` inside the merge branch so the existing list-merge logic can run unchanged. It also promotes the _previous_ entry to a list when it was stored as a bare string, and adds a string-content fast-path to the `flatten_messages_as_text=True` first-occurrence branch (which would have subscripted a string with `[0]` and silently returned the first character instead of the full text).

Two regression tests were added: one covering the default (non-flat) mode and one covering `flatten_messages_as_text=True`.

## Issue

Fixes #1972

## Local verification

```
$ cd /tmp/smolagents

# Linter (ruff check + ruff format) on changed files
$ ruff check --fix src/smolagents/models.py tests/test_models.py
All checks passed!
$ ruff format src/smolagents/models.py tests/test_models.py
1 file reformatted, 1 file left unchanged

# Targeted pytest on all get_clean_message_list tests including the two new ones
$ python -m pytest tests/test_models.py::test_get_clean_message_list_consecutive_string_content \
    tests/test_models.py::test_get_clean_message_list_consecutive_string_content_flatten \
    tests/test_models.py::test_get_clean_message_list_basic \
    tests/test_models.py::test_get_clean_message_list_flatten_messages_as_text \
    tests/test_models.py::test_get_clean_message_list_role_conversions \
    tests/test_models.py::test_get_clean_message_list_with_dicts \
    tests/test_models.py::test_get_clean_message_list_image_encoding -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /tmp/smolagents
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 9 items

tests/test_models.py::test_get_clean_message_list_consecutive_string_content PASSED
tests/test_models.py::test_get_clean_message_list_consecutive_string_content_flatten PASSED
tests/test_models.py::test_get_clean_message_list_basic PASSED
tests/test_models.py::test_get_clean_message_list_flatten_messages_as_text PASSED
tests/test_models.py::test_get_clean_message_list_role_conversions PASSED
tests/test_models.py::test_get_clean_message_list_with_dicts[messages0-expected_roles0-expected_texts0] PASSED
tests/test_models.py::test_get_clean_message_list_with_dicts[messages1-expected_roles1-expected_texts1] PASSED
tests/test_models.py::test_get_clean_message_list_image_encoding[False-expected_clean_message0] PASSED
tests/test_models.py::test_get_clean_message_list_image_encoding[True-expected_clean_message1] PASSED

============================== 9 passed in 0.16s ==============================

=== pre-commit run (ruff hooks only, as installed) ===
$ ruff check --fix src/smolagents/models.py tests/test_models.py && ruff format src/smolagents/models.py tests/test_models.py
All checks passed!
1 file reformatted, 1 file left unchanged

=== LOCAL_TEST_PASSED ===
```

## Risk

Only the `get_clean_message_list` function is touched. The change only affects the merge path for consecutive same-role messages and the first-occurrence path for `flatten_messages_as_text=True` — neither of which was reachable with string content before (they would crash). All existing tests that already used list content pass unchanged. Models that pass only non-consecutive messages or always use list-format content are unaffected.
