### PR TITLE
Revert fix: correct f-string escaping

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {e}") from e
+                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
 
     @staticmethod
     def loads(data, allow_pickle=False):


### PR DESCRIPTION
Revert "fix: correct f-string escaping in ToolSerializer.dumps error message (#2134)"

This reverts commit 025b6adb25578ff951cd658935d5b15a1d4c0eb3.

### Motivation

The PR introduced a F821 error.

Since line 429 is inside the outer `f'''...'''` template string in `get_safe_serializer_code()`, the `{e}` gets evaluated as an f-string expression at call time, but `e` isn't defined there. The original `{{e}}` was correct: it produces the literal text {e} in the generated code string.

The commit author misread the situation: they saw {{e}} and thought it was mistakenly over-escaped compared to line 292 (which is regular Python code, not inside a template f-string). The two locations are different contexts.