### PR TITLE
fix: report managed agent empty failures

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -873,11 +873,17 @@ You have been provided with these additional arguments, that you can access dire
             self.prompt_templates["managed_agent"]["task"],
             variables=dict(name=self.name, task=task),
         )
-        result = self.run(full_task, **kwargs)
-        if isinstance(result, RunResult):
-            report = result.output
+        try:
+            result = self.run(full_task, **kwargs)
+        except Exception as e:
+            report = f"Sub-agent '{self.name}' failed while running: {e}"
         else:
-            report = result
+            if isinstance(result, RunResult):
+                report = result.output
+            else:
+                report = result
+            if report is None or report == "":
+                report = f"Sub-agent '{self.name}' did not produce a result."
         answer = populate_template(
             self.prompt_templates["managed_agent"]["report"], variables=dict(name=self.name, final_answer=report)
         )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -574,6 +574,25 @@ class TestAgent:
         assert agent.name == "managed_agent"
         assert agent.description == "Empty"
 
+    def test_managed_agent_reports_empty_result(self):
+        agent = CodeAgent(tools=[], model=FakeCodeModel(), name="managed_agent", description="Empty")
+        agent.run = MagicMock(return_value=None)
+
+        report = agent("Delegate this task")
+
+        assert "managed_agent" in report
+        assert "did not produce a result" in report
+
+    def test_managed_agent_reports_run_exception(self):
+        agent = CodeAgent(tools=[], model=FakeCodeModel(), name="managed_agent", description="Empty")
+        agent.run = MagicMock(side_effect=RuntimeError("tool exploded"))
+
+        report = agent("Delegate this task")
+
+        assert "managed_agent" in report
+        assert "failed while running" in report
+        assert "tool exploded" in report
+
     def test_agent_description_gets_correctly_inserted_in_system_prompt(self):
         managed_agent = CodeAgent(
             tools=[], model=FakeCodeModelFunctionDef(), name="managed_agent", description="Empty"


### PR DESCRIPTION
## Summary
- report managed-agent exceptions back to the manager instead of returning an empty result
- turn None or empty managed-agent outputs into an explicit failure report
- add regressions for empty results and raised exceptions

Fixes #2166

## To verify
- PYTHONPATH=src python -m pytest tests\test_agents.py::TestAgent::test_managed_agent_reports_empty_result tests\test_agents.py::TestAgent::test_managed_agent_reports_run_exception tests\test_agents.py::TestAgent::test_init_managed_agent -q
- python -m py_compile src\smolagents\agents.py tests\test_agents.py
- python -m ruff check src\smolagents\agents.py tests\test_agents.py
- python -m ruff format --check src\smolagents\agents.py tests\test_agents.py
- git diff --check

Note: tests\test_agents.py::TestMultiAgents::test_multiagents currently fails on this Windows checkout because Rich renders the tree as ASCII (+--) while the test expects box-drawing glyphs. The managed-agent flow itself completes before that existing display assertion.