### PR TITLE
fix: add `nt.system` to DANGEROUS_FUNCTIONS for Windows parity

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -147,6 +147,7 @@ DANGEROUS_FUNCTIONS = [
     "builtins.globals",
     "builtins.locals",
     "builtins.__import__",
+    "nt.system",
     "os.popen",
     "os.system",
     "posix.system",


### PR DESCRIPTION
## Summary

- Adds `"nt.system"` to `DANGEROUS_FUNCTIONS` so `check_safer_result` correctly blocks `os.system` on Windows.

On Windows, `os.system.__module__` returns `"nt"` (not `"os"`), so the existing check against `"os.system"` silently passes. The Linux equivalent `"posix.system"` was already present; this adds the missing Windows entry.

Only affects users who explicitly authorize `os` via `additional_authorized_imports=["os"]` — the default sandbox blocks `os` entirely.

## Test plan

- [ ] Existing `test_vulnerability_for_all_dangerous_functions[os.system]` now passes on Windows
- [ ] No behavior change on Linux/macOS (existing `posix.system` and `os.system` entries still cover those platforms)

Closes #2232