### PR TITLE
fix: handle Pydantic model objects in get_dict_from_nested_dataclasses

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -71,6 +71,12 @@ def get_dict_from_nested_dataclasses(obj, ignore_key=None):
     def convert(obj):
         if hasattr(obj, "__dataclass_fields__"):
             return {k: convert(v) for k, v in asdict(obj).items() if k != ignore_key}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        if isinstance(obj, list):
+            return [convert(item) for item in obj]
+        if isinstance(obj, dict):
+            return {k: convert(v) for k, v in obj.items()}
         return obj
 
     return convert(obj)


### PR DESCRIPTION
## Summary

Fixes #1929

`get_dict_from_nested_dataclasses` only recursed into dataclass instances (via `asdict()`), leaving Pydantic `BaseModel` objects untouched in the output. When `ChatMessage.model_dump_json()` later calls `json.dumps`, these objects raise:

```
TypeError: Object of type ChatCompletionMessageFunctionToolCall is not JSON serializable
```

This affects users running `OpenAIModel` with OpenAI-compatible endpoints (e.g. doubao, deepseek-v3) and Langfuse/OpenInference instrumentation, which calls `model_dump_json()` on output messages.

### Root cause

The `convert()` function inside `get_dict_from_nested_dataclasses` checked `hasattr(obj, "__dataclass_fields__")` but did not handle:
- Pydantic `BaseModel` objects (which have `model_dump()`)
- Lists or dicts containing such objects

### Fix

Add fallback handling in `convert()` for:
1. Objects with `model_dump()` method (Pydantic v2 models) — call `model_dump()` to convert to dict
2. Lists — recurse into each element
3. Dicts — recurse into values

## Test plan

- [x] Normal `ChatMessage` with string tool call arguments serializes correctly
- [x] `ChatMessage` with Pydantic model objects nested in tool call arguments serializes correctly
- [x] `raw` field is still excluded when `ignore_key="raw"` is used
- [x] Existing test suite passes (22/22 relevant tests, 1 skip due to missing optional dep)