### PR TITLE
support prompt caching for claude models to cut latency and api costs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,3 @@
 - Follow OOP principles
 - Be Pythonic: follow Python best practices and idiomatic patterns
 - Write unit tests for new functionality
-
-<!-- BRIEFED_START -->
-## [2026-06-06T14:47:54.882Z] e8b988d0a33ae2f0ca6e53a111fd21bc1aed42f3
-FILES: .github/ (dependabot.yml)
-DEPS: 11 insertions, 0 deletions
-<!-- BRIEFED_END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,9 @@
 - Follow OOP principles
 - Be Pythonic: follow Python best practices and idiomatic patterns
 - Write unit tests for new functionality
+
+<!-- BRIEFED_START -->
+## [2026-06-06T14:47:54.882Z] e8b988d0a33ae2f0ca6e53a111fd21bc1aed42f3
+FILES: .github/ (dependabot.yml)
+DEPS: 11 insertions, 0 deletions
+<!-- BRIEFED_END -->

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -487,6 +487,7 @@ class Model:
         tool_name_key: str = "name",
         tool_arguments_key: str = "arguments",
         model_id: str | None = None,
+        use_prompt_caching: bool = False,
         **kwargs,
     ):
         self.flatten_messages_as_text = flatten_messages_as_text
@@ -494,6 +495,7 @@ class Model:
         self.tool_arguments_key = tool_arguments_key
         self.kwargs = kwargs
         self.model_id: str | None = model_id
+        self.use_prompt_caching = use_prompt_caching
 
     @property
     def supports_stop_parameter(self) -> bool:
@@ -526,6 +528,29 @@ class Model:
             convert_images_to_image_urls=convert_images_to_image_urls,
             flatten_messages_as_text=flatten_messages_as_text,
         )
+        is_anthropic = self.model_id and ("claude" in self.model_id.lower() or "anthropic" in self.model_id.lower())
+        if self.use_prompt_caching and is_anthropic:
+            if len(messages_as_dicts) > 0:
+                first_msg = messages_as_dicts[0]
+                if isinstance(first_msg["content"], list) and len(first_msg["content"]) > 0:
+                    first_msg["content"][0]["cache_control"] = {"type": "ephemeral"}
+                elif isinstance(first_msg["content"], str):
+                    first_msg["content"] = [{"type": "text", "text": first_msg["content"], "cache_control": {"type": "ephemeral"}}]
+            
+            if len(messages_as_dicts) > 1:
+                second_msg = messages_as_dicts[1]
+                if isinstance(second_msg["content"], list) and len(second_msg["content"]) > 0:
+                    second_msg["content"][0]["cache_control"] = {"type": "ephemeral"}
+                elif isinstance(second_msg["content"], str):
+                    second_msg["content"] = [{"type": "text", "text": second_msg["content"], "cache_control": {"type": "ephemeral"}}]
+
+            if len(messages_as_dicts) >= 4:
+                hist_msg = messages_as_dicts[-3]
+                if isinstance(hist_msg["content"], list) and len(hist_msg["content"]) > 0:
+                    hist_msg["content"][-1]["cache_control"] = {"type": "ephemeral"}
+                elif isinstance(hist_msg["content"], str):
+                    hist_msg["content"] = [{"type": "text", "text": hist_msg["content"], "cache_control": {"type": "ephemeral"}}]
+
         # Start with messages
         completion_kwargs = {
             "messages": messages_as_dicts,
@@ -613,6 +638,7 @@ class Model:
             "organization",
             "project",
             "azure_endpoint",
+            "use_prompt_caching",
         ]:
             if hasattr(self, attribute):
                 model_dictionary[attribute] = getattr(self, attribute)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -243,6 +243,34 @@ class TestModel:
         assert isinstance(message2.role, MessageRole)
         assert message2.role == MessageRole.ASSISTANT
 
+    def test_prepare_completion_kwargs_prompt_caching(self):
+        model = Model(model_id="gpt-4", use_prompt_caching=True)
+        messages = [
+            ChatMessage(role=MessageRole.SYSTEM, content="System prompt"),
+            ChatMessage(role=MessageRole.USER, content="User message"),
+        ]
+        completion_kwargs = model._prepare_completion_kwargs(messages)
+        for msg in completion_kwargs["messages"]:
+            if isinstance(msg["content"], list):
+                assert "cache_control" not in msg["content"][0]
+            else:
+                assert "cache_control" not in msg
+
+        anthropic_model = Model(model_id="anthropic/claude-3-5-sonnet", use_prompt_caching=True)
+        messages = [
+            ChatMessage(role=MessageRole.SYSTEM, content="System prompt"),
+            ChatMessage(role=MessageRole.USER, content="User message"),
+            ChatMessage(role=MessageRole.ASSISTANT, content="Assistant message"),
+            ChatMessage(role=MessageRole.USER, content="Last user message"),
+        ]
+        completion_kwargs = anthropic_model._prepare_completion_kwargs(messages)
+        formatted_messages = completion_kwargs["messages"]
+        
+        assert formatted_messages[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert formatted_messages[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert formatted_messages[-3]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in formatted_messages[-1]["content"][0]
+
     @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="requires macOS")
     def test_get_mlx_message_no_tool(self):
         model = MLXModel(model_id="HuggingFaceTB/SmolLM2-135M-Instruct", max_tokens=10)


### PR DESCRIPTION
_**This PR adds support for ephemeral prompt caching for anthropic models (claude) within the model interaction layer.**_

1. **The Problem:** When running multi-step agent loops (like ReAct), the system prompt, available tools, and message history get sent back and forth to the model on every single step. This leads to redundant token processing, which slows down response times and increases costs.

2. **Where it matters:** For longer runs or complex agents with many tools, this can cut down token latency and costs by up to 90% since Claude can retrieve the prompt context from its cache instantly instead of reading it again.

3. Added a clean unit test in `tests/test_models.py` (`test_prepare_completion_kwargs_prompt_caching`) to ensure the headers are formatted correctly for Claude, and completely ignored for other models.