### PR TITLE
Fix supports_stop_parameter for versioned o3-mini snapshots

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -428,7 +428,8 @@ def supports_stop_parameter(model_id: str) -> bool:
         bool: True if the model supports the stop parameter, False otherwise
     """
     model_name = model_id.split("/")[-1]
-    if model_name == "o3-mini":
+    if model_name == "o3-mini" or model_name.startswith("o3-mini-"):
+        # o3-mini supports `stop` (unlike o3); its dated snapshots (e.g. o3-mini-2025-01-31) do too.
         return True
     # o3* (except mini), o4*, all grok-* models, and the gpt-5* family (including versioned variants) don't support stop parameter
     openai_model_pattern = r"(o3(?:$|[-.].*)|o4(?:$|[-.].*)|gpt-5.*)"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -890,6 +890,9 @@ def test_flatten_messages_as_text_for_all_models(
         ("oci/xai.grok-3-mini", False),
         # Supported models
         ("o3-mini", True),
+        ("o3-mini-2025-01-31", True),  # versioned o3-mini still supports stop (o3-mini is exempt, unlike o3)
+        ("openai/o3-mini", True),
+        ("openai/o3-mini-2025-01-31", True),
         ("gpt-4", True),
         ("claude-3-5-sonnet", True),
         ("mistral-large", True),


### PR DESCRIPTION
## What

`supports_stop_parameter` special-cases the bare `o3-mini` id to support `stop` (o3-mini is exempt from the o3 "no `stop`" rule). But a dated snapshot like `o3-mini-2025-01-31` is not the bare string `o3-mini`, so it falls through to the `o3(?:$|[-.].*)` pattern and is incorrectly reported as **not** supporting `stop`.

As a result `stop` / `stop_sequences` is silently dropped for pinned o3-mini snapshots, while it works for `o3-mini` — an inconsistency, since a dated snapshot is the same model.

## Fix

Extend the exemption to o3-mini's versioned variants (`o3-mini-*`), matching the bare `o3-mini` behavior.

## Tests

Added cases to `test_supports_stop_parameter` for `o3-mini-2025-01-31` and the `openai/`-prefixed forms (all expected `True`). These fail on `main` and pass with the fix.
