### PR TITLE
docs: avoid broken tool demo runtime link

### DIFF
--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -72,9 +72,7 @@ For the push to Hub to work, your tool will need to respect some rules:
 - If you subclass the `__init__` method, you can give it no other argument than `self`. This is because arguments set during a specific tool instance's initialization are hard to track, which prevents from sharing them properly to the hub. And anyway, the idea of making a specific class is that you can already set class attributes for anything you need to hard-code (just set `your_variable=(...)` directly under the `class YourTool(Tool):` line). And of course you can still create a class attribute anywhere in your code by assigning stuff to `self.your_variable`.
 
 
-Once your tool is pushed to Hub, you can visualize it. [Here](https://huggingface.co/spaces/m-ric/hf-model-downloads) is the `model_downloads_tool` that I've pushed. It has a nice gradio interface.
-
-When diving into the tool files, you can find that all the tool's logic is under [tool.py](https://huggingface.co/spaces/m-ric/hf-model-downloads/blob/main/tool.py). That is where you can inspect a tool shared by someone else.
+Once your tool is pushed to Hub, you can inspect the files that were exported with it. For example, the shared `model_downloads_tool` stores its implementation in [tool.py](https://huggingface.co/spaces/m-ric/hf-model-downloads/blob/main/tool.py). That is where you can inspect a tool shared by someone else without depending on the Space runtime being healthy.
 
 Then you can load the tool with [`load_tool`] or create it with [`~Tool.from_hub`] and pass it to the `tools` parameter in your agent.
 Since running tools means running custom code, you need to make sure you trust the repository, thus we require to pass `trust_remote_code=True` to load a tool from the Hub.


### PR DESCRIPTION
## Summary

Fixes #2349.

The tools tutorial currently points readers to the running `m-ric/hf-model-downloads` Space and describes it as a Gradio demo. That Space can return a runtime error when its hosted Python/Gradio dependency stack breaks, so the docs example becomes unreliable even though the exported tool source is still available.

This changes the tutorial to point at the stable `tool.py` file for the shared tool and avoids depending on the Space runtime being healthy.

## To verify

```console
git diff --check
```

I also checked that the `tool.py` Hub URL responds with HTTP 200.
