### PR TITLE
Fix stale print logs after syntax errors

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -830,6 +830,16 @@ def function():
         evaluate_python_code(code, {"print": print, "range": range}, state=state)
         assert state["_print_outputs"].value == "1\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n"
 
+    def test_syntax_error_clears_previous_print_output(self):
+        state = {}
+        evaluate_python_code("print('previous step')", BASE_PYTHON_TOOLS, state=state)
+        assert state["_print_outputs"].value == "previous step\n"
+
+        with pytest.raises(InterpreterError, match="Code parsing failed"):
+            evaluate_python_code("print('current step')\ndef bad_syntax(\n    pass", BASE_PYTHON_TOOLS, state=state)
+
+        assert state["_print_outputs"].value == ""
+
     def test_tuple_target_in_iterator(self):
         code = "for a, b in [('Ralf Weikert', 'Austria'), ('Samuel Seungwon Lee', 'South Korea')]:res = a.split()[0]"
         result, _ = evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})


### PR DESCRIPTION
## Summary

Fixes #1998.

`evaluate_python_code` initialized `_print_outputs` after `ast.parse()`. When parsing raised `SyntaxError`, the executor skipped that initialization and left the previous step's print buffer in `state`, so the next error observation could show stale logs from an earlier step.

This moves per-run executor state initialization before parsing, so syntax errors clear the current step's print buffer just like execution errors do.

## Tests

- `uv run --with pytest --with numpy --with pandas python -m pytest tests/test_local_python_executor.py::TestEvaluatePythonCode::test_syntax_error_clears_previous_print_output -q`
- `uv run --with pytest --with numpy --with pandas python -m pytest tests/test_local_python_executor.py::TestEvaluatePythonCode::test_print_output tests/test_local_python_executor.py::TestEvaluatePythonCode::test_syntax_error_clears_previous_print_output -q`
- `uv run --with ruff ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py`
- `uv run python -m py_compile src/smolagents/local_python_executor.py tests/test_local_python_executor.py`
- `git diff --check`