### PR TITLE
docs: add Tuning Engines OpenAI-compatible endpoint

### DIFF
--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -78,6 +78,35 @@ model = OpenAIModel(
 )
 ```
 
+## Using Tuning Engines
+
+Tuning Engines exposes an OpenAI-compatible endpoint for teams that want to run
+`smolagents` agents through a governed AI control plane. The agent code remains
+the same, while Tuning Engines can centralize model access, policy enforcement,
+audit logs, traces, and usage/cost reporting.
+
+First, create an inference key in Tuning Engines and make sure the key has
+access to the model alias you want to use:
+```python
+TUNING_ENGINES_API_KEY = <YOUR-TUNING-ENGINES-INFERENCE-KEY>
+```
+
+Then, initialize the model with [`OpenAIModel`] and point `api_base` at the
+Tuning Engines API:
+```python
+from smolagents import OpenAIModel
+
+model = OpenAIModel(
+    model_id="gpt-4o",
+    api_base="https://api.tuningengines.com/v1",
+    api_key=TUNING_ENGINES_API_KEY,
+)
+```
+
+This is useful when your application team wants to keep using `smolagents` for
+agent behavior and tools, while platform or security teams manage model routing,
+allowed models, policy checks, and traceability in one place.
+
 ## Using xAI's Grok Models
 
 xAI's Grok models can be accessed through [`LiteLLMModel`].


### PR DESCRIPTION
## Summary
- add a small Tuning Engines example to the existing model-provider docs
- show the OpenAI-compatible base URL and TUNING_ENGINES_API_KEY setup
- clarify that smolagents continues to own agent behavior and tools while Tuning Engines handles governed model access, policy, traces, and usage/cost reporting

## Why
We are an AI infrastructure team using smolagents with Tuning Engines. Since this page already documents alternate OpenAI-compatible model endpoints such as OpenRouter, this gives teams using Tuning Engines a copy-paste setup path without changing their agent code. It would mean a lot to us if you are open to including it, and I am happy to adjust wording or placement to match the project style.

## Validation
- git diff --check