### PR TITLE
fix: make `WebSearchTool` HTTP timeout configurable

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -345,10 +345,11 @@ class WebSearchTool(Tool):
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
 
-    def __init__(self, max_results: int = 10, engine: str = "duckduckgo"):
+    def __init__(self, max_results: int = 10, engine: str = "duckduckgo", timeout: int | None = None):
         super().__init__()
         self.max_results = max_results
         self.engine = engine
+        self.timeout = timeout
 
     def forward(self, query: str) -> str:
         results = self.search(query)
@@ -376,6 +377,7 @@ class WebSearchTool(Tool):
             "https://lite.duckduckgo.com/lite/",
             params={"q": query},
             headers={"User-Agent": "Mozilla/5.0"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         parser = self._create_duckduckgo_parser()
@@ -436,6 +438,7 @@ class WebSearchTool(Tool):
         response = requests.get(
             "https://www.bing.com/search",
             params={"q": query, "format": "rss"},
+            timeout=self.timeout,
         )
         response.raise_for_status()
         root = ET.fromstring(response.text)


### PR DESCRIPTION
## Summary

- Adds an optional `timeout` parameter to `WebSearchTool.__init__` (defaults to `None` for backwards compatibility)
- Passes it through to `requests.get()` in both `search_duckduckgo()` and `search_bing()` methods
- Without this, there's no way to control HTTP timeouts, which can cause indefinite hangs on slow networks

```python
tool = WebSearchTool(timeout=10)  # 10-second timeout for all searches
```

## Test plan

- [ ] `WebSearchTool()` still works with no timeout (default `None`)
- [ ] `WebSearchTool(timeout=10)` passes timeout to requests
- [ ] Both DuckDuckGo and Bing engines respect the timeout

Closes #2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)