### PR TITLE
security: reject legacy unprefixed pickle format

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -328,22 +328,11 @@ class SafeSerializer:
             )
             return pickle.loads(base64.b64decode(data[7:]))
         else:
-            # No prefix - legacy format, assume pickle
-            if not allow_pickle:
-                raise SerializationError(
-                    "Pickle data rejected: allow_pickle=False requires safe-only data. "
-                    "This data appears to be pickle-serialized (legacy format). To deserialize it, set "
-                    "allow_pickle=True (not recommended for untrusted data)."
-                )
-            # Warn about insecure pickle deserialization
-            import warnings
-
-            warnings.warn(
-                "Deserializing pickle data. This is a security risk if the data is untrusted.",
-                FutureWarning,
-                stacklevel=2,
+            # No prefix - unknown format, reject for security
+            raise SerializationError(
+                "Unknown serialization format. Data must start with a recognized prefix "
+                f"({SafeSerializer.SAFE_PREFIX!r} for safe JSON, or 'pickle:' for pickle)."
             )
-            return pickle.loads(base64.b64decode(data))
 
     @staticmethod
     def _extract_method_body(method) -> str:
@@ -442,10 +431,7 @@ class SafeSerializer:
                 raise SerializationError("Pickle data rejected: allow_pickle=False")
             return pickle.loads(base64.b64decode(data[7:]))
         else:
-            # Legacy format (no prefix) - assume pickle
-            if not allow_pickle:
-                raise SerializationError("Pickle data rejected: allow_pickle=False")
-            return pickle.loads(base64.b64decode(data))
+            raise SerializationError("Unknown serialization format")
 '''
 
     @staticmethod
@@ -477,15 +463,8 @@ class SafeSerializer:
                 "        import pickle",
                 "        return pickle.loads(base64.b64decode(data[7:]))",
             ]
-            legacy_pickle_branch = [
-                "        import pickle",
-                "        return pickle.loads(base64.b64decode(data))",
-            ]
         else:
             prefixed_pickle_branch = [
-                '        raise SerializationError("Pickle data rejected: allow_pickle=False")',
-            ]
-            legacy_pickle_branch = [
                 '        raise SerializationError("Pickle data rejected: allow_pickle=False")',
             ]
 
@@ -507,8 +486,7 @@ class SafeSerializer:
             '    elif isinstance(data, str) and data.startswith("pickle:"):',
             *prefixed_pickle_branch,
             "    else:",
-            "        # No safe prefix - legacy format, assume pickle",
-            *legacy_pickle_branch,
+            '        raise SerializationError("Unknown serialization format")',
             "",
         ]
         return "\n".join(lines)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -63,8 +63,8 @@ class TestSafeSerializationSecurity:
         # Create pickle data (no "safe:" prefix)
         pickle_data = base64.b64encode(pickle.dumps({"test": "data"})).decode()
 
-        # Should raise error in safe mode
-        with pytest.raises(SerializationError, match="Pickle data rejected"):
+        # Should raise error in safe mode - legacy unprefixed format is now rejected
+        with pytest.raises(SerializationError, match="Unknown serialization format"):
             SafeSerializer.loads(pickle_data, allow_pickle=False)
 
     def test_pickle_fallback_with_warning(self):
@@ -186,16 +186,21 @@ class TestBackwardCompatibility:
     """Test that legacy pickle data can still be read when explicitly allowed."""
 
     def test_read_legacy_pickle_data(self):
-        """Verify we can read old pickle data when allow_insecure=True."""
+        """Verify legacy pickle data requires explicit 'pickle:' prefix for security."""
 
-        # Simulate legacy pickle data (no "safe:" prefix)
+        # Legacy unprefixed pickle data is now rejected for security
         legacy_data = {"key": "value", "number": 42}
         pickle_encoded = base64.b64encode(pickle.dumps(legacy_data)).decode()
 
-        # Should work with allow_pickle=True
+        # Unprefixed pickle data is rejected even with allow_pickle=True
+        with pytest.raises(SerializationError, match="Unknown serialization format"):
+            SafeSerializer.loads(pickle_encoded, allow_pickle=True)
+
+        # Explicit 'pickle:' prefix still works with allow_pickle=True
+        explicit_pickle = "pickle:" + pickle_encoded
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = SafeSerializer.loads(pickle_encoded, allow_pickle=True)
+            result = SafeSerializer.loads(explicit_pickle, allow_pickle=True)
 
             assert result == legacy_data
             assert len(w) == 1  # Warning emitted
@@ -244,8 +249,8 @@ class TestDefaultBehavior:
         # Create pickle data
         pickle_data = base64.b64encode(pickle.dumps(obj)).decode()
 
-        # Should reject pickle data by default
-        with pytest.raises(SerializationError, match="Pickle data rejected"):
+        # Should reject unprefixed data by default (security fix)
+        with pytest.raises(SerializationError, match="Unknown serialization format"):
             SafeSerializer.loads(pickle_data)
 
 
@@ -807,14 +812,14 @@ class TestPrefixHandling:
         assert result.value == 42
 
     def test_legacy_format_detection(self):
-        """Test detection and handling of legacy format (no prefix)."""
+        """Test that legacy unprefixed format is rejected for security."""
         # Simulate legacy pickle data (no prefix)
         legacy_data = {"key": "value"}
         legacy_encoded = base64.b64encode(pickle.dumps(legacy_data)).decode()
 
-        # Should work with allow_pickle=True
-        result = SafeSerializer.loads(legacy_encoded, allow_pickle=True)
-        assert result == legacy_data
+        # Unprefixed data is now rejected even with allow_pickle=True
+        with pytest.raises(SerializationError, match="Unknown serialization format"):
+            SafeSerializer.loads(legacy_encoded, allow_pickle=True)
 
 
 class TestRealWorldScenarios:
@@ -892,6 +897,15 @@ class TestGeneratedDeserializerCode:
         payload = "pickle:" + base64.b64encode(pickle.dumps({"hello": "world"})).decode()
         result = namespace["_deserialize"](payload)
         assert result == {"hello": "world"}
+
+    def test_generated_deserializer_rejects_legacy_pickle_when_enabled(self):
+        code = SafeSerializer.get_deserializer_code(allow_pickle=True)
+        namespace = {}
+        exec(code, namespace, namespace)
+
+        payload = base64.b64encode(pickle.dumps({"hello": "world"})).decode()
+        with pytest.raises(Exception, match="Unknown serialization format"):
+            namespace["_deserialize"](payload)
 
 
 class TestConcurrency:


### PR DESCRIPTION
## Summary
`SafeSerializer.loads()` currently treats data without a recognized prefix as legacy pickle when `allow_pickle=True`. This makes the trust boundary less explicit than the documented `safe:` / `pickle:` prefix scheme.

This PR rejects unknown unprefixed data in both the main loader and the generated remote deserializer code, while preserving the explicit `pickle:` path for callers that intentionally opt in to pickle support.

## Changes
- Reject unprefixed/unknown data with `SerializationError` instead of treating it as pickle.
- Keep explicit `pickle:` deserialization behavior unchanged when `allow_pickle=True`.
- Update serialization tests and add generated-deserializer regression coverage.

## Verification
```text
python -m pytest tests/test_serialization.py -q
python -m ruff check src/smolagents/serialization.py tests/test_serialization.py
git diff --check
```

Signed-off-by: Ersa-tech <Ersa-tech@users.noreply.github.com>
