### PR TITLE
docs: add Text Generation Inference (TGI) integration example

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -208,6 +208,27 @@ agent.run(
 )
 ```
 </hfoption>
+<hfoption id="Text Generation Inference (TGI)">
+
+[Text Generation Inference (TGI)](https://huggingface.co/docs/text-generation-inference) is a toolkit for deploying and serving LLMs. You can connect smolagents to a running TGI endpoint using `LiteLLMModel`.
+
+```python
+# !pip install 'smolagents[litellm]'
+from smolagents import CodeAgent, LiteLLMModel
+
+model = LiteLLMModel(
+    model_id="huggingface/tgi",
+    api_base="http://your-tgi-endpoint.com",  # replace with your TGI endpoint URL
+    api_key="YOUR_API_KEY",  # replace with your API key if required
+)
+
+agent = CodeAgent(tools=[], model=model, add_base_tools=True)
+
+agent.run(
+    "Could you give me the 118th number in the Fibonacci sequence?",
+)
+```
+</hfoption>
 <hfoption id="Azure OpenAI">
 
 To connect to Azure OpenAI, you can either use `AzureOpenAIModel` directly, or use `LiteLLMModel` and configure it accordingly.


### PR DESCRIPTION
## Summary

Adds a **Text Generation Inference (TGI)** tab to the "Pick a LLM" options block in the guided tour, showing users how to connect smolagents to a self-hosted TGI endpoint via `LiteLLMModel`.

The guided tour already covers Inference Providers, Local Transformers, OpenAI/Anthropic, Ollama, Azure OpenAI, Amazon Bedrock, and mlx-lm. TGI is a first-party HuggingFace deployment toolkit and a natural fit for this list, especially for users running their own models on-premise or in a private cloud.

**Added tab:**
```python
# !pip install 'smolagents[litellm]'
from smolagents import CodeAgent, LiteLLMModel

model = LiteLLMModel(
    model_id="huggingface/tgi",
    api_base="http://your-tgi-endpoint.com",  # replace with your TGI endpoint URL
    api_key="YOUR_API_KEY",  # replace with your API key if required
)

agent = CodeAgent(tools=[], model=model, add_base_tools=True)

agent.run(
    "Could you give me the 118th number in the Fibonacci sequence?",
)
```

## Related issue

Closes #1567

## Testing

Documentation-only change. No code logic modified.