### PR TITLE
fix: add HTTP request timeout to GoogleSearchTool and ApiWebSearchTool

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -207,7 +207,7 @@ class GoogleSearchTool(Tool):
         if filter_year is not None:
             params["tbs"] = f"cdr:1,cd_min:01/01/{filter_year},cd_max:12/31/{filter_year}"
 
-        response = requests.get(base_url, params=params)
+        response = requests.get(base_url, params=params, timeout=20)
 
         if response.status_code == 200:
             results = response.json()
@@ -314,7 +314,7 @@ class ApiWebSearchTool(Tool):
 
         self._enforce_rate_limit()
         params = {**self.params, "q": query}
-        response = requests.get(self.endpoint, headers=self.headers, params=params)
+        response = requests.get(self.endpoint, headers=self.headers, params=params, timeout=20)
         response.raise_for_status()
         data = response.json()
         results = self.extract_results(data)

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -160,3 +161,48 @@ def test_wikipedia_search(language, content_type, extract_format, query):
         assert len(result.split()) < 1000, "Summary mode should return a shorter text"
     if content_type == "text":
         assert len(result.split()) > 1000, "Full text mode should return a longer text"
+
+
+def test_google_search_tool_passes_request_timeout(monkeypatch):
+    """GoogleSearchTool must pass an HTTP timeout to requests.get().
+
+    Without a timeout, a stalled search API hangs the call (and therefore
+    the whole agent loop) indefinitely. VisitWebpageTool already passes
+    timeout=20; the search tools must do the same.
+    """
+    from smolagents.default_tools import GoogleSearchTool
+
+    monkeypatch.setenv("SERPER_API_KEY", "test-key")
+    tool = GoogleSearchTool(provider="serper")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {tool.organic_key: []}
+
+    with patch("requests.get", return_value=mock_response) as mock_get:
+        tool.forward("hello world")
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs.get("timeout") == 20
+
+
+def test_api_web_search_tool_passes_request_timeout():
+    """ApiWebSearchTool must pass an HTTP timeout to requests.get().
+
+    Without a timeout, a stalled search API hangs the call (and therefore
+    the whole agent loop) indefinitely.
+    """
+    from smolagents.default_tools import ApiWebSearchTool
+
+    tool = ApiWebSearchTool(api_key="test-key", rate_limit=None)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"web": {"results": []}}
+
+    with patch("requests.get", return_value=mock_response) as mock_get:
+        tool.forward("hello world")
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs.get("timeout") == 20


### PR DESCRIPTION
## Problem

`GoogleSearchTool.forward()` and `ApiWebSearchTool.forward()` call `requests.get()` with **no `timeout` argument**. `requests` defaults to no timeout, so a search API that accepts the TCP connection but never sends a response will hang the call **forever** — and with it the entire agent loop, since tool calls are synchronous.

This is the same failure mode that `WebSearchTool` issue #2162 / PR #2286 is about. `VisitWebpageTool` already guards against it:

```python
# default_tools.py — VisitWebpageTool.forward()
response = requests.get(url, timeout=20)
```

The two API-backed search tools are inconsistent with it.

## Fix

Pass `timeout=20` to both `requests.get()` calls in `default_tools.py`, matching `VisitWebpageTool`:

```python
# GoogleSearchTool.forward()
response = requests.get(base_url, params=params, timeout=20)

# ApiWebSearchTool.forward()
response = requests.get(self.endpoint, headers=self.headers, params=params, timeout=20)
```

A timed-out request now raises `requests.exceptions.Timeout` (a normal, catchable error) instead of hanging indefinitely. This fits both tools' existing error models:

- `ApiWebSearchTool.forward()` already calls `response.raise_for_status()` and lets request exceptions propagate.
- `GoogleSearchTool.forward()` likewise surfaces request failures to the caller rather than swallowing them.

## Scope

Deliberately scoped to the two affected built-in search tools. `VisitWebpageTool` already has the timeout; `WebSearchTool`'s timeout is being handled separately in #2286. The `requests` calls in `agent_types.py` / `remote_executors.py` are a different surface and out of scope here.

## Tests

Two unit tests added to `tests/test_default_tools.py`:

- `test_google_search_tool_passes_request_timeout`
- `test_api_web_search_tool_passes_request_timeout`

Each mocks `requests.get`, invokes the tool's `forward()`, and asserts `requests.get` was called with `timeout=20`. They run fully offline — no live API key or network needed.

Local run: `uv run pytest tests/test_default_tools.py -k timeout` — both new tests pass. `ruff check` and `ruff format --check` pass on the changed files.

## Checklist

- [x] Minimal, focused change consistent with the existing `VisitWebpageTool` precedent.
- [x] Offline unit tests added and passing.
- [x] No new API surface; no behaviour change for fast/normal responses.
- [x] Lint + format clean.