### PR TITLE
Pass quantization_config through TransformersModel

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -873,6 +873,8 @@ class TransformersModel(Model):
             The device_map to initialize your model with.
         torch_dtype (`str`, *optional*):
             The torch_dtype to initialize your model with.
+        quantization_config (`Any`, *optional*):
+            A Transformers quantization config to pass to `from_pretrained`, such as `BitsAndBytesConfig`.
         trust_remote_code (bool, default `False`):
             Some models on the Hub require running remote code: for this model, you would have to set this flag to True.
         model_kwargs (`dict[str, Any]`, *optional*):
@@ -908,6 +910,7 @@ class TransformersModel(Model):
         model_id: str | None = None,
         device_map: str | None = None,
         torch_dtype: str | None = None,
+        quantization_config: Any | None = None,
         trust_remote_code: bool = False,
         model_kwargs: dict[str, Any] | None = None,
         max_new_tokens: int = 4096,
@@ -944,7 +947,9 @@ class TransformersModel(Model):
             device_map = "cuda" if torch.cuda.is_available() else "cpu"
         logger.info(f"Using device: {device_map}")
         self._is_vlm = False
-        self.model_kwargs = model_kwargs or {}
+        self.model_kwargs = dict(model_kwargs or {})
+        if quantization_config is not None:
+            self.model_kwargs["quantization_config"] = quantization_config
         self.apply_chat_template_kwargs = apply_chat_template_kwargs or {}
         try:
             self.model = AutoModelForImageTextToText.from_pretrained(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -681,6 +681,40 @@ class TestTransformersModel:
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.args == ("test-model",)
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
 
+    @pytest.mark.parametrize(
+        "patching,loader_target",
+        [
+            (
+                [
+                    (
+                        "transformers.AutoModelForImageTextToText.from_pretrained",
+                        {"side_effect": ValueError("Unrecognized configuration class")},
+                    ),
+                    ("transformers.AutoModelForCausalLM.from_pretrained", {}),
+                    ("transformers.AutoTokenizer.from_pretrained", {}),
+                ],
+                "transformers.AutoModelForCausalLM.from_pretrained",
+            ),
+            (
+                [
+                    ("transformers.AutoModelForImageTextToText.from_pretrained", {}),
+                    ("transformers.AutoProcessor.from_pretrained", {}),
+                ],
+                "transformers.AutoModelForImageTextToText.from_pretrained",
+            ),
+        ],
+    )
+    def test_init_passes_quantization_config(self, patching, loader_target):
+        with ExitStack() as stack:
+            mocks = {target: stack.enter_context(patch(target, **kwargs)) for target, kwargs in patching}
+            TransformersModel(
+                model_id="test-model",
+                device_map="cpu",
+                quantization_config="QCFG",
+            )
+
+        assert mocks[loader_target].call_args.kwargs["quantization_config"] == "QCFG"
+
 
 def test_get_clean_message_list_basic():
     messages = [


### PR DESCRIPTION
Fixes #969.

## Summary
- add a dedicated quantization_config init parameter to TransformersModel
- pass quantization_config through to the underlying Transformers from_pretrained loaders
- add regression coverage for both causal and image-text model init paths

## Testing
- $env:PYTHONPATH='src'; python -m pytest tests/test_models.py -k "TestTransformersModel" -q