### PR TITLE
docs: fix python_executor call in web_browser example

### DIFF
--- a/docs/source/en/examples/web_browser.md
+++ b/docs/source/en/examples/web_browser.md
@@ -128,7 +128,7 @@ agent = CodeAgent(
 )
 
 # Import helium for the agent
-agent.python_executor("from helium import *", agent.state)
+agent.python_executor("from helium import *")
 ```
 
 The agent needs instructions on how to use Helium for web automation. Here are the instructions we'll provide:


### PR DESCRIPTION
 ## What does this PR do?

  Fixes a broken code example in `docs/source/en/examples/web_browser.md` where
  `agent.python_executor()` is called with too many arguments.

 ## The bug

  The example currently calls the executor with two arguments:

  ```python
  agent.python_executor("from helium import *", agent.state)

  But PythonExecutor.__call__ (in src/smolagents/local_python_executor.py) only accepts a single
  argument — the code string to execute. State is managed internally by the executor.

  Running the example as-is raises:

  TypeError: __call__() takes 2 positional arguments but 3 were given

  The fix

  Remove the second argument so the call matches the __call__ signature:

  agent.python_executor("from helium import *")
