### PR TITLE
Update docstring of LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1689,10 +1689,10 @@ class LocalPythonExecutor(PythonExecutor):
     """
     Executor of Python code in a local environment.
 
-    This executor evaluates Python code with restricted access to imports and built-in functions,
-    making it suitable for running untrusted code. It maintains state between executions,
-    allows for custom tools and functions to be made available to the code, and captures
-    print outputs separately from return values.
+    This executor evaluates Python code with restricted access to imports and built-in functions.
+    It is not a security sandbox: for isolated execution of untrusted code, use a remote executor.
+    It maintains state between executions, allows for custom tools and functions to be made available
+    to the code, and captures print outputs separately from return values.
 
     Args:
         additional_authorized_imports (`list[str]`):


### PR DESCRIPTION
Update docstring of LocalPythonExecutor.

This PR updates the documentation for the `LocalPythonExecutor` class to clarify its security model. The docstring now explicitly states that this executor is not a security sandbox and recommends using a remote executor for isolated execution of untrusted code.

This aligns with all the rest of the documentation, where this is clearly stated, so no ambiguity is left.

Documentation improvements:

* Updated the class docstring for `LocalPythonExecutor` to clarify that it is not a security sandbox and should not be used for isolated execution of untrusted code.