### PR TITLE
Fix TransformersModel to forward from_pretrained kwargs (#969)

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -910,6 +910,20 @@ class TransformersModel(Model):
         torch_dtype: str | None = None,
         trust_remote_code: bool = False,
         model_kwargs: dict[str, Any] | None = None,
+        token: str | bool | None = None,
+        revision: str = "main",
+        cache_dir: str | None = None,
+        force_download: bool = False,
+        local_files_only: bool = False,
+        subfolder: str = "",
+        quantization_config: Any | None = None,
+        attn_implementation: str | None = None,
+        max_memory: dict | None = None,
+        offload_folder: str | None = None,
+        offload_buffers: bool = False,
+        variant: str | None = None,
+        gguf_file: str | None = None,
+        ignore_mismatched_sizes: bool = False,
         max_new_tokens: int = 4096,
         max_tokens: int | None = None,
         apply_chat_template_kwargs: dict[str, Any] | None = None,
@@ -946,15 +960,50 @@ class TransformersModel(Model):
         self._is_vlm = False
         self.model_kwargs = model_kwargs or {}
         self.apply_chat_template_kwargs = apply_chat_template_kwargs or {}
+
+        shared_kwargs = {}
+        if token is not None:
+            shared_kwargs["token"] = token
+        if revision != "main":
+            shared_kwargs["revision"] = revision
+        if cache_dir is not None:
+            shared_kwargs["cache_dir"] = cache_dir
+        if force_download:
+            shared_kwargs["force_download"] = force_download
+        if local_files_only:
+            shared_kwargs["local_files_only"] = local_files_only
+        if subfolder:
+            shared_kwargs["subfolder"] = subfolder
+
+        model_only_kwargs = {**shared_kwargs, **self.model_kwargs}
+        if quantization_config is not None:
+            model_only_kwargs["quantization_config"] = quantization_config
+        if attn_implementation is not None:
+            model_only_kwargs["attn_implementation"] = attn_implementation
+        if max_memory is not None:
+            model_only_kwargs["max_memory"] = max_memory
+        if offload_folder is not None:
+            model_only_kwargs["offload_folder"] = offload_folder
+        if offload_buffers:
+            model_only_kwargs["offload_buffers"] = offload_buffers
+        if variant is not None:
+            model_only_kwargs["variant"] = variant
+        if gguf_file is not None:
+            model_only_kwargs["gguf_file"] = gguf_file
+        if ignore_mismatched_sizes:
+            model_only_kwargs["ignore_mismatched_sizes"] = ignore_mismatched_sizes
+
         try:
             self.model = AutoModelForImageTextToText.from_pretrained(
                 model_id,
                 device_map=device_map,
                 torch_dtype=torch_dtype,
                 trust_remote_code=trust_remote_code,
-                **self.model_kwargs,
+                **model_only_kwargs,
             )
-            self.processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+            self.processor = AutoProcessor.from_pretrained(
+                model_id, trust_remote_code=trust_remote_code, **shared_kwargs
+            )
             self._is_vlm = True
             self.streamer = TextIteratorStreamer(self.processor.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore
 
@@ -965,9 +1014,11 @@ class TransformersModel(Model):
                     device_map=device_map,
                     torch_dtype=torch_dtype,
                     trust_remote_code=trust_remote_code,
-                    **self.model_kwargs,
+                    **model_only_kwargs,
                 )
-                self.tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+                self.tokenizer = AutoTokenizer.from_pretrained(
+                    model_id, trust_remote_code=trust_remote_code, **shared_kwargs
+                )
                 self.streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)  # type: ignore
             else:
                 raise e

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -681,6 +681,88 @@ class TestTransformersModel:
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.args == ("test-model",)
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
 
+    @pytest.mark.parametrize(
+        "patching",
+        [
+            [
+                (
+                    "transformers.AutoModelForImageTextToText.from_pretrained",
+                    {"side_effect": ValueError("Unrecognized configuration class")},
+                ),
+                ("transformers.AutoModelForCausalLM.from_pretrained", {}),
+                ("transformers.AutoTokenizer.from_pretrained", {}),
+            ],
+            [
+                ("transformers.AutoModelForImageTextToText.from_pretrained", {}),
+                ("transformers.AutoProcessor.from_pretrained", {}),
+            ],
+        ],
+    )
+    def test_init_forwards_kwargs(self, patching):
+        with ExitStack() as stack:
+            mocks = {target: stack.enter_context(patch(target, **kwargs)) for target, kwargs in patching}
+            TransformersModel(
+                model_id="test-model",
+                device_map="cpu",
+                torch_dtype="float16",
+                trust_remote_code=True,
+                token="hf_test_token",
+                revision="feature-branch",
+                cache_dir="/tmp/cache",
+                force_download=True,
+                local_files_only=True,
+                subfolder="models",
+                quantization_config={"load_in_4bit": True},
+                attn_implementation="flash_attention_2",
+                max_memory={0: "2GiB"},
+                offload_folder="/tmp/offload",
+                offload_buffers=True,
+                variant="fp16",
+                gguf_file="model.gguf",
+                ignore_mismatched_sizes=True,
+            )
+            shared_kwargs = {
+                "token": "hf_test_token",
+                "revision": "feature-branch",
+                "cache_dir": "/tmp/cache",
+                "force_download": True,
+                "local_files_only": True,
+                "subfolder": "models",
+            }
+            model_only_kwargs = {
+                **shared_kwargs,
+                "quantization_config": {"load_in_4bit": True},
+                "attn_implementation": "flash_attention_2",
+                "max_memory": {0: "2GiB"},
+                "offload_folder": "/tmp/offload",
+                "offload_buffers": True,
+                "variant": "fp16",
+                "gguf_file": "model.gguf",
+                "ignore_mismatched_sizes": True,
+            }
+            if "transformers.AutoTokenizer.from_pretrained" in mocks:
+                assert mocks["transformers.AutoModelForCausalLM.from_pretrained"].call_args.kwargs == {
+                    "device_map": "cpu",
+                    "torch_dtype": "float16",
+                    "trust_remote_code": True,
+                    **model_only_kwargs,
+                }
+                assert mocks["transformers.AutoTokenizer.from_pretrained"].call_args.kwargs == {
+                    "trust_remote_code": True,
+                    **shared_kwargs,
+                }
+            elif "transformers.AutoProcessor.from_pretrained" in mocks:
+                assert mocks["transformers.AutoModelForImageTextToText.from_pretrained"].call_args.kwargs == {
+                    "device_map": "cpu",
+                    "torch_dtype": "float16",
+                    "trust_remote_code": True,
+                    **model_only_kwargs,
+                }
+                assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {
+                    "trust_remote_code": True,
+                    **shared_kwargs,
+                }
+
 
 def test_get_clean_message_list_basic():
     messages = [


### PR DESCRIPTION
Fixes #969

### Description
This PR adds 14 commonly-used `from_pretrained` parameters as explicit keyword arguments to `TransformersModel.__init__`. 

### Motivation
Previously, `AutoTokenizer.from_pretrained` and `AutoProcessor.from_pretrained` received none of these beyond `trust_remote_code`. This caused issues when using private models (requiring `token`) or specific versions (requiring `revision`).

### Key Changes
- **Shared parameters** (forwarded to model, tokenizer, and processor): `token`, `revision`, `cache_dir`, `force_download`, `local_files_only`, `subfolder`.
- **Model-only parameters**: `quantization_config`, `attn_implementation`, `max_memory`, `offload_folder`, `offload_buffers`, `variant`, `gguf_file`, `ignore_mismatched_sizes`.
- Updated all four `from_pretrained` call sites in `src/smolagents/models.py`.

### Usage Example
```python
model = TransformersModel(
    model_id="meta-llama/Llama-3-8B-Instruct",
    device_map="auto",
    quantization_config=BitsAndBytesConfig(load_in_4bit=True),
    attn_implementation="flash_attention_2",
    token="hf_...",
)
```

### Changes
* `src/smolagents/models.py` — extended `__init__` signature + built `shared_kwargs`/`model_only_kwargs` dicts + updated all 4 `from_pretrained` call sites
* `tests/test_models.py` — added `test_init_forwards_kwargs` covering both VLM and CausalLM code paths

