### PR TITLE
Track executed CodeAgent tool calls in memory

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1752,6 +1752,15 @@ class CodeAgent(MultiStepAgent):
         truncated_output = truncate_content(str(code_output.output))
         observation += "Last output from code snippet:\n" + truncated_output
         memory_step.observations = observation
+        if code_output.executed_tool_calls:
+            memory_step.tool_calls = [
+                ToolCall(
+                    name=executed_tool_call["name"],
+                    arguments=executed_tool_call["arguments"],
+                    id=f"call_{len(self.memory.steps)}_{idx}",
+                )
+                for idx, executed_tool_call in enumerate(code_output.executed_tool_calls)
+            ]
 
         if not code_output.is_final_answer:
             execution_outputs_console += [

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1753,7 +1753,7 @@ class CodeAgent(MultiStepAgent):
         observation += "Last output from code snippet:\n" + truncated_output
         memory_step.observations = observation
         if code_output.executed_tool_calls:
-            memory_step.tool_calls = [
+            memory_step.tool_calls = memory_step.tool_calls + [
                 ToolCall(
                     name=executed_tool_call["name"],
                     arguments=executed_tool_call["arguments"],

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -916,17 +916,24 @@ def evaluate_call(
         ):
             raise InterpreterError(f"Forbidden call to dunder function: {func.__name__}")
         tracked_tool_name = get_tracked_tool_name(func_name, func, state, static_tools)
+        result = func(*args, **kwargs)
         if tracked_tool_name is not None:
             state["_executed_tool_calls"].append(
                 {
                     "name": tracked_tool_name,
-                    "arguments": serialize_tool_call_arguments(args, kwargs),
+                    "arguments": format_tool_call_arguments(args, kwargs),
                 }
             )
-        return func(*args, **kwargs)
+        return result
 
 
-def serialize_tool_call_arguments(args: list[Any], kwargs: dict[str, Any]) -> Any:
+def format_tool_call_arguments(args: list[Any], kwargs: dict[str, Any]) -> Any:
+    """Reshape tool call arguments into a normalized form for recording in memory.
+
+    Returns kwargs dict if present, positional args otherwise.
+    Note: returned values may contain arbitrary Python objects; consumers
+    that need JSON-safe output should apply their own serialization.
+    """
     if kwargs:
         if args:
             return {"args": args, "kwargs": kwargs}
@@ -948,13 +955,10 @@ def get_tracked_tool_name(
     if func_name in tracked_tool_names:
         return func_name
 
-    resolved_func = inspect.unwrap(func)
-    for name in tracked_tool_names:
-        static_tool = static_tools.get(name)
-        if static_tool is None:
-            continue
-        if inspect.unwrap(static_tool) is resolved_func:
-            return name
+    reverse_lookup = state.get("_tool_reverse_lookup")
+    if reverse_lookup is not None:
+        resolved_func = inspect.unwrap(func)
+        return reverse_lookup.get(id(resolved_func))
     return None
 
 
@@ -1811,6 +1815,11 @@ class LocalPythonExecutor(PythonExecutor):
         # Combine agent tools, base Python tools, and additional Python functions
         self.state["_tracked_tool_names"] = set(tools.keys())
         self.static_tools = {**tools, **BASE_PYTHON_TOOLS.copy(), **self.additional_functions}
+
+        # Build reverse lookup for O(1) tool name resolution by function identity
+        self.state["_tool_reverse_lookup"] = {}
+        for name, tool in tools.items():
+            self.state["_tool_reverse_lookup"][id(inspect.unwrap(tool))] = name
 
 
 __all__ = ["evaluate_python_code", "LocalPythonExecutor"]

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -915,7 +915,47 @@ def evaluate_call(
             and (func.__name__ not in ALLOWED_DUNDER_METHODS)
         ):
             raise InterpreterError(f"Forbidden call to dunder function: {func.__name__}")
+        tracked_tool_name = get_tracked_tool_name(func_name, func, state, static_tools)
+        if tracked_tool_name is not None:
+            state["_executed_tool_calls"].append(
+                {
+                    "name": tracked_tool_name,
+                    "arguments": serialize_tool_call_arguments(args, kwargs),
+                }
+            )
         return func(*args, **kwargs)
+
+
+def serialize_tool_call_arguments(args: list[Any], kwargs: dict[str, Any]) -> Any:
+    if kwargs:
+        if args:
+            return {"args": args, "kwargs": kwargs}
+        return kwargs
+    if len(args) == 1:
+        return args[0]
+    if len(args) > 1:
+        return args
+    return {}
+
+
+def get_tracked_tool_name(
+    func_name: str | None,
+    func: Callable,
+    state: dict[str, Any],
+    static_tools: dict[str, Callable],
+) -> str | None:
+    tracked_tool_names = state.get("_tracked_tool_names", set())
+    if func_name in tracked_tool_names:
+        return func_name
+
+    resolved_func = inspect.unwrap(func)
+    for name in tracked_tool_names:
+        static_tool = static_tools.get(name)
+        if static_tool is None:
+            continue
+        if inspect.unwrap(static_tool) is resolved_func:
+            return name
+    return None
 
 
 def evaluate_subscript(
@@ -1626,6 +1666,7 @@ def evaluate_python_code(
     custom_tools = custom_tools if custom_tools is not None else {}
     state["_print_outputs"] = PrintContainer()
     state["_operations_count"] = {"counter": 0}
+    state["_executed_tool_calls"] = []
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]
@@ -1672,6 +1713,7 @@ class CodeOutput:
     output: Any
     logs: str
     is_final_answer: bool
+    executed_tool_calls: list[dict[str, Any]] | None = None
 
 
 class PythonExecutor(ABC):
@@ -1755,13 +1797,19 @@ class LocalPythonExecutor(PythonExecutor):
             timeout_seconds=self.timeout_seconds,
         )
         logs = str(self.state["_print_outputs"])
-        return CodeOutput(output=output, logs=logs, is_final_answer=is_final_answer)
+        return CodeOutput(
+            output=output,
+            logs=logs,
+            is_final_answer=is_final_answer,
+            executed_tool_calls=list(self.state.get("_executed_tool_calls", [])),
+        )
 
     def send_variables(self, variables: dict[str, Any]):
         self.state.update(variables)
 
     def send_tools(self, tools: dict[str, Tool]):
         # Combine agent tools, base Python tools, and additional Python functions
+        self.state["_tracked_tool_names"] = set(tools.keys())
         self.static_tools = {**tools, **BASE_PYTHON_TOOLS.copy(), **self.additional_functions}
 
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1652,8 +1652,12 @@ def evaluate_python_code(
             A dictionary mapping variable names to values. The `state` should contain the initial inputs but will be
             updated by this function to contain all variables as they are evaluated.
             The print outputs will be stored in the state under the key "_print_outputs".
+        authorized_imports (`list[str]`):
+            The modules the evaluated code is allowed to import.
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
+        max_print_outputs_length (`int`, *optional*, defaults to `DEFAULT_MAX_LEN_OUTPUT`):
+            Maximum length of captured print output before it is truncated.
     """
     try:
         expression = ast.parse(code)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -470,7 +470,35 @@ class TestAgent:
         assert output == 7.2904
         assert agent.memory.steps[0].task == "What is 2 multiplied by 3.6452?"
         assert agent.memory.steps[2].tool_calls == [
-            ToolCall(name="python_interpreter", arguments="final_answer(7.2904)", id="call_2")
+            ToolCall(name="final_answer", arguments=7.2904, id="call_2_0")
+        ]
+
+    def test_code_agent_memory_tracks_executed_tools(self):
+        @tool
+        def repeat_text(text: str, count: int) -> str:
+            """Repeat text.
+
+            Args:
+                text: Text to repeat.
+                count: Number of repetitions.
+            """
+
+            return text * count
+
+        class FakeToolUsingCodeModel(Model):
+            def generate(self, messages, stop_sequences=None, **kwargs):
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="<code>\nresult = repeat_text(text='ha', count=2)\nfinal_answer(result)\n</code>",
+                )
+
+        agent = CodeAgent(tools=[repeat_text], model=FakeToolUsingCodeModel(), verbosity_level=10)
+        output = agent.run("Repeat text.")
+
+        assert output == "haha"
+        assert agent.memory.steps[1].tool_calls == [
+            ToolCall(name="repeat_text", arguments={"text": "ha", "count": 2}, id="call_1_0"),
+            ToolCall(name="final_answer", arguments="haha", id="call_1_1"),
         ]
 
     def test_additional_args_added_to_task(self):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -42,6 +42,7 @@ from smolagents.local_python_executor import (
     get_safe_module,
     timeout,
 )
+from smolagents.tools import tool
 
 
 # Fake function we will use as tool
@@ -51,8 +52,9 @@ def add_two(x):
 
 class TestEvaluatePythonCode:
     def assertDictEqualNoPrint(self, dict1, dict2):
-        assert {k: v for k, v in dict1.items() if k != "_print_outputs"} == {
-            k: v for k, v in dict2.items() if k != "_print_outputs"
+        ignored_keys = {"_print_outputs", "_executed_tool_calls", "_tracked_tool_names"}
+        assert {k: v for k, v in dict1.items() if k not in ignored_keys} == {
+            k: v for k, v in dict2.items() if k not in ignored_keys
         }
 
     def test_evaluate_assign(self):
@@ -1465,6 +1467,37 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         ).output
         assert res.__name__ == "target_function"
         assert res.__source__ == "def target_function():\n    return 'Hello world'"
+
+    def test_executor_tracks_agent_tool_calls(self):
+        @tool
+        def sample_tool(text: str, count: int) -> str:
+            """Repeat text.
+
+            Args:
+                text: Text to repeat.
+                count: Number of repetitions.
+            """
+
+            return text * count
+
+        executor = LocalPythonExecutor([])
+        executor.send_tools({"sample_tool": sample_tool, "final_answer": FinalAnswerTool()})
+
+        result = executor(
+            dedent(
+                """
+                alias = sample_tool
+                repeated = alias(text="ha", count=2)
+                final_answer(repeated)
+                """
+            )
+        )
+
+        assert result.output == "haha"
+        assert result.executed_tool_calls == [
+            {"name": "sample_tool", "arguments": {"text": "ha", "count": 2}},
+            {"name": "final_answer", "arguments": "haha"},
+        ]
 
     def test_evaluate_class_def_with_pass(self):
         code = dedent("""


### PR DESCRIPTION
Fixes #1724.

## Summary
- track executed tool invocations inside the local Python executor
- persist real executed tool calls in CodeAgent memory instead of only the synthetic python_interpreter placeholder when real tools were called
- preserve tool traceability even when a tool is first aliased in generated code

## Testing
- $env:PYTHONPATH='src'; python -m pytest tests/test_local_python_executor.py -k "tracks_agent_tool_calls" -q
- $env:PYTHONPATH='src'; python -m pytest tests/test_agents.py -k "fake_code_agent or memory_tracks_executed_tools" -q