### PR TITLE
Guard Bedrock responses when tool_calls is absent

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -601,6 +601,35 @@ class TestAmazonBedrockModel:
 
         assert model.client == MockBoto3.return_value
 
+    def test_generate_allows_missing_tool_calls(self):
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "The 118th Fibonacci number is returned."}],
+                }
+            },
+            "usage": {
+                "inputTokens": 11,
+                "outputTokens": 7,
+            },
+        }
+
+        with patch("boto3.client") as MockBoto3:
+            mock_client = MockBoto3.return_value
+            mock_client.converse.return_value = response
+
+            model = AmazonBedrockModel(model_id="us.amazon.nova-pro-v1:0")
+            messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello"}])]
+            result = model.generate(messages)
+
+        assert result.role == "assistant"
+        assert result.content == "The 118th Fibonacci number is returned."
+        assert result.tool_calls is None
+        assert result.token_usage is not None
+        assert result.token_usage.input_tokens == 11
+        assert result.token_usage.output_tokens == 7
+
 
 class TestAzureOpenAIModel:
     def test_client_kwargs_passed_correctly(self):


### PR DESCRIPTION
## Summary

Guard `AmazonBedrockModel.generate()` against Bedrock responses that omit the `tool_calls` key and add a regression test for that response shape.

## Root cause

The Bedrock adapter accessed `response["output"]["message"]["tool_calls"]` directly. When Bedrock returns a valid message without a `tool_calls` field, the adapter raises `KeyError` instead of returning a normal `ChatMessage`.

## Changes

- read `tool_calls` with `response["output"]["message"].get("tool_calls")`
- add a focused test covering a Bedrock response whose message has text content but no `tool_calls`
- keep the fix confined to the Bedrock path only

## Validation

- `python -m pytest tests/test_models.py -p no:xdist -o addopts="" -k "TestAmazonBedrockModel"`
- `ruff check src/smolagents/models.py tests/test_models.py`

## Notes

A full `tests/test_models.py` run in the local minimal environment hits unrelated optional dependency gaps (`torch`, `transformers`, `litellm`, `openai`). The Bedrock-focused regression slice added in this PR passes.