### PR TITLE
fix: add `nt.system` to DANGEROUS_FUNCTIONS for Windows safety

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -150,6 +150,7 @@ DANGEROUS_FUNCTIONS = [
     "os.popen",
     "os.system",
     "posix.system",
+    "nt.system",
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds `"nt.system"` to the `DANGEROUS_FUNCTIONS` blocklist in `local_python_executor.py`
- On Windows, `os.system` is backed by `nt.system`. Without blocking it, an agent can bypass the `os.system` guard via `import nt; nt.system("cmd")`
- The existing parametrized test (`test_vulnerability_for_all_dangerous_functions`) already covers all entries and uses `pytest.importorskip` for platform-specific modules — no test changes needed

## Test plan

- [ ] Existing tests pass on Linux (nt skipped via `importorskip`)
- [ ] On Windows, `import nt; nt.system("echo hello")` raises `InterpreterError`

Closes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)