### PR TITLE
Add OrcaRouterModel for the OrcaRouter API gateway

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -30,6 +30,7 @@ from smolagents import (
     LiteLLMModel,
     Model,
     OpenAIModel,
+    OrcaRouterModel,
     Tool,
     ToolCallingAgent,
     TransformersModel,
@@ -55,7 +56,7 @@ def parse_arguments():
         "--model-type",
         type=str,
         default="InferenceClientModel",
-        help="The model type to use (e.g., InferenceClientModel, OpenAIModel, LiteLLMModel, TransformersModel)",
+        help="The model type to use (e.g., InferenceClientModel, OpenAIModel, LiteLLMModel, TransformersModel, OrcaRouterModel)",
     )
     parser.add_argument(
         "--action-type",
@@ -155,7 +156,7 @@ def interactive_mode():
     model_type = Prompt.ask(
         "[bold]Model type[/]",
         default="InferenceClientModel",
-        choices=["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel"],
+        choices=["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel", "OrcaRouterModel"],
     )
 
     model_id = Prompt.ask("[bold white]Model ID[/]", default="Qwen/Qwen2.5-Coder-32B-Instruct")
@@ -168,7 +169,7 @@ def interactive_mode():
     action_type = "code"
 
     if Confirm.ask("\n[bold white]Configure advanced options?[/]", default=False):
-        if model_type in ["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel"]:
+        if model_type in ["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "OrcaRouterModel"]:
             provider = Prompt.ask("[bold white]Provider[/]", default="")
             api_base = Prompt.ask("[bold white]API Base URL[/]", default="")
             api_key = Prompt.ask("[bold white]API Key[/]", default="", password=True)
@@ -211,6 +212,12 @@ def load_model(
             model_id=model_id,
             token=api_key or os.getenv("HF_API_KEY"),
             provider=provider,
+        )
+    elif model_type == "OrcaRouterModel":
+        return OrcaRouterModel(
+            model_id=model_id,
+            api_key=api_key or os.getenv("ORCAROUTER_API_KEY"),
+            api_base=api_base,
         )
     else:
         raise ValueError(f"Unsupported model type: {model_type}")

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1796,6 +1796,43 @@ class OpenAIModel(ApiModel):
 OpenAIServerModel = OpenAIModel
 
 
+class OrcaRouterModel(OpenAIModel):
+    """This model connects to the OrcaRouter API (https://orcarouter.ai), which is OpenAI-compatible.
+
+    Parameters:
+        model_id (`str`):
+            The model identifier to route through OrcaRouter (e.g. "openai/gpt-4o", "anthropic/claude-sonnet-4").
+        api_key (`str`, *optional*):
+            The OrcaRouter API key. If not provided, falls back to the `ORCAROUTER_API_KEY` environment variable.
+        api_base (`str`, *optional*):
+            Override the OrcaRouter base URL. Defaults to "https://api.orcarouter.ai/v1".
+        **kwargs:
+            Forwarded to `OpenAIModel`.
+    """
+
+    DEFAULT_API_BASE = "https://api.orcarouter.ai/v1"
+
+    def __init__(
+        self,
+        model_id: str,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        **kwargs,
+    ):
+        api_key = api_key or os.getenv("ORCAROUTER_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OrcaRouter API key is required. Pass it via `api_key=...` or set the "
+                "`ORCAROUTER_API_KEY` environment variable."
+            )
+        super().__init__(
+            model_id=model_id,
+            api_key=api_key,
+            api_base=api_base or self.DEFAULT_API_BASE,
+            **kwargs,
+        )
+
+
 class AzureOpenAIModel(OpenAIModel):
     """This model connects to an Azure OpenAI deployment.
 
@@ -2077,6 +2114,7 @@ MODEL_REGISTRY = {
     "OpenAIModel": OpenAIModel,
     "AzureOpenAIModel": AzureOpenAIModel,
     "AmazonBedrockModel": AmazonBedrockModel,
+    "OrcaRouterModel": OrcaRouterModel,
 }
 
 __all__ = [
@@ -2098,5 +2136,6 @@ __all__ = [
     "AzureOpenAIModel",
     "AmazonBedrockServerModel",
     "AmazonBedrockModel",
+    "OrcaRouterModel",
     "ChatMessage",
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,6 +33,7 @@ from smolagents.models import (
     MLXModel,
     Model,
     OpenAIModel,
+    OrcaRouterModel,
     TransformersModel,
     get_clean_message_list,
     get_tool_call_from_text,
@@ -589,6 +590,46 @@ class TestOpenAIModel:
             assert result.content == "This is some text"
             assert "<STOP>" not in result.content
             assert "and this should be removed" not in result.content
+
+
+class TestOrcaRouterModel:
+    def test_defaults_base_url_and_uses_env_api_key(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+        with patch("openai.OpenAI") as MockOpenAI:
+            model = OrcaRouterModel(model_id="anthropic/claude-haiku-4.5")
+        MockOpenAI.assert_called_once_with(
+            base_url="https://api.orcarouter.ai/v1",
+            api_key="env-key",
+            organization=None,
+            project=None,
+        )
+        assert model.client == MockOpenAI.return_value
+        assert model.model_id == "anthropic/claude-haiku-4.5"
+
+    def test_explicit_api_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+        with patch("openai.OpenAI") as MockOpenAI:
+            OrcaRouterModel(model_id="anthropic/claude-haiku-4.5", api_key="explicit-key")
+        assert MockOpenAI.call_args.kwargs["api_key"] == "explicit-key"
+
+    def test_custom_api_base_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+        with patch("openai.OpenAI") as MockOpenAI:
+            OrcaRouterModel(
+                model_id="anthropic/claude-haiku-4.5",
+                api_base="https://proxy.example.com/v1",
+            )
+        assert MockOpenAI.call_args.kwargs["base_url"] == "https://proxy.example.com/v1"
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="ORCAROUTER_API_KEY"):
+            OrcaRouterModel(model_id="anthropic/claude-haiku-4.5")
+
+    def test_registered_in_model_registry(self):
+        from smolagents.models import MODEL_REGISTRY
+
+        assert MODEL_REGISTRY.get("OrcaRouterModel") is OrcaRouterModel
 
 
 class TestAmazonBedrockModel:


### PR DESCRIPTION
## Summary

- Adds `OrcaRouterModel`, a thin subclass of `OpenAIModel` that targets [OrcaRouter](https://orcarouter.ai) — an OpenAI-compatible routing gateway fronting Anthropic, OpenAI, Google, DeepSeek and others. Default base URL is `https://api.orcarouter.ai/v1`; credentials read from `ORCAROUTER_API_KEY` (mirroring the env-var fallback pattern used by `AzureOpenAIModel` and `InferenceClientModel`).
- Registers the class in `MODEL_REGISTRY` (so agent `to_dict` / `from_dict` round-trips), exports via `__all__`, and wires it into the `smolagent` CLI (`load_model` dispatch, `--model-type` help text, interactive wizard choices).
- Adds five unit tests covering default base URL, env-var key fallback, explicit-key precedence, custom `api_base` override, missing-key error, and registry membership. All run offline by mocking `openai.OpenAI`.

## Why a dedicated class rather than `OpenAIModel(api_base=...)`?

Happy to drop this and just add a README snippet if you'd prefer the same pattern used for Together / OpenRouter. The argument for a dedicated class: it removes one footgun (forgetting the trailing `/v1`), gives a stable env-var convention, and shows up in the CLI's interactive wizard. If maintainers consider that too narrow, I'll close this and send a docs-only PR instead — just let me know.

## Usage

```python
from smolagents import CodeAgent, OrcaRouterModel

model = OrcaRouterModel(model_id="anthropic/claude-sonnet-4.5")  # reads ORCAROUTER_API_KEY from env
agent = CodeAgent(tools=[], model=model)
agent.run("...")
```

CLI:
```bash
smolagent "task" --model-type OrcaRouterModel --model-id anthropic/claude-sonnet-4.5
```

## Test plan

- [x] `pytest tests/test_models.py::TestOrcaRouterModel -v` — 5/5 passing offline
- [x] `pytest tests/test_models.py::TestOpenAIModel tests/test_models.py::TestAzureOpenAIModel` — neighboring classes still pass
- [x] Live smoke test: `OrcaRouterModel(model_id="anthropic/claude-haiku-4.5").generate(...)` returns expected content with populated `TokenUsage`
- [x] End-to-end `CodeAgent` run via OrcaRouter completed a multi-step task with `final_answer` correctly (Claude Sonnet 4.5, ~7s, 2326 in / 144 out tokens)