### PR TITLE
Report managed-agent max steps failures

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -873,11 +873,21 @@ You have been provided with these additional arguments, that you can access dire
             self.prompt_templates["managed_agent"]["task"],
             variables=dict(name=self.name, task=task),
         )
-        result = self.run(full_task, **kwargs)
-        if isinstance(result, RunResult):
-            report = result.output
-        else:
-            report = result
+        run_kwargs = {**kwargs, "return_full_result": True}
+        try:
+            result = self.run(full_task, **run_kwargs)
+            if isinstance(result, RunResult):
+                report = result.output
+                if result.state == "max_steps_error":
+                    report = (
+                        f"Sub-agent '{self.name}' did not produce a final answer. "
+                        f"Reason: max_steps ({run_kwargs.get('max_steps') or self.max_steps}) reached without "
+                        "calling final_answer."
+                    )
+            else:
+                report = result
+        except AgentError as error:
+            report = f"Sub-agent '{self.name}' failed with {type(error).__name__}: {error}"
         answer = populate_template(
             self.prompt_templates["managed_agent"]["report"], variables=dict(name=self.name, final_answer=report)
         )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -574,6 +574,44 @@ class TestAgent:
         assert agent.name == "managed_agent"
         assert agent.description == "Empty"
 
+    def test_managed_agent_reports_max_steps_failure(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=1,
+            name="managed_agent",
+            description="Empty",
+            verbosity_level=0,
+        )
+
+        answer = agent("Dummy task")
+
+        assert "Sub-agent 'managed_agent' did not produce a final answer." in answer
+        assert "max_steps (1) reached without calling final_answer" in answer
+
+        class FakeToolCallModelNoCall(Model):
+            def generate(self, messages, stop_sequences=None, tools_to_call_from=None):
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="I don't want to call tools today",
+                    tool_calls=None,
+                    raw="I don't want to call tools today",
+                )
+
+        agent = ToolCallingAgent(
+            tools=[],
+            model=FakeToolCallModelNoCall(),
+            max_steps=1,
+            name="managed_agent",
+            description="Empty",
+            verbosity_level=0,
+        )
+
+        answer = agent("Dummy task")
+
+        assert "Sub-agent 'managed_agent' did not produce a final answer." in answer
+        assert "max_steps (1) reached without calling final_answer" in answer
+
     def test_agent_description_gets_correctly_inserted_in_system_prompt(self):
         managed_agent = CodeAgent(
             tools=[], model=FakeCodeModelFunctionDef(), name="managed_agent", description="Empty"


### PR DESCRIPTION
Fixes #2166.

## Summary
- run managed-agent calls with full result metadata internally
- return a structured failure report when a sub-agent reaches max_steps without a final answer
- cover both CodeAgent and ToolCallingAgent managed-agent failures

## Tests
- `PYTHONPATH=src python -m pytest tests/test_agents.py::TestAgent::test_managed_agent_reports_max_steps_failure tests/test_agents.py::TestAgent::test_fails_max_steps tests/test_agents.py::TestAgent::test_agent_description_gets_correctly_inserted_in_system_prompt -q`
- `python -m compileall -q src/smolagents/agents.py tests/test_agents.py`
- `git diff --check`