### PR TITLE
Add ChainAnchorCallback helper for verifiable agent step receipts

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -18,6 +18,8 @@
     title: 🛡️ Secure code execution
   - local: tutorials/memory
     title: 📚 Manage your agent's memory
+  - local: tutorials/verifiable_receipts
+    title: 🧾 Verifiable receipts (chain-anchor/v1)
 - title: Conceptual guides
   sections:
   - local: conceptual_guides/intro_agents

--- a/docs/source/en/tutorials/verifiable_receipts.md
+++ b/docs/source/en/tutorials/verifiable_receipts.md
@@ -1,0 +1,152 @@
+# Verifiable receipts via `ChainAnchorCallback`
+
+[[open-in-colab]]
+
+> [!TIP]
+> If you're new to smolagents, start with the [intro to agents](../conceptual_guides/intro_agents) and the [guided tour](../guided_tour).
+
+## Why anchor agent runs?
+
+In regulated or cross-organization deployments, agent runs sometimes need an audit trail that doesn't depend on the operator's word, the operator's logs, or the operator's continued operation. The agent did *something* — for compliance, dispute resolution, or simple accountability, a third party may need to verify, weeks or years later, *what the agent committed to* at a given point in time.
+
+A common shape for this is to compute a hash over each step, build a merkle root over the run, and commit that root somewhere durable: a public chain, an RFC 3161 trusted timestamping authority, or a notary service. The receipt sidecar travels with the run; a verifier with just the sidecar and one external lookup can reconstruct what the agent did.
+
+smolagents already exposes a [`step_callbacks`](../reference/agents#smolagents.MultiStepAgent.step_callbacks) hook on every agent. The [`ChainAnchorCallback`] is a small utility that snaps into that hook and emits a [`chain-anchor/v1`](https://proof.satsignal.cloud/spec-chain-anchor) sidecar for each run.
+
+smolagents takes no network dependency itself. The anchor backend — Satsignal, RFC 3161, your own notary — is a function you supply.
+
+## Quick start
+
+```python
+from smolagents import (
+    CodeAgent, InferenceClientModel,
+    ActionStep, FinalAnswerStep, ChainAnchorCallback,
+)
+from smolagents.memory import PlanningStep
+
+def my_anchor_fn(root_hex: str) -> dict:
+    # Plug in any backend conforming to chain-anchor/v1.
+    # This stub just records the root locally; replace with
+    # your real POST to Satsignal / RFC 3161 TSA / etc.
+    return {
+        "v": 1, "system": "my-service", "chain": "bsv-mainnet",
+        "txid": "<from your anchor backend>",
+        "root_hash": root_hex,
+    }
+
+cb = ChainAnchorCallback(
+    anchor_fn=my_anchor_fn,
+    out_dir="./receipts",
+)
+
+agent = CodeAgent(
+    tools=[],
+    model=InferenceClientModel(),
+    step_callbacks={
+        ActionStep: cb,
+        FinalAnswerStep: cb,
+        PlanningStep: cb,  # optional; only fires if the agent plans
+    },
+)
+agent.run("What's 2 + 2?")
+# → ./receipts/run-<uuid>.chain-anchor.json
+```
+
+The callback is registered against multiple step types so it sees both the body of the run (`ActionStep`) and the end (`FinalAnswerStep`, when the merkle root is computed and the anchor backend is called).
+
+## What the sidecar looks like
+
+```json
+{
+  "version": "chain-anchor-v1-sidecar",
+  "run_id": "0e7d…",
+  "started_at_epoch": 1778611200.0,
+  "finished_at_epoch": 1778611207.4,
+  "leaf_count": 4,
+  "leaf_hashing": "leaf = sha256(JCS({label, sha256_hex}))",
+  "tree": "satsignal merkle row, dup-last-when-odd",
+  "merkle_root_hex": "686c620b9b0e7219bf943bf31f8ffa3be2b23fc21384aef4ae63a163ff3ebfb7",
+  "items": [
+    {"index": 0, "label": "action-step-1", "sha256_hex": "..."},
+    {"index": 1, "label": "action-step-2", "sha256_hex": "..."},
+    {"index": 2, "label": "action-step-3", "sha256_hex": "..."},
+    {"index": 3, "label": "final-answer",  "sha256_hex": "..."}
+  ],
+  "chain_anchor": {
+    "v": 1, "system": "my-service", "chain": "bsv-mainnet",
+    "txid": "...", "root_hash": "686c620b..."
+  },
+  "anchor_error": null
+}
+```
+
+A verifier with just this file plus one explorer lookup can:
+
+1. Re-hash each step independently (smolagents step dicts canonicalize deterministically via the same JCS rule).
+2. Walk the merkle root over the per-step leaves.
+3. Confirm the resulting root equals `merkle_root_hex` *and* equals the `root_hash` committed on chain.
+
+## Pluggable backends
+
+The `anchor_fn` is a single function with signature `(root_hex: str) -> dict | None`. Anything that returns a dict conforming to [chain-anchor/v1](https://proof.satsignal.cloud/spec-chain-anchor) — at minimum `v`, `system`, `chain`, `txid`, `root_hash` — slots in. Two common shapes:
+
+### Satsignal (BSV public-chain anchor)
+
+```python
+import requests
+
+def satsignal_anchor(root_hex: str) -> dict:
+    r = requests.post(
+        "https://app.satsignal.cloud/api/v1/anchors",
+        headers={"Authorization": f"Bearer {os.environ['SATSIGNAL_API_KEY']}"},
+        json={
+            "matter_slug": "agent-runs",
+            "category": "commitment",
+            "sha256_hex": root_hex,
+        },
+    )
+    r.raise_for_status()
+    a = r.json()
+    return {
+        "v": 1, "system": "satsignal", "chain": "bsv-mainnet",
+        "txid": a["txid"], "root_hash": root_hex,
+        "anchor_id": a["bundle_id"],
+    }
+```
+
+### Local RFC 3161 / TSA path
+
+```python
+import base64, requests
+
+def tsa_anchor(root_hex: str) -> dict:
+    # Submit the root to an RFC 3161 TSA, return the token along with
+    # a chain-anchor-shaped envelope that points at the TSA instead.
+    # Example uses freetsa.org for demonstration.
+    tsq = build_rfc3161_request(bytes.fromhex(root_hex))
+    r = requests.post(
+        "https://freetsa.org/tsr",
+        headers={"Content-Type": "application/timestamp-query"},
+        data=tsq,
+    )
+    return {
+        "v": 1, "system": "rfc3161", "chain": "tsa:freetsa.org",
+        "txid": "tsa:" + hashlib.sha256(r.content).hexdigest(),
+        "root_hash": root_hex,
+        "_tsa_token_b64": base64.b64encode(r.content).decode(),
+    }
+```
+
+If your `anchor_fn` raises, the callback records the error in `anchor_error` instead of crashing the run. Local hashes still get the sidecar so you can backfill.
+
+## Including planning steps
+
+By default, planning steps are excluded from the leaves (they tend to be verbose and don't carry actions). To include them:
+
+```python
+cb = ChainAnchorCallback(anchor_fn=..., include_planning=True)
+```
+
+## Reproducible roots
+
+The callback canonicalizes each step's `.dict()` representation via [RFC 8785 JSON Canonicalization Scheme](https://datatracker.ietf.org/doc/html/rfc8785) (sorted keys, no whitespace, UTF-8, no `NaN`/`Infinity`), then sha256s it. Two runs that produce *byte-identical* step contents produce the same root. Two runs with different timings or different LLM outputs do not — which is what you want; the receipt commits to the run that actually happened.

--- a/src/smolagents/__init__.py
+++ b/src/smolagents/__init__.py
@@ -18,6 +18,7 @@ __version__ = "1.25.0.dev0"
 
 from .agent_types import *  # noqa: I001
 from .agents import *  # Above noqa avoids a circular dependency due to cli.py
+from .chain_anchor import *
 from .default_tools import *
 from .gradio_ui import *
 from .local_python_executor import *

--- a/src/smolagents/chain_anchor.py
+++ b/src/smolagents/chain_anchor.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verifiable-receipt callback that anchors a batch of step hashes to any
+third-party anchor backend conforming to ``chain-anchor-v1``.
+
+Plug-and-play with :class:`MultiStepAgent` via the ``step_callbacks``
+argument. smolagents takes no network dependency; the anchor backend
+(BSV, RFC 3161 TSA, local timestamp service, anything) is supplied by
+the caller as ``anchor_fn``.
+
+Format reference: https://proof.satsignal.cloud/spec-chain-anchor
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from typing import Any, Callable
+
+from smolagents.memory import (
+    ActionStep,
+    FinalAnswerStep,
+    MemoryStep,
+    PlanningStep,
+)
+
+
+__all__ = ["ChainAnchorCallback"]
+
+
+def _jcs(obj: Any) -> bytes:
+    """RFC 8785-ish JSON Canonicalization Scheme — sorted keys, no
+    whitespace, UTF-8, no NaN/Infinity. Sufficient for the
+    sha256-of-canonical-bytes pattern used by chain-anchor-v1."""
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=str,
+    ).encode("utf-8")
+
+
+def _sha(b: bytes) -> bytes:
+    return hashlib.sha256(b).digest()
+
+
+def _leaf_hash(label: str, sha256_hex: str) -> bytes:
+    """Manifest-mode leaf hashing per chain-anchor-v1 §4.1: bind
+    label and sha together so a swapped label can't preserve the leaf."""
+    return _sha(_jcs({"label": label, "sha256_hex": sha256_hex}))
+
+
+def _merkle_root(leaves: list[bytes]) -> bytes:
+    """Satsignal merkle row, dup-last-when-odd."""
+    if not leaves:
+        return b"\x00" * 32
+    level = list(leaves)
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])
+        level = [_sha(level[i] + level[i + 1]) for i in range(0, len(level), 2)]
+    return level[0]
+
+
+def _step_label(step: MemoryStep, index: int) -> str:
+    if isinstance(step, ActionStep):
+        return f"action-step-{step.step_number}"
+    if isinstance(step, PlanningStep):
+        return f"planning-step-{index}"
+    if isinstance(step, FinalAnswerStep):
+        return "final-answer"
+    return f"step-{index}-{type(step).__name__.lower()}"
+
+
+class ChainAnchorCallback:
+    """Step callback that produces a ``chain-anchor-v1`` JSON sidecar
+    per agent run.
+
+    The callback collects a sha256 of each (canonicalized) step's
+    serialized form as a leaf, computes a merkle root over the batch
+    when the final answer fires, hands the root to a user-supplied
+    ``anchor_fn``, and writes a sidecar JSON file conforming to
+    ``chain-anchor-v1``.
+
+    smolagents itself takes no network dependency; the anchor backend
+    (BSV, RFC 3161 TSA, local timestamp service, anything else) lives
+    entirely in the caller's ``anchor_fn``.
+
+    Args:
+        anchor_fn (`Callable[[str], dict | None]`): User-supplied function
+            that takes the hex-encoded merkle root and returns a dict
+            conforming to chain-anchor-v1 (``v``, ``system``, ``chain``,
+            ``txid``, ``root_hash``, plus any optional fields). May
+            return ``None`` if the caller does not have a backend yet —
+            the sidecar still records the local merkle root + leaves
+            so an anchor can be backfilled later.
+        out_dir (`str`, *optional*, defaults to ``"."``): Directory the
+            sidecar is written to. Filename is
+            ``run-<uuid>.chain-anchor.json``.
+        include_planning (`bool`, *optional*, defaults to ``False``):
+            Whether to commit planning steps as leaves alongside action
+            steps.
+        run_id (`str`, *optional*): Override the generated run UUID.
+            Useful in tests.
+        clock (`Callable[[], float]`, *optional*, defaults to
+            ``time.time``): Time source. Useful in tests.
+
+    Register against both ``ActionStep`` and ``FinalAnswerStep`` so
+    the callback sees the end of a run::
+
+        from smolagents import (
+            CodeAgent, ActionStep, FinalAnswerStep, ChainAnchorCallback,
+        )
+        from smolagents.memory import PlanningStep
+
+        def my_anchor_fn(root_hex):
+            # Plug in any anchor service.
+            return {"v": 1, "system": "my-service", "chain": "bsv-mainnet",
+                    "txid": "<from POST>", "root_hash": root_hex}
+
+        cb = ChainAnchorCallback(anchor_fn=my_anchor_fn, out_dir="./receipts")
+        agent = CodeAgent(
+            tools=[...],
+            model=...,
+            step_callbacks={ActionStep: cb, FinalAnswerStep: cb,
+                            PlanningStep: cb},
+        )
+        agent.run("Some task")
+        # → ./receipts/run-<uuid>.chain-anchor.json
+    """
+
+    def __init__(
+        self,
+        anchor_fn: Callable[[str], dict | None] | None = None,
+        out_dir: str = ".",
+        include_planning: bool = False,
+        run_id: str | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self.anchor_fn = anchor_fn
+        self.out_dir = out_dir
+        self.include_planning = include_planning
+        self.run_id = run_id or str(uuid.uuid4())
+        self.clock = clock
+        self._items: list[dict[str, str]] = []
+        self._leaves: list[bytes] = []
+        self._started_at = self.clock()
+        self._flushed = False
+
+    def __call__(self, memory_step: MemoryStep, agent=None) -> None:
+        # Skip planning steps unless explicitly requested.
+        if isinstance(memory_step, PlanningStep) and not self.include_planning:
+            return
+        # Record the step as a leaf.
+        if isinstance(memory_step, (ActionStep, PlanningStep, FinalAnswerStep)):
+            label = _step_label(memory_step, len(self._items))
+            canonical = _jcs(memory_step.dict())
+            step_sha = hashlib.sha256(canonical).hexdigest()
+            self._items.append({"label": label, "sha256_hex": step_sha})
+            self._leaves.append(_leaf_hash(label, step_sha))
+        # Flush the anchor on the final-answer step.
+        if isinstance(memory_step, FinalAnswerStep):
+            self._flush()
+
+    def _flush(self) -> None:
+        if self._flushed:
+            return
+        self._flushed = True
+        root_hex = _merkle_root(self._leaves).hex()
+        chain_anchor: dict | None = None
+        anchor_error: str | None = None
+        if self.anchor_fn is not None:
+            try:
+                chain_anchor = self.anchor_fn(root_hex)
+            except Exception as e:
+                anchor_error = f"{type(e).__name__}: {e}"
+        sidecar = {
+            "version": "chain-anchor-v1-sidecar",
+            "run_id": self.run_id,
+            "started_at_epoch": self._started_at,
+            "finished_at_epoch": self.clock(),
+            "leaf_count": len(self._leaves),
+            "leaf_hashing": "leaf = sha256(JCS({label, sha256_hex}))",
+            "tree": "satsignal merkle row, dup-last-when-odd",
+            "merkle_root_hex": root_hex,
+            "items": [
+                {"index": i, **it} for i, it in enumerate(self._items)
+            ],
+            "chain_anchor": chain_anchor,
+            "anchor_error": anchor_error,
+        }
+        os.makedirs(self.out_dir, exist_ok=True)
+        path = os.path.join(self.out_dir, f"run-{self.run_id}.chain-anchor.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(sidecar, f, indent=2, sort_keys=False)
+        self.sidecar_path = path
+        self.sidecar = sidecar

--- a/tests/test_chain_anchor.py
+++ b/tests/test_chain_anchor.py
@@ -1,0 +1,182 @@
+import hashlib
+import json
+
+from smolagents.chain_anchor import (
+    ChainAnchorCallback,
+    _jcs,
+    _leaf_hash,
+    _merkle_root,
+)
+from smolagents.memory import ActionStep, FinalAnswerStep, PlanningStep
+from smolagents.models import ChatMessage, MessageRole
+from smolagents.monitoring import Timing
+
+
+def _make_action_step(n: int, output: str) -> ActionStep:
+    return ActionStep(
+        step_number=n,
+        timing=Timing(start_time=0.0, end_time=1.0),
+        action_output=output,
+    )
+
+
+class TestHelpers:
+    def test_jcs_sorts_keys_and_strips_whitespace(self):
+        out = _jcs({"b": 2, "a": 1})
+        assert out == b'{"a":1,"b":2}'
+
+    def test_jcs_utf8(self):
+        out = _jcs({"k": "café"})
+        assert b"caf\xc3\xa9" in out
+
+    def test_leaf_hash_binds_label(self):
+        # Same sha256_hex but different labels → different leaf hashes
+        l1 = _leaf_hash("step-1", "deadbeef" * 8)
+        l2 = _leaf_hash("step-2", "deadbeef" * 8)
+        assert l1 != l2
+
+    def test_merkle_root_single_leaf(self):
+        leaf = b"\xaa" * 32
+        assert _merkle_root([leaf]) == leaf
+
+    def test_merkle_root_two_leaves(self):
+        a, b = b"\x01" * 32, b"\x02" * 32
+        expected = hashlib.sha256(a + b).digest()
+        assert _merkle_root([a, b]) == expected
+
+    def test_merkle_root_three_leaves_dups_last(self):
+        a, b, c = b"\x01" * 32, b"\x02" * 32, b"\x03" * 32
+        # Level 1: pair(a,b), pair(c,c)
+        l1 = hashlib.sha256(a + b).digest()
+        l2 = hashlib.sha256(c + c).digest()
+        expected = hashlib.sha256(l1 + l2).digest()
+        assert _merkle_root([a, b, c]) == expected
+
+    def test_merkle_root_empty(self):
+        assert _merkle_root([]) == b"\x00" * 32
+
+
+class TestChainAnchorCallback:
+    def test_callback_writes_sidecar_with_local_root(self, tmp_path):
+        cb = ChainAnchorCallback(out_dir=str(tmp_path), run_id="testrun")
+        cb(_make_action_step(1, "alpha"))
+        cb(_make_action_step(2, "beta"))
+        cb(FinalAnswerStep(output="done"))
+        path = tmp_path / "run-testrun.chain-anchor.json"
+        assert path.exists()
+        sidecar = json.loads(path.read_text())
+        assert sidecar["version"] == "chain-anchor-v1-sidecar"
+        assert sidecar["run_id"] == "testrun"
+        assert sidecar["leaf_count"] == 3
+        assert sidecar["chain_anchor"] is None
+        assert sidecar["anchor_error"] is None
+        # Merkle root is deterministic from the 3 leaves
+        assert len(sidecar["merkle_root_hex"]) == 64
+        labels = [it["label"] for it in sidecar["items"]]
+        assert labels == ["action-step-1", "action-step-2", "final-answer"]
+
+    def test_callback_calls_anchor_fn_with_root(self, tmp_path):
+        captured: dict[str, str] = {}
+
+        def fake_anchor_fn(root_hex: str) -> dict:
+            captured["root"] = root_hex
+            return {
+                "v": 1, "system": "test", "chain": "bsv-mainnet",
+                "txid": "deadbeef" * 8, "root_hash": root_hex,
+            }
+
+        cb = ChainAnchorCallback(
+            anchor_fn=fake_anchor_fn, out_dir=str(tmp_path), run_id="r2",
+        )
+        cb(_make_action_step(1, "x"))
+        cb(FinalAnswerStep(output="done"))
+        sidecar = json.loads((tmp_path / "run-r2.chain-anchor.json").read_text())
+        assert sidecar["merkle_root_hex"] == captured["root"]
+        assert sidecar["chain_anchor"]["txid"] == "deadbeef" * 8
+        assert sidecar["chain_anchor"]["root_hash"] == captured["root"]
+
+    def test_anchor_fn_exception_recorded_not_raised(self, tmp_path):
+        def boom(_root: str) -> dict:
+            raise RuntimeError("network unreachable")
+
+        cb = ChainAnchorCallback(
+            anchor_fn=boom, out_dir=str(tmp_path), run_id="r3",
+        )
+        cb(_make_action_step(1, "x"))
+        cb(FinalAnswerStep(output="done"))
+        sidecar = json.loads((tmp_path / "run-r3.chain-anchor.json").read_text())
+        assert sidecar["chain_anchor"] is None
+        assert "RuntimeError" in sidecar["anchor_error"]
+        assert "network unreachable" in sidecar["anchor_error"]
+
+    def test_planning_steps_excluded_by_default(self, tmp_path):
+        cb = ChainAnchorCallback(out_dir=str(tmp_path), run_id="r4")
+        cb(_make_action_step(1, "x"))
+        cb(PlanningStep(
+            model_input_messages=[],
+            model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content="plan body"),
+            plan="some plan",
+            timing=Timing(start_time=0.0, end_time=1.0),
+        ))
+        cb(FinalAnswerStep(output="done"))
+        sidecar = json.loads((tmp_path / "run-r4.chain-anchor.json").read_text())
+        assert sidecar["leaf_count"] == 2  # action + final, no planning
+        labels = [it["label"] for it in sidecar["items"]]
+        assert "planning-step-1" not in labels
+
+    def test_planning_steps_included_when_opted_in(self, tmp_path):
+        cb = ChainAnchorCallback(
+            out_dir=str(tmp_path), run_id="r5", include_planning=True,
+        )
+        cb(_make_action_step(1, "x"))
+        cb(PlanningStep(
+            model_input_messages=[],
+            model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content="plan body"),
+            plan="some plan",
+            timing=Timing(start_time=0.0, end_time=1.0),
+        ))
+        cb(FinalAnswerStep(output="done"))
+        sidecar = json.loads((tmp_path / "run-r5.chain-anchor.json").read_text())
+        assert sidecar["leaf_count"] == 3
+        labels = [it["label"] for it in sidecar["items"]]
+        assert "planning-step-1" in labels
+
+    def test_flush_is_idempotent(self, tmp_path):
+        cb = ChainAnchorCallback(out_dir=str(tmp_path), run_id="r6")
+        cb(_make_action_step(1, "x"))
+        cb(FinalAnswerStep(output="done"))
+        cb(FinalAnswerStep(output="done"))  # second flush should be a no-op
+        sidecar = json.loads((tmp_path / "run-r6.chain-anchor.json").read_text())
+        # leaf_count would have been 3 if the second flush had recorded
+        # another final-answer leaf
+        assert sidecar["leaf_count"] == 2
+
+    def test_merkle_root_matches_independent_recomputation(self, tmp_path):
+        """Sanity check: an independent stdlib re-implementation produces
+        the same root the callback writes. This is the property a
+        chain-anchor-v1 verifier checks."""
+        cb = ChainAnchorCallback(out_dir=str(tmp_path), run_id="r7")
+        cb(_make_action_step(1, "alpha"))
+        cb(_make_action_step(2, "beta"))
+        cb(FinalAnswerStep(output="gamma"))
+        sidecar = json.loads((tmp_path / "run-r7.chain-anchor.json").read_text())
+
+        # Re-derive from sidecar items.
+        def jcs(o):
+            return json.dumps(o, sort_keys=True, separators=(",", ":"),
+                              ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+        def sha(b):
+            return hashlib.sha256(b).digest()
+
+        leaves = [
+            sha(jcs({"label": it["label"], "sha256_hex": it["sha256_hex"]}))
+            for it in sidecar["items"]
+        ]
+        # dup-last-when-odd merkle
+        level = list(leaves)
+        while len(level) > 1:
+            if len(level) % 2 == 1:
+                level.append(level[-1])
+            level = [sha(level[i] + level[i + 1]) for i in range(0, len(level), 2)]
+        assert level[0].hex() == sidecar["merkle_root_hex"]


### PR DESCRIPTION
## Summary
Adds `ChainAnchorCallback`, an opt-in step callback that emits a [`chain-anchor/v1`](https://proof.satsignal.cloud/spec-chain-anchor) JSON sidecar per agent run. Lets users attach verifiable, third-party-auditable public-chain (or TSA) commitments to agent step history without modifying any core agent code.

## Motivation
Production agents increasingly need post-hoc, third-party-verifiable evidence of what they did — for audit, dispute resolution, regulated commerce, or cross-org delegation. smolagents already exposes `step_callbacks` on every `MultiStepAgent`; this PR ships the minimal helper that turns those callbacks into a portable receipt artifact.

`chain-anchor/v1` is a format-agnostic embedding: the callback canonicalizes each step's `.dict()` via RFC 8785 JCS, sha256s it, builds a merkle root over the batch, and hands the root to a user-supplied `anchor_fn`. The anchor backend (Satsignal, RFC 3161 TSA, local notary, anything else conforming to the format) is entirely on the caller's side — smolagents itself takes no new network dependency.

## Implementation notes
- One new flat module `src/smolagents/chain_anchor.py` (~215 LOC). No changes to `agents.py`, `memory.py`, or any existing module.
- Stdlib only: `hashlib`, `json`, `os`, `time`, `uuid`. No new dependencies in `pyproject.toml`.
- Output is a sidecar JSON file written to `out_dir`; no change to in-memory step state.
- `anchor_fn` is optional — if absent, the sidecar still records the local merkle root + leaves so an anchor can be backfilled later.
- `anchor_fn` exceptions are captured into the sidecar's `anchor_error` field rather than propagated; the agent run is unaffected.
- Tests are offline (no network) and use a fake `anchor_fn`. 14 unit tests cover JCS, leaf hashing, merkle row (including dup-last-when-odd), sidecar writing, error handling, planning-step opt-in, and flush idempotency.
- Includes a docs tutorial at \`tutorials/verifiable_receipts.md\` with a quick start and two pluggable-backend examples (Satsignal BSV anchor + RFC 3161 TSA).

## Backwards compatibility
Fully additive. No behavior changes unless \`ChainAnchorCallback\` is explicitly registered via \`step_callbacks=...\`. Existing tests pass unchanged.

## Try it

\`\`\`python
from smolagents import CodeAgent, ActionStep, FinalAnswerStep, ChainAnchorCallback

def my_anchor_fn(root_hex):
    return {"v": 1, "system": "demo", "chain": "bsv-mainnet",
            "txid": "...", "root_hash": root_hex}

cb = ChainAnchorCallback(anchor_fn=my_anchor_fn, out_dir="./receipts")
agent = CodeAgent(
    tools=[], model=...,
    step_callbacks={ActionStep: cb, FinalAnswerStep: cb},
)
agent.run("Some task")
# → ./receipts/run-<uuid>.chain-anchor.json
\`\`\`