### PR TITLE
Fix print output leak on SyntaxError in local code execution

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1378,6 +1378,26 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_clears_print_outputs(self):
+        """Test that print outputs from a previous execution don't leak when a SyntaxError occurs.
+
+        See GitHub issue #1998 for details.
+        """
+        # First execution: successful code with a print
+        code_step1 = "print('Output from step 1')"
+        state = {}
+        evaluate_python_code(code_step1, BASE_PYTHON_TOOLS, state=state)
+        assert state["_print_outputs"].value == "Output from step 1\n"
+
+        # Second execution: code with a SyntaxError, reusing the same state
+        code_step2 = "print('Step 2')\na = ;"
+        with pytest.raises(InterpreterError):
+            evaluate_python_code(code_step2, BASE_PYTHON_TOOLS, state=state)
+        # The print output container should have been reset, so no leak from step 1
+        assert state["_print_outputs"].value == "", (
+            f"Expected empty print outputs after SyntaxError, got: {state['_print_outputs'].value!r}"
+        )
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Description

When `evaluate_python_code` encounters a `SyntaxError` during `ast.parse`, the state initialization (including resetting `_print_outputs`) was being skipped because it happened **after** the parse step. This caused print outputs from a previous successful execution to leak into the current step's execution logs if the current code had a syntax error.

## Root Cause

In `local_python_executor.py`, the `evaluate_python_code` function:
1. First calls `ast.parse(code)` to parse the code
2. Only then initializes `state["_print_outputs"] = PrintContainer()`

If step 1 raises a `SyntaxError`, the `PrintContainer` from the previous execution (which persists in the shared `state` dict across steps) is never reset, causing its accumulated output to appear in the error logs of the current step.

## Fix

Moved state initialization (including `_print_outputs` reset) before `ast.parse(code)`, ensuring the print container is always fresh before any code processing begins.

## Testing

- Added `test_syntax_error_clears_print_outputs` that reproduces the bug scenario: runs successful code with a print, then runs code with a SyntaxError using the same state, and asserts print outputs are empty
- All 398 existing tests continue to pass

## Related Issue

Fixes #1998
