### PR TITLE
docs: fix LiteLLMModel parameter name in guided_tour example

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -314,7 +314,7 @@ Alternatively, you can use `LiteLLMModel` with Bedrock models:
 ```python
 from smolagents import LiteLLMModel, CodeAgent
 
-model = LiteLLMModel(model_name="bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
+model = LiteLLMModel(model_id="bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
 agent = CodeAgent(tools=[], model=model)
 
 agent.run("Explain the concept of quantum computing")


### PR DESCRIPTION
## What does this PR do?

  Fixes a broken code example in `docs/source/en/guided_tour.md` where the Bedrock example for
  `LiteLLMModel` uses the wrong keyword argument name.

  ## The bug

  The example currently uses `model_name=`:

  ```python
  model = LiteLLMModel(model_name="bedrock/anthropic.claude-3-sonnet-20240229-v1:0")

  But LiteLLMModel.__init__ (in src/smolagents/models.py) accepts model_id, not model_name. Running
  the example as-is raises:

  TypeError: __init__() got an unexpected keyword argument 'model_name'

  The fix

  Replace model_name= with model_id= so the example matches the actual constructor signature.