### PR TITLE
Fix duplicate max-step stream action events

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -605,7 +605,6 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -519,6 +519,32 @@ class TestAgent:
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
+    def test_stream_fails_max_steps_without_duplicate_action_step(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),  # use this callable because it never ends
+            max_steps=1,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+        action_steps = [step for step in steps if isinstance(step, ActionStep)]
+
+        assert [step.step_number for step in action_steps] == [1]
+        assert isinstance(steps[-1], FinalAnswerStep)
+
+    def test_stream_fails_max_steps_with_zero_max_steps(self):
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),  # use this callable because it never ends
+            max_steps=0,
+        )
+
+        steps = list(agent.run("What is 2 multiplied by 3.6452?", stream=True))
+
+        assert not any(isinstance(step, ActionStep) for step in steps)
+        assert isinstance(steps[-1], FinalAnswerStep)
+        assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
+
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"


### PR DESCRIPTION
## Summary

Fixes #1816.

This removes the extra `yield action_step` after the max-steps branch in `MultiStepAgent._run_stream`. The action step for the final executed iteration is already yielded from the loop `finally` block, so yielding it again sends duplicate step events to stream consumers. When `max_steps=0`, the loop never creates `action_step`, so the same line also raises `UnboundLocalError`.

## Tests

- `uv run pytest tests/test_agents.py::TestAgent::test_stream_fails_max_steps_without_duplicate_action_step tests/test_agents.py::TestAgent::test_stream_fails_max_steps_with_zero_max_steps -q`
- `uv run pytest tests/test_agents.py -k "test_fails_max_steps or test_step_number or test_end_code_appending" -q`
- `uv run ruff check src/smolagents/agents.py tests/test_agents.py`
- `uv run ruff format --check src/smolagents/agents.py tests/test_agents.py`
- `git diff --check`
- `uv run make quality`

I also ran `uv run pytest tests/test_agents.py -q`; it reported 96 passed / 2 skipped and one unrelated failure in `TestAgent::test_transformers_toolcalling_agent` because the local environment could not download `HuggingFaceTB/SmolLM2-360M-Instruct` from `https://hf-mirror.com` and had no cached copy.