### PR TITLE
docs: fix GitHub and JavaScript wording

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -117,7 +117,7 @@ Adding a new tutorial or section is done in two steps:
 - Add a new Markdown (.md) file under `./source`.
 - Link that file in `./source/_toctree.yml` on the correct toc-tree.
 
-Make sure to put your new file under the proper section. If you have a doubt, feel free to ask in a Github Issue or PR.
+Make sure to put your new file under the proper section. If you have a doubt, feel free to ask in a GitHub issue or PR.
 
 ### Writing source documentation
 
@@ -266,4 +266,3 @@ output.
 Often, readers will try out the example before even going through the function
 or class definitions. Therefore, it is of utmost importance that the example
 works as expected.
-

--- a/examples/open_deep_research/scripts/mdconvert.py
+++ b/examples/open_deep_research/scripts/mdconvert.py
@@ -58,7 +58,7 @@ class _CustomMarkdownify(markdownify.MarkdownConverter):
         return super().convert_hn(n, el, text, convert_as_inline)  # type: ignore
 
     def convert_a(self, el: Any, text: str, convert_as_inline: bool):
-        """Same as usual converter, but removes Javascript links and escapes URIs."""
+        """Same as usual converter, but removes JavaScript links and escapes URIs."""
         prefix, suffix, text = markdownify.chomp(text)  # type: ignore
         if not text:
             return ""


### PR DESCRIPTION
Fixes two small wording issues in documentation/comments: standard GitHub issue capitalization and JavaScript capitalization. No runtime behavior changes.