### PR TITLE
fix(agents): strip api_key/token from executor_kwargs in CodeAgent.to_dict()

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1773,7 +1773,16 @@ class CodeAgent(MultiStepAgent):
         agent_dict = super().to_dict()
         agent_dict["authorized_imports"] = self.authorized_imports
         agent_dict["executor_type"] = self.executor_type
-        agent_dict["executor_kwargs"] = self.executor_kwargs
+        # Strip credentials from executor_kwargs before exporting. Remote executors
+        # such as E2BExecutor accept `api_key` / `token` via **kwargs and pass them
+        # straight to the sandbox client, so they can land in self.executor_kwargs.
+        sanitized_executor_kwargs = {k: v for k, v in self.executor_kwargs.items() if k not in ("api_key", "token")}
+        for stripped in set(self.executor_kwargs) - set(sanitized_executor_kwargs):
+            print(
+                f"For security reasons, we do not export the `{stripped}` value from `executor_kwargs`. "
+                "Please export it manually."
+            )
+        agent_dict["executor_kwargs"] = sanitized_executor_kwargs
         agent_dict["max_print_outputs_length"] = self.max_print_outputs_length
         return agent_dict
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2090,6 +2090,22 @@ class TestToolCallingAgent:
 
 
 class TestCodeAgent:
+    def test_to_dict_strips_secrets_from_executor_kwargs(self, capsys):
+        # E2BExecutor (and other remote executors) accept `api_key` / `token`
+        # via **kwargs. If a user passes them through `executor_kwargs`, they
+        # used to be exported verbatim by `CodeAgent.to_dict()`.
+        # Use a no-op executor placeholder so we don't need a real sandbox.
+        agent = CodeAgent(tools=[], model=MagicMock(), executor=MagicMock())
+        agent.executor_kwargs = {"api_key": "e2b-secret-key", "token": "extra-secret", "cpu": 2}
+        exported = agent.to_dict()
+        assert "api_key" not in exported["executor_kwargs"]
+        assert "token" not in exported["executor_kwargs"]
+        # non-secret values are still exported
+        assert exported["executor_kwargs"]["cpu"] == 2
+        captured = capsys.readouterr().out
+        assert "api_key" in captured
+        assert "token" in captured
+
     def test_code_agent_instructions(self):
         agent = CodeAgent(tools=[], model=MagicMock(), instructions="Test instructions")
         assert agent.instructions == "Test instructions"


### PR DESCRIPTION
## Security: executor credentials leak via `CodeAgent.to_dict()`

**CVE-class:** Credential exposure — `api_key` / `token` passed in `executor_kwargs` are silently included in serialised agent output (logs, `agent.save()` files, API responses, checkpoints).

---

## Root cause

`CodeAgent.to_dict()` in `src/smolagents/agents.py` exports `self.executor_kwargs` verbatim with no filtering. Remote executors such as `E2BExecutor` accept credentials via `**kwargs`:

```python
agent = CodeAgent(
    tools=[],
    model=model,
    executor_type="e2b",
    executor_kwargs={"api_key": "e2b-sk-secret"},
)
agent.to_dict()  # → {'executor_kwargs': {'api_key': 'e2b-sk-secret'}, ...}  ← leaked
```

The rest of the codebase (`Model.to_dict`, direct attribute checks) already has a `dangerous_attributes` pattern that strips and warns on `api_key`/`token`. `executor_kwargs` was simply never covered.

## Fix

In `CodeAgent.to_dict()`, filter `api_key` / `token` out of the exported `executor_kwargs` copy and emit the existing `"For security reasons…"` warning. Non-secret kwargs (e.g. `cpu`, `metadata`, `timeout`) still round-trip normally.

## Test

New test `TestCodeAgent::test_to_dict_strips_secrets_from_executor_kwargs` in `tests/test_agents.py` asserts both the strip behaviour and the warning emission. Passes locally.

## Related

Companion PR #2301 covers the same credential-leak class in `Model.to_dict()` via `**kwargs`.