### PR TITLE
fix: don't pass parent kwargs to managed agents in from_dict() (fixes #1849)

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {


### PR DESCRIPTION
## Summary
Fix MultiStepAgent.from_dict() to not override child agent configurations with parent kwargs during deserialization.

## Root Cause
In MultiStepAgent.from_dict(), parent kwargs were forwarded to child agents via `agent_class.from_dict(managed_agent_dict, **kwargs)`, causing parent's `additional_authorized_imports`, `max_steps`, etc. to override child's own config.

## Changes
- `src/smolagents/agents.py`: Removed `**kwargs` passthrough to managed agents in `from_dict()`

## Testing
- [x] All existing tests pass (619 passed, 1 unrelated pre-existing failure)
- [x] Ruff linter/formatter clean

## Related Issue
Closes #1849
