### PR TITLE
fix: add platform marker to mlx[cpu] for Windows compatibility (fixes #2272)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ test = [
   "smolagents[all]",
   "rank-bm25", # For test_all_docs
   "Wikipedia-API>=0.8.1",
-  "mlx[cpu]",  # GH-1588
+  'mlx[cpu]; sys_platform != "win32"',  # GH-1588 - mlx has no Windows wheels
 ]
 dev = [
   "smolagents[quality,test]",


### PR DESCRIPTION
## Description

`mlx` (Apple MLX framework) only ships wheels for Linux and macOS. When users on Windows try to install `smolagents[dev]` (which pulls in `smolagents[test]` including `mlx[cpu]`), uv fails with:

```
× No solution found when resolving dependencies:
  ╰─▶ Because all versions of mlx[cpu] have no wheels with a matching platform tag (e.g., `win_amd64`)
```

## Changes

Added a `sys_platform != "win32"` environment marker to the `mlx[cpu]` dependency in the test extras.

Fixes #2272