### PR TITLE
fix: merge consecutive string messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,18 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                text_content = message.content if isinstance(message.content, str) else message.content[0]["text"]
+                output_message_list[-1]["content"] += "\n" + text_content
+            elif isinstance(message.content, str):
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] += "\n" + message.content
+                else:
+                    output_message_list[-1]["content"].append({"type": "text", "text": message.content})
             else:
+                assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
@@ -385,7 +393,7 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = message.content if isinstance(message.content, str) else message.content[0]["text"]
             else:
                 content = message.content
             output_message_list.append(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -805,6 +805,21 @@ def test_get_clean_message_list_flatten_messages_as_text():
     assert result[0]["content"] == "Hello!\nHow are you?"
 
 
+def test_get_clean_message_list_merges_consecutive_string_messages():
+    messages = [
+        {"role": "system", "content": "Start with FOO."},
+        {"role": "system", "content": "End with BAR."},
+        {"role": "user", "content": "Say hello."},
+    ]
+
+    result = get_clean_message_list(messages)
+
+    assert result == [
+        {"role": "system", "content": "Start with FOO.\nEnd with BAR."},
+        {"role": "user", "content": "Say hello."},
+    ]
+
+
 @pytest.mark.parametrize(
     "model_class, model_kwargs, patching, expected_flatten_messages_as_text",
     [


### PR DESCRIPTION
﻿## Summary
- merge consecutive same-role string messages in get_clean_message_list instead of asserting
- keep mixed string/list content paths valid when message flattening is enabled or disabled
- add a regression test for consecutive system string messages

Fixes #1972.

## Validation
- PYTHONPATH=src python -m pytest tests/test_models.py::test_get_clean_message_list_merges_consecutive_string_messages tests/test_models.py::test_get_clean_message_list_basic tests/test_models.py::test_get_clean_message_list_flatten_messages_as_text -q
- python -m ruff check src/smolagents/models.py tests/test_models.py
- python -m ruff format --check src/smolagents/models.py tests/test_models.py
- python -m py_compile src/smolagents/models.py tests/test_models.py
- git diff --check

## Notes
I also ran python -m pytest tests/test_models.py -q locally. The changed tests passed, but the full file still needs optional test extras/platform dependencies in this Windows environment: pytest-datadir for shared_datadir, accelerate for the local transformers device_map path, and mlx_lm for the MLXModel parametrization.
