### PR TITLE
Fix get_imports missing imports with inline comments

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -77,8 +77,8 @@ def get_imports(code: str) -> list[str]:
         flags=re.MULTILINE,
     )
 
-    # Imports of the form `import xxx` or `import xxx as yyy`
-    imports = re.findall(r"^\s*import\s+(\S+?)(?:\s+as\s+\S+)?\s*$", code, flags=re.MULTILINE)
+    # Imports of the form `import xxx` or `import xxx as yyy` (with optional inline comment)
+    imports = re.findall(r"^\s*import\s+(\S+?)(?:\s+as\s+\S+)?\s*(?:#.*)?\s*$", code, flags=re.MULTILINE)
     # Imports of the form `from xxx import yyy`
     imports += re.findall(r"^\s*from\s+(\S+)\s+import", code, flags=re.MULTILINE)
     # Only keep the top-level module


### PR DESCRIPTION
## Summary

Fixes #2211

The `get_imports()` function in `_function_type_hints_utils.py` uses regex-based parsing to extract imports from tool source code. The pattern for `import xxx` statements required the line to end immediately after the import (`\s*$`), which caused imports with inline comments to be missed entirely.

For example:
```python
import IPython  # noqa: F401
```

The regex `^\s*import\s+(\S+?)(?:\s+as\s+\S+)?\s*$` fails to match because `# noqa: F401` sits between the import and the end of line.

## Fix

Updated the regex to allow an optional inline comment before end-of-line:
```
^\s*import\s+(\S+?)(?:\s+as\s+\S+)?\s*(?:#.*)?\s*$
```

The `(?:#.*)?` group optionally matches a `#` followed by any characters (the comment), so both plain imports and commented imports are captured.

## Impact

When saving tools via `Tool.save()` or `Tool.push_to_hub()`, the generated `requirements.txt` now correctly includes packages from import statements that have inline comments (e.g., `# noqa`, `# type: ignore`, etc.).