### PR TITLE
fix: clean Docker executor on process exit

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atexit
 import base64
 import inspect
 import json
@@ -591,6 +592,7 @@ class DockerExecutor(RemotePythonExecutor):
         self.host = host
         self.port = port
         self.image_name = image_name
+        self._atexit_cleanup = None
 
         self.dockerfile_content = dockerfile_content or dedent(
             """\
@@ -650,6 +652,7 @@ class DockerExecutor(RemotePythonExecutor):
             container_kwargs["environment"] = env
 
             self.container = self.client.containers.run(self.image_name, **container_kwargs)
+            self._register_cleanup()
 
             retries = 0
             while self.container.status != "running" and retries < 5:
@@ -676,6 +679,11 @@ class DockerExecutor(RemotePythonExecutor):
             self.cleanup()
             raise RuntimeError(f"Failed to initialize Jupyter kernel: {e}") from e
 
+    def _register_cleanup(self):
+        if self._atexit_cleanup is None:
+            self._atexit_cleanup = self.cleanup
+            atexit.register(self._atexit_cleanup)
+
     def run_code_raise_errors(self, code: str) -> CodeOutput:
         """
         Execute Python code in the Docker container and return the result.
@@ -693,6 +701,14 @@ class DockerExecutor(RemotePythonExecutor):
 
     def cleanup(self):
         """Clean up the Docker container and resources."""
+        cleanup_callback = getattr(self, "_atexit_cleanup", None)
+        if cleanup_callback is not None:
+            try:
+                atexit.unregister(cleanup_callback)
+            except Exception:
+                pass
+            self._atexit_cleanup = None
+
         try:
             if hasattr(self, "container"):
                 self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -237,6 +237,8 @@ class TestDockerExecutorUnit:
             patch("requests.get") as mock_get,
             patch("requests.post") as mock_post,
             patch("websocket.create_connection"),
+            patch("smolagents.remote_executors.atexit.register") as mock_atexit_register,
+            patch("smolagents.remote_executors.atexit.unregister") as mock_atexit_unregister,
         ):
             # Setup mocks
             mock_container = MagicMock()
@@ -252,11 +254,14 @@ class TestDockerExecutorUnit:
 
             # Create executor
             executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+            cleanup_callback = mock_atexit_register.call_args.args[0]
+            assert cleanup_callback == executor.cleanup
 
             # Call cleanup
             executor.cleanup()
 
             # Verify container was stopped and removed
+            mock_atexit_unregister.assert_called_once_with(cleanup_callback)
             mock_container.stop.assert_called_once()
             mock_container.remove.assert_called_once()
 


### PR DESCRIPTION
## Summary

Fixes #2050.

`DockerExecutor` already has a `cleanup()` method, but it is only reached when user code calls it or when the object is finalized. If the host script exits with an unhandled exception or `sys.exit()` after the Jupyter container has been created, the container can stay alive and keep port 8888 bound.

This registers the existing cleanup method with `atexit` as soon as the container is created. Explicit cleanup unregisters the callback before stopping/removing the container, so normal cleanup does not leave a second shutdown callback behind.

I kept this deliberately narrow: no signal handler replacement and no Docker API behavior changes.

## Duplicate check

I checked existing PRs before opening this:

- #2074 and #2104 were earlier attempts for the same issue, both closed without merge and without maintainer rejection comments.
- There is no current open PR for #2050.

## Validation

```text
PYTHONPATH=src python -m pytest tests/test_remote_executors.py::TestDockerExecutorUnit::test_cleanup -q
python -m py_compile src/smolagents/remote_executors.py tests/test_remote_executors.py
ruff check src/smolagents/remote_executors.py tests/test_remote_executors.py
git diff --check
```
