### PR TITLE
feat: add TWZRD Agent Intel MCP trust verification example

### DIFF
--- a/examples/mcp_agent_trust.py
+++ b/examples/mcp_agent_trust.py
@@ -1,0 +1,43 @@
+"""Example: Using TWZRD Agent Intel MCP server with smolagents.
+
+TWZRD Agent Intel (https://intel.twzrd.xyz) scores autonomous AI agents on Solana
+based on real transaction history. Use it to verify agent trust before routing
+value through an x402 workflow or any agent-to-agent interaction.
+
+This example connects a CodeAgent to the TWZRD MCP server via streamable-http
+and asks it to evaluate a known agent wallet.
+
+Install:
+    pip install smolagents mcp
+"""
+
+from smolagents import CodeAgent, InferenceClientModel, MCPClient
+
+
+# TWZRD Agent Intel MCP server — free tools, no API key required
+mcp_server_parameters = {
+    "url": "https://intel.twzrd.xyz/mcp",
+    "transport": "streamable-http",
+}
+
+mcp_client = MCPClient(server_parameters=mcp_server_parameters)
+
+model = InferenceClientModel()
+
+agent = CodeAgent(
+    model=model,
+    tools=mcp_client.get_tools(),
+)
+
+# score_agent returns a trust score (0–100) derived from on-chain transaction history.
+# resolve_agent maps an arbitrary identifier (Twitter handle, ENS, .sol domain) to a wallet.
+# preflight_check returns human-readable context on a wallet before committing to a payment.
+result = agent.run(
+    "Use the score_agent tool to get the trust score for wallet "
+    "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi, "
+    "then explain what the score means."
+)
+
+print(result)
+
+mcp_client.disconnect()


### PR DESCRIPTION
## Summary

Adds `examples/mcp_agent_trust.py` — a minimal working example showing how to connect a `CodeAgent` to the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server via streamable-http and query an autonomous agent's on-chain trust score.

**Why this is useful for smolagents users:**
- Demonstrates `MCPClient` with a real-world remote MCP server (streamable-http transport)
- Shows a practical agent-trust verification pattern before routing value in multi-agent or x402 workflows
- The MCP server is free to use (no API key required) and always-on at `https://intel.twzrd.xyz/mcp`

## What the example does

1. Connects `MCPClient` to `https://intel.twzrd.xyz/mcp` (streamable-http)
2. Creates a `CodeAgent` with the available tools (`score_agent`, `resolve_agent`, `preflight_check`, `verify_trust_receipt`)
3. Asks the agent to score a known Solana wallet and explain the result

## Usage

```bash
pip install smolagents mcp
python examples/mcp_agent_trust.py
```

No API key needed — the TWZRD tools are free.

## MCP server details

- **Endpoint**: `https://intel.twzrd.xyz/mcp` (streamable-http)
- **Free tools**: `score_agent`, `resolve_agent`, `preflight_check`, `verify_trust_receipt`
- **Paid tool**: `get_trust_receipt` (returns a signed verifiable trust receipt via HTTP 402)