### PR TITLE
Fix consecutive string message merging

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -347,6 +347,17 @@ def get_clean_message_list(
     """
     output_message_list: list[dict[str, Any]] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
+
+    def _message_content_as_text(content: str | list[dict[str, Any]] | None) -> str:
+        if isinstance(content, list):
+            return content[0]["text"]
+        return content or ""
+
+    def _message_content_as_blocks(content: str | list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        if isinstance(content, list):
+            return content
+        return [{"type": "text", "text": content or ""}]
+
     for message in message_list:
         if isinstance(message, dict):
             message = ChatMessage.from_dict(message)
@@ -373,11 +384,16 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                output_message_list[-1]["content"] += "\n" + _message_content_as_text(message.content)
             else:
-                for el in message.content:
+                previous_content = output_message_list[-1]["content"]
+                if isinstance(previous_content, str) and not isinstance(message.content, list):
+                    output_message_list[-1]["content"] += "\n" + _message_content_as_text(message.content)
+                    continue
+                if isinstance(previous_content, str):
+                    output_message_list[-1]["content"] = _message_content_as_blocks(previous_content)
+                for el in _message_content_as_blocks(message.content):
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
                         output_message_list[-1]["content"][-1]["text"] += "\n" + el["text"]
@@ -385,7 +401,7 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = _message_content_as_text(message.content)
             else:
                 content = message.content
             output_message_list.append(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -265,6 +265,16 @@ class TestModel:
             {"role": MessageRole.SYSTEM, "content": "Start with FOO\nEnd with BAR"},
         ]
 
+    def test_get_clean_message_list_merges_string_with_text_blocks(self):
+        messages = [
+            {"role": "system", "content": "Start with FOO"},
+            {"role": "system", "content": [{"type": "text", "text": "End with BAR"}]},
+        ]
+
+        assert get_clean_message_list(messages) == [
+            {"role": MessageRole.SYSTEM, "content": [{"type": "text", "text": "Start with FOO\nEnd with BAR"}]},
+        ]
+
     @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="requires macOS")
     def test_get_mlx_message_no_tool(self):
         model = MLXModel(model_id="HuggingFaceTB/SmolLM2-135M-Instruct", max_tokens=10)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -243,6 +243,28 @@ class TestModel:
         assert isinstance(message2.role, MessageRole)
         assert message2.role == MessageRole.ASSISTANT
 
+    def test_get_clean_message_list_merges_consecutive_string_messages(self):
+        messages = [
+            {"role": "system", "content": "Start with FOO"},
+            {"role": "system", "content": "End with BAR"},
+            {"role": "user", "content": "Just say '.'"},
+        ]
+
+        assert get_clean_message_list(messages) == [
+            {"role": MessageRole.SYSTEM, "content": "Start with FOO\nEnd with BAR"},
+            {"role": MessageRole.USER, "content": "Just say '.'"},
+        ]
+
+    def test_get_clean_message_list_flattens_consecutive_string_messages(self):
+        messages = [
+            {"role": "system", "content": "Start with FOO"},
+            {"role": "system", "content": "End with BAR"},
+        ]
+
+        assert get_clean_message_list(messages, flatten_messages_as_text=True) == [
+            {"role": MessageRole.SYSTEM, "content": "Start with FOO\nEnd with BAR"},
+        ]
+
     @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="requires macOS")
     def test_get_mlx_message_no_tool(self):
         model = MLXModel(model_id="HuggingFaceTB/SmolLM2-135M-Instruct", max_tokens=10)


### PR DESCRIPTION
## Summary

Fixes #1972.

`get_clean_message_list` merged consecutive messages with the same role, but the merge branch assumed the later message content was always a list of content blocks. Dict inputs with string content, such as consecutive `system` messages, are converted into `ChatMessage` objects with string content and currently fail with an assertion error.

This keeps the existing block merge behavior while supporting consecutive string messages by joining them with a newline. Mixed string/block content is normalized into text blocks only when needed.

## Validation

- Reproduced on current `upstream/main`: two consecutive string `system` messages raise `AssertionError: Error: wrong content:End with BAR`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with pytest-asyncio pytest tests/test_models.py::TestModel::test_get_clean_message_list_merges_consecutive_string_messages tests/test_models.py::TestModel::test_get_clean_message_list_flattens_consecutive_string_messages tests/test_models.py::TestModel::test_get_clean_message_list_merges_string_with_text_blocks -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with pytest-asyncio pytest tests/test_models.py -k get_clean_message_list -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest python -m pytest tests/test_models.py::TestModel::test_chatmessage_from_dict_role_conversion tests/test_models.py::TestModel::test_get_clean_message_list_merges_consecutive_string_messages tests/test_models.py::TestModel::test_get_clean_message_list_flattens_consecutive_string_messages -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with litellm python -m pytest tests/test_models.py::TestLiteLLMModel::test_passing_flatten_messages -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with ruff ruff check src/smolagents/models.py tests/test_models.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run python -m py_compile src/smolagents/models.py tests/test_models.py`
- `git diff --check`

I also tried the full `tests/test_models.py` file in this lightweight local env, but it requires optional extras/fixtures that are not all installed here (`mlx_lm`, `torch`/`transformers`, `litellm`, `openai`, `shared_datadir`). The focused helper tests above cover the changed path.