### PR TITLE
fix: evaluate_with() calls __exit__ on original context manager (fixes #2090)

### DIFF
--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1076,6 +1076,22 @@ assert cm.exited == True
     """
         evaluate_python_code(code, {}, state={})
 
+    def test_with_threading_lock(self):
+        code = """
+import threading
+lock = threading.Lock()
+with lock:
+    x = 1
+assert x == 1
+assert not lock.locked()
+"""
+        evaluate_python_code(
+            code,
+            {},
+            state={},
+            authorized_imports=["threading"],
+        )
+
     def test_with_context_manager_no_as_clause_exit_called(self):
         """Test that __exit__ is called on context managers used without 'as' clause."""
         code = """


### PR DESCRIPTION
## Summary
Fix evaluate_with() to call __exit__ on the original context manager instead of the __enter__ return value.

## Root Cause
In local_python_executor.py, evaluate_with() called .__exit__() on the return value of .__enter__() instead of the original context manager object. This breaks with statement objects like threading.Lock where __enter__ returns True (not the lock itself).

## Changes
- `src/smolagents/local_python_executor.py`: Fixed evaluate_with to save original context manager and call __exit__ on it

## Testing
- [x] All existing tests pass
- [x] Added regression test for threading.Lock with statement
- [x] Ruff linter/formatter clean

## Related Issue
Closes #2090
