### PR TITLE
fix: handle consecutive system messages in get_clean_message_list

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,22 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+            # Normalize content to list format for merging
+            if isinstance(message.content, str):
+                message.content = [{"type": "text", "text": message.content}]
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                prev_content = output_message_list[-1]["content"]
+                if isinstance(prev_content, str):
+                    output_message_list[-1]["content"] = prev_content + "\n" + message.content[0]["text"]
+                else:
+                    output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:
+                # Normalize previous message content to list if it's a string
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [
+                        {"type": "text", "text": output_message_list[-1]["content"]}
+                    ]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones


### PR DESCRIPTION
## Description

Fixes `AssertionError` when multiple consecutive messages share the same role (e.g., two system messages passed to `LiteLLMModel`).

## Problem

`get_clean_message_list()` merges consecutive same-role messages but asserts `isinstance(message.content, list)`. When users pass plain dict messages like `{"role": "system", "content": "text"}`, the content is a string after `ChatMessage.from_dict()`, causing the assertion to fail.

## Reproduction (from #1972)

```python
from smolagents import LiteLLMModel

model = LiteLLMModel(model_id="gemini/gemini-2.5-flash", api_key="...")
messages = [
    {"role": "system", "content": "Start with FOO"},
    {"role": "system", "content": "End with BAR"},
    {"role": "user", "content": "Say ."},
]
response = model(messages)  # AssertionError: Error: wrong content: Start with FOO
```

## Fix

Normalize string content to list format `[{"type": "text", "text": ...}]` before merging, for both the incoming message and the existing output message. Handles all content type combinations (string+string, string+list, list+string, list+list).

## Changes

- `src/smolagents/models.py`: `get_clean_message_list()` — added content normalization before the merge assertion

Fixes #1972