### PR TITLE
Block dunder access via str.format/format_map field paths in sandbox

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -153,6 +153,38 @@ DANGEROUS_FUNCTIONS = [
 ]
 
 
+def _format_string_has_dunder_field(format_string: str) -> bool:
+    """
+    Return True if `format_string` references a dunder attribute via a field-path
+    expression such as ``{0.__class__.__bases__}``.
+
+    ``str.format`` and ``str.format_map`` evaluate field paths using CPython's
+    C-level ``_PyObject_LookupAttr`` from the ``_string`` module, which
+    bypasses the sandbox's Python-level ``getattr`` override and the AST-level
+    dunder check in :func:`evaluate_attribute`. Format strings must therefore
+    be validated before delegating to ``str.format`` / ``str.format_map``.
+    """
+    import string
+
+    try:
+        parsed = list(string.Formatter().parse(format_string))
+    except (ValueError, TypeError):
+        # Malformed format strings will raise when actually called; let that
+        # happen at call time rather than masking the error here.
+        return False
+
+    for _literal_text, field_name, _format_spec, _conversion in parsed:
+        if not field_name:
+            continue
+        # field_name looks like "0", "0.foo", "0.foo.bar[2]", "name.attr", etc.
+        # Split on '.' and '[' to enumerate attribute segments.
+        for segment in re.split(r"[\.\[]", field_name):
+            segment = segment.rstrip("]")
+            if segment.startswith("__") and segment.endswith("__"):
+                return True
+    return False
+
+
 def check_safer_result(result: Any, static_tools: dict[str, Callable] = None, authorized_imports: list[str] = None):
     """
     Checks if a result is safer according to authorized imports and static tools.
@@ -915,6 +947,21 @@ def evaluate_call(
             and (func.__name__ not in ALLOWED_DUNDER_METHODS)
         ):
             raise InterpreterError(f"Forbidden call to dunder function: {func.__name__}")
+        # ``str.format`` / ``str.format_map`` evaluate field paths (e.g.
+        # ``{0.__class__.__bases__}``) through CPython's C-level
+        # ``_PyObject_LookupAttr``, which bypasses the Python-level dunder
+        # check above and the dunder check in :func:`evaluate_attribute`.
+        # Validate the format string before delegating to the real method.
+        if (
+            func_name in ("format", "format_map")
+            and isinstance(getattr(func, "__self__", None), str)
+            and _format_string_has_dunder_field(func.__self__)
+        ):
+            raise InterpreterError(
+                "Forbidden dunder access in format string field path "
+                "(e.g. '{0.__class__}'): the sandbox's dunder filter applies to attribute "
+                "access expressions as well as format-string field paths."
+            )
         return func(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary

The `local_python_executor` sandbox's dunder filter (`evaluate_attribute` line 390, `evaluate_call` dunder-name check line 910-917, and `nodunder_getattr` line 68-71) prevents sandboxed code from accessing dunder attributes such as `__class__`, `__bases__`, `__subclasses__`.

`str.format()` (and `str.format_map()`), however, evaluate field-path expressions like `{0.__class__.__bases__}` through CPython's C-level `_PyObject_LookupAttr` in the `_string` module, **bypassing the Python-level override**.

```python
# Inside the sandbox today (main, validated):
>>> '{0.__class__.__bases__[0].__subclasses__}'.format('a')
'<built-in method __subclasses__ of type object at 0x7f...>'
```

The traversal happens; the value returned is the `repr()` of the leaked method rather than the method itself, so the bypass on its own is not RCE. But it still:

- enumerates class hierarchies the sandbox intends to hide
- discloses memory addresses (an ASLR side channel in deployments that run the sandbox in-process)
- probes dunder method existence on tools and arguments passed in by the host

This is a weakening of the sandbox's defense-in-depth and a useful primitive for chaining toward higher-severity escapes.

## Fix

Two pieces:

1. **`_format_string_has_dunder_field`** in `local_python_executor.py`: parses a format string with `string.Formatter().parse()` and returns `True` if any field-name segment matches the dunder pattern. Robust against bracket access (`{0.attr[idx]}`) and chained traversal.

2. **Hook in `evaluate_call`**: when the resolved callable is a bound `str.format` / `str.format_map` method (`func_name in ("format", "format_map")` and `func.__self__` is a `str`), validate the format string before delegating. Raises `InterpreterError` with a clear message on dunder field paths.

## Tested behavior (against this branch)

```
TEST 1 PASS: '{0.__class__.__bases__[0].__subclasses__}'.format('a') → InterpreterError (was: succeeded)
TEST 2 PASS: 'Hello {0}'.format(name)                                → 'Hello world' (benign, unaffected)
TEST 3 PASS: '{cls.__class__}'.format_map({'cls': 'a'})              → InterpreterError
TEST 4 PASS: '{0.upper}'.format('hi')                                → still works (non-dunder field path)
```

## Notes for reviewers

- The check runs inside `evaluate_call` at the same point as the existing dunder-name filter for function calls (line 910-917). Both checks live next to each other for cohesion.
- I parse the format string with the stdlib's `string.Formatter().parse()` rather than a regex over `{...}` so that escapes (`{{`, `}}`) and format-spec syntax are handled correctly.
- Malformed format strings let `str.format` raise its usual `ValueError` at call time; the sandbox check doesn't try to mask those errors.

## Linked report

Disclosed in huntr report: https://huntr.com/bounties/30e6527b-f92f-46c2-b29c-a088dde505e4

This PR is the second of two security fixes from the same audit; the first (#2270) addressed insecure defaults in `GradioUI.launch`.