### PR TITLE
Secure defaults in GradioUI.launch (share=False, debug parameterized, auth required for public CodeAgent)

### DIFF
--- a/src/smolagents/gradio_ui.py
+++ b/src/smolagents/gradio_ui.py
@@ -419,15 +419,36 @@ class GradioUI:
                     all_messages[streaming_msg_idx] = msg
                 yield all_messages
 
-    def launch(self, share: bool = True, **kwargs):
+    def launch(self, share: bool = False, debug: bool = False, auth=None, **kwargs):
         """
         Launch the Gradio app with the agent interface.
 
+        SECURITY: passing ``share=True`` exposes the agent — and any tools it
+        can execute, including arbitrary Python code for ``CodeAgent`` — to the
+        public internet via a Gradio tunnel (``*.gradio.live``). When sharing,
+        always pass ``auth=("user", "pass")`` (or stronger) to prevent
+        unauthenticated remote code execution by anyone who finds the URL.
+
         Args:
-            share (`bool`, defaults to `True`): Whether to share the app publicly.
-            **kwargs: Additional keyword arguments to pass to the Gradio launch method.
+            share (`bool`, defaults to `False`): Whether to share the app publicly via a Gradio tunnel.
+            debug (`bool`, defaults to `False`): Whether to launch Gradio in debug mode.
+            auth: Optional Gradio ``auth`` value forwarded to ``gradio.Blocks.launch``.
+                A ``("user", "pass")`` tuple, callable, or list of credentials.
+            **kwargs: Additional keyword arguments forwarded to ``gradio.Blocks.launch``.
         """
-        self.create_app().launch(debug=True, share=share, **kwargs)
+        # Refuse to publicly expose a CodeAgent without authentication —
+        # share=True + CodeAgent + no auth == unauthenticated RCE-as-a-Service.
+        from smolagents.agents import CodeAgent  # local import to avoid circular at module load
+
+        if share and auth is None and isinstance(self.agent, CodeAgent):
+            raise ValueError(
+                "Refusing to launch a CodeAgent publicly without authentication. "
+                "CodeAgent executes arbitrary code on the host; share=True with no "
+                "auth would expose that capability to the public internet. "
+                'Pass auth=("user", "pass") to launch(), or set share=False.'
+            )
+
+        self.create_app().launch(debug=debug, share=share, auth=auth, **kwargs)
 
     def create_app(self):
         import gradio as gr


### PR DESCRIPTION
## Summary

Currently `smolagents.GradioUI.launch()` defaults `share=True` and hardcodes `debug=True`:

```python
def launch(self, share: bool = True, **kwargs):
    """..."""
    self.create_app().launch(debug=True, share=share, **kwargs)
```

A user following the canonical example from the file's own docstring (`GradioUI(CodeAgent(...)).launch()`) ends up publishing a `CodeAgent` — which executes arbitrary Python locally — behind a public, unauthenticated `*.gradio.live` tunnel URL. Anyone with the URL can drive the agent to execute code on the host.

This PR:

1. **Changes the default of `share` from `True` to `False`.** Users who want public sharing now opt in explicitly.
2. **Removes the hardcoded `debug=True`** and makes `debug` an explicit parameter defaulting to `False` (previously couldn't be disabled via `**kwargs`).
3. **Adds an `auth` parameter** forwarded to `gradio.Blocks.launch`. Lets users pass `("user", "pass")`, a callable, or a list of credentials.
4. **Refuses `share=True` for `CodeAgent` unless `auth` is provided.** Raises `ValueError` early with a clear message explaining the risk.

## Backward compatibility

- Users who currently pass `share=True` explicitly continue to work, except they now have to provide `auth=...` when the agent is a `CodeAgent`. The error message tells them exactly what to do.
- Users who currently pass `share=False` are unaffected.
- The most common implicit-default user (just calling `.launch()` with no args) goes from "publicly exposed" to "localhost only" — strictly safer.

## Why this matters

The previous defaults make it trivially easy to inadvertently publish a remote-code-execution endpoint. `*.gradio.live` URLs end up in browser history, Discord pastes, screenshots, Internet Archive snapshots, etc. Anyone finding one of those URLs — even months later — can pivot to the agent's code-execution capability while the script is running. This is the kind of secure-default bug that costs real users real harm and tends to get flagged as a CVE.

## Linked report

Disclosed in huntr report: https://huntr.com/bounties/46647dfa-22d1-4864-a25f-9ad143c1bc83

## Notes for reviewers

- The `from smolagents.agents import CodeAgent` is a local (function-scope) import to avoid a circular import at module load time. `agents.py` itself imports from this module via the agent class hierarchy.
- An alternative to the `ValueError` would be a loud warning + override of `share` to `False`. I chose `ValueError` because failing closed is the safer default for this category of bug; happy to switch to a warning if the maintainers prefer.
