### PR TITLE
feat: Add CurrentTimeTool for time-awarenessfeat: Add CurrentTimeTool to allow agent to get local time

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -638,12 +638,39 @@ class SpeechToTextTool(PipelineTool):
         return self.pre_processor.batch_decode(outputs, skip_special_tokens=True)[0]
 
 
+
+class CurrentTimeTool(Tool):
+    name = "current_time"
+    description = (
+        "Returns the current local time, date, and day of the week."
+        "Use this tool whenever you need to know the current date or time to answer a user's query about 'today', 'tomorrow', or relative dates."
+    )
+    inputs = {}
+    output_type = "string"
+
+    def forward(self) -> str:
+        import datetime
+        try:
+            #get current local time
+            now = datetime.datetime.now()
+            #format it as "Monday, January 1, 2024, 12:00 PM"
+            current_time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+            #get weekday,eg "Monday"
+            weekday = now.strftime("%A")
+
+            return f"Current local time: {current_time_str} (Weekday: {weekday})"
+        except Exception as e:
+            return f"Error fetching current time: {str(e)}"
+
 TOOL_MAPPING = {
     tool_class.name: tool_class
     for tool_class in [
         PythonInterpreterTool,
         DuckDuckGoSearchTool,
         VisitWebpageTool,
+        WikipediaSearchTool,
+        SpeechToTextTool,
+        CurrentTimeTool,
     ]
 }
 
@@ -658,4 +685,5 @@ __all__ = [
     "VisitWebpageTool",
     "WikipediaSearchTool",
     "SpeechToTextTool",
+    "CurrentTimeTool"
 ]


### PR DESCRIPTION
### Description
Added a simple `CurrentTimeTool` using the built-in `datetime` module. 

### Motivation
LLMs lack internal time-awareness. This tool allows the agent to correctly answer user queries involving relative dates like "today", "tomorrow", or specific weekday inquiries. 

Tested locally and the agent successfully uses the tool to answer time-based prompts.