### PR TITLE
fix: don't pass parent kwargs to managed agents in from_dict()

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {


### PR DESCRIPTION
## Description

Fixes managed agents losing their custom configurations (e.g., `additional_authorized_imports`) after deserialization via `from_dict()`.

## Problem

`MultiStepAgent.from_dict()` passes the parent agent's `**kwargs` to child managed agents:

```python
managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
```

This causes the parent's kwargs to override the child's own serialized configuration. For example, if the parent has no `additional_authorized_imports` but the child has `["sympy"]`, the child loses its imports after deserialization.

## Fix

Don't forward parent kwargs to managed agents:

```python
managed_agent = agent_class.from_dict(managed_agent_dict)
```

Each managed agent's configuration is self-contained in its serialized dict — it doesn't need (and shouldn't receive) the parent's overrides.

## Reproduction (from #1849)

```python
sub_agent = CodeAgent(tools=[], model=model, additional_authorized_imports=["sympy"])
main_agent = CodeAgent(tools=[], model=model, managed_agents=[sub_agent])

# Serialize and deserialize
restored = CodeAgent.from_dict(main_agent.to_dict())

# Before fix: restored sub-agent loses 'sympy' import
# After fix: restored sub-agent retains 'sympy' import
```

Fixes #1849