### PR TITLE
Add new possible error message to test of LiteLLM providers w/o key

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -407,6 +407,7 @@ class TestLiteLLMModel:
             "The api_key client option must be set",
             "AuthenticationError",
             "Unauthorized",
+            "Missing credentials",
         ]
         model = LiteLLMModel(model_id=model_id)
         messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Test message"}])]


### PR DESCRIPTION
Add new possible error message to test of LiteLLM providers w/o key.

Fix #2274.