### PR TITLE
fix(deps): restrict mlx[cpu] to non-Windows platforms in test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
-  "mlx[cpu]",  # GH-1588
+  "mlx[cpu]; sys_platform != 'win32'",  # GH-1588: mlx has no Windows wheels
 ]
 dev = [
   "smolagents[quality,test]",


### PR DESCRIPTION
## Summary

The `mlx[cpu]` entry in the `test` (and transitively `dev`) optional-dependency group is pinned without a platform marker. `mlx` publishes wheels for Linux (`manylinux_2_35_x86_64`, `manylinux_2_35_aarch64`) and macOS (`macosx_14_0_arm64`, etc.) but has no Windows wheels at all. As a result, `uv pip install -e "smolagents[dev] @ ."` fails immediately on Windows with "No solution found when resolving dependencies" — blocking Windows contributors from setting up the repo entirely. Adding a `sys_platform != 'win32'` environment marker causes `pip`/`uv` to skip the constraint on Windows while keeping it on Linux and macOS where the wheels exist.

## Issue

Fixes #2272

## Local verification

```
# Verify TOML is valid and marker is well-formed
$ python3 -c "
import tomllib
with open('pyproject.toml', 'rb') as f:
    data = tomllib.load(f)
print('TOML valid')
mlx_entry = [e for e in data['project']['optional-dependencies']['test'] if 'mlx[cpu]' in e]
print('mlx entry:', mlx_entry)
"
TOML valid
mlx entry: ["mlx[cpu]; sys_platform != 'win32'"]

# Verify PEP 508 requirement is parseable
$ python3 -c "
from packaging.requirements import Requirement
r = Requirement(\"mlx[cpu]; sys_platform != 'win32'\")
print('PEP 508 valid:', r, '| marker:', r.marker)
"
PEP 508 valid: mlx[cpu]; sys_platform != "win32" | marker: sys_platform != "win32"

# ruff check (only pre-existing error in serialization.py, unrelated to this change)
$ ruff check examples src tests
F821 Undefined name `e`
   --> src/smolagents/serialization.py:429:74
Found 1 error.

# ruff format check
$ ruff format --check examples src tests
73 files already formatted

# pre-commit on touched file
$ pre-commit run --files pyproject.toml
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped

=== LOCAL_TEST_PASSED ===
```

## Risk

Very low: changes only a single dependency marker in `pyproject.toml`. Linux and macOS install/test pipelines are unaffected (mlx wheels exist on both). The F821 ruff error shown above is pre-existing on `main` (`src/smolagents/serialization.py:429`) and not introduced by this PR.
