### PR TITLE
fix: use .get() for tool_calls in AmazonBedrockModel to avoid KeyError

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],


### PR DESCRIPTION
**Problem**

When using `AmazonBedrockModel` with a cross-region inference profile 
(e.g. `us.anthropic.claude-sonnet-4-6`), the agent raises a `KeyError` 
on `tool_calls` because the Bedrock response does not always include 
a `tool_calls` key.

**Root cause**

In `models.py` line 2054:
```python
tool_calls=response["output"]["message"]["tool_calls"],
```
When the model responds without tool calls (e.g. CodeAgent writing
pure Python), the key is absent in the Bedrock response.

**Fix**
```python
tool_calls=response["output"]["message"].get("tool_calls"),
```

This is consistent with how tool_calls is handled elsewhere in the
codebase (e.g. line 152).

**Steps to reproduce**
```python
import boto3
from smolagents import CodeAgent, AmazonBedrockModel

session = boto3.Session(
    profile_name="your-profile",
    region_name="us-west-2"
)
client = session.client("bedrock-runtime")

model = AmazonBedrockModel(
    model_id="us.anthropic.claude-sonnet-4-6",
    client=client
)
agent = CodeAgent(tools=[], model=model, add_base_tools=True)
agent.run("Could you give me the 118th number in the Fibonacci sequence?")
```

Fixes #2351

