### PR TITLE
fix: remove duplicate action_step yield and prevent NameError when max_steps=0

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -605,7 +605,6 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step


### PR DESCRIPTION
## Description

Fixes two bugs in `MultiStepAgent._run_stream()`:

1. **Duplicate yield**: When `max_steps` is reached, `action_step` was yielded in the `finally` block AND again after the while loop. Stream consumers received duplicate step events.

2. **NameError when max_steps=0**: If `max_steps=0`, the while loop never executes, so `action_step` is never defined. The post-loop `yield action_step` raises `NameError`.

## Fix

Remove the redundant `yield action_step` after the while loop. The `finally` block already yields every `action_step` on each iteration, and `_handle_max_steps_reached()` handles the max-steps case without needing to re-yield.

## One-line change

```diff
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
```

Fixes #1816