### PR TITLE
fix: reset print output before syntax parsing

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -830,6 +830,15 @@ def function():
         evaluate_python_code(code, {"print": print, "range": range}, state=state)
         assert state["_print_outputs"].value == "1\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n"
 
+    def test_syntax_error_clears_previous_print_output(self):
+        state = {}
+        evaluate_python_code("print('from previous step')", BASE_PYTHON_TOOLS, state=state)
+
+        with pytest.raises(InterpreterError):
+            evaluate_python_code("print('new step')\ndef broken(", BASE_PYTHON_TOOLS, state=state)
+
+        assert state["_print_outputs"].value == ""
+
     def test_tuple_target_in_iterator(self):
         code = "for a, b in [('Ralf Weikert', 'Austria'), ('Samuel Seungwon Lee', 'South Korea')]:res = a.split()[0]"
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})


### PR DESCRIPTION
﻿Fixes #1998.

`evaluate_python_code()` used to reset `_print_outputs` after `ast.parse()`. When parsing failed with `SyntaxError`, the new step never got a fresh `PrintContainer`, so consumers could read logs from the previous successful step.

This moves the per-run executor state initialization before parsing, so syntax errors clear the current step's print buffer the same way runtime errors do.

## To verify

- `PYTHONPATH=src python -m pytest tests\test_local_python_executor.py -q -k "syntax_error_clears_previous_print_output or print_output"`
- `python -m ruff check src\smolagents\local_python_executor.py tests\test_local_python_executor.py`
- `python -m ruff format --check src\smolagents\local_python_executor.py tests\test_local_python_executor.py`
- `python -m py_compile src\smolagents\local_python_executor.py tests\test_local_python_executor.py`
- `git diff --check`

I also ran the full file with `PYTHONPATH=src python -m pytest tests\test_local_python_executor.py -q`; the result was 395 passed, 3 skipped, and 2 existing Windows-specific failures unrelated to this change:

- `TestLocalPythonExecutorSecurity.test_vulnerability_for_all_dangerous_functions[os.system]`
- `TestLocalPythonExecutorSecurity.test_vulnerability_via_dunder_call[...]`, which tries to execute `sh` on Windows
