### PR TITLE
fix: stream max-steps boundary once

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -603,9 +603,9 @@ You have been provided with these additional arguments, that you can access dire
                 yield action_step
                 self.step_number += 1
 
-        if not returned_final_answer and self.step_number == max_steps + 1:
-            final_answer = self._handle_max_steps_reached(task)
-            yield action_step
+        if not returned_final_answer:
+            final_answer, max_steps_step = self._handle_max_steps_reached(task)
+            yield max_steps_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step
@@ -622,7 +622,7 @@ You have been provided with these additional arguments, that you can access dire
             memory_step.timing.end_time = time.time()
         self.step_callbacks.callback(memory_step, agent=self)
 
-    def _handle_max_steps_reached(self, task: str) -> Any:
+    def _handle_max_steps_reached(self, task: str) -> tuple[Any, ActionStep]:
         action_step_start_time = time.time()
         final_answer = self.provide_final_answer(task)
         final_memory_step = ActionStep(
@@ -634,7 +634,7 @@ You have been provided with these additional arguments, that you can access dire
         final_memory_step.action_output = final_answer.content
         self._finalize_step(final_memory_step)
         self.memory.steps.append(final_memory_step)
-        return final_answer.content
+        return final_answer.content, final_memory_step
 
     def _generate_planning_step(
         self, task, is_first_step: bool, step: int

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -519,6 +519,36 @@ class TestAgent:
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
+    def test_stream_yields_max_steps_step_once(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=2,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+        action_steps = [step for step in steps if isinstance(step, ActionStep)]
+
+        assert [step.step_number for step in action_steps] == [1, 2, 3]
+        assert type(action_steps[-1].error) is AgentMaxStepsError
+        assert len({id(step) for step in action_steps}) == len(action_steps)
+        assert isinstance(steps[-1], FinalAnswerStep)
+
+    def test_stream_handles_zero_max_steps(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),
+            max_steps=0,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+
+        assert len(steps) == 2
+        assert isinstance(steps[0], ActionStep)
+        assert steps[0].step_number == 1
+        assert type(steps[0].error) is AgentMaxStepsError
+        assert isinstance(steps[1], FinalAnswerStep)
+
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"


### PR DESCRIPTION
## Summary

Fixes #1816.

When a streaming agent reached `max_steps`, `_run_stream()` yielded the previous `action_step` a second time after `_handle_max_steps_reached()` appended a separate max-steps error step to memory. That made stream consumers see a duplicate final action step and hid the generated max-steps error step from the stream.

This change yields the max-steps error step returned by `_handle_max_steps_reached()` instead. It also makes the `max_steps=0` boundary safe by avoiding any reference to an `action_step` that was never created.

## Validation

- `uv run --extra test pytest tests/test_agents.py::TestAgent::test_stream_yields_max_steps_step_once tests/test_agents.py::TestAgent::test_stream_handles_zero_max_steps -q`
- `uv run --extra test pytest tests/test_agents.py::TestAgent::test_fails_max_steps tests/test_agents.py::TestAgent::test_stream_yields_max_steps_step_once tests/test_agents.py::TestAgent::test_stream_handles_zero_max_steps -q`
- `uv run --extra test pytest tests/test_agents.py -q`
- `uv run --extra quality ruff check src/smolagents/agents.py tests/test_agents.py`
- `uv run --extra quality ruff format --check src/smolagents/agents.py tests/test_agents.py`
- `git diff --check`