### PR TITLE
Store per-tool observations on action steps

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1435,8 +1435,18 @@ class ToolCallingAgent(MultiStepAgent):
 
         memory_step.tool_calls = [parallel_calls[k] for k in sorted(parallel_calls.keys())]
         memory_step.observations = memory_step.observations or ""
+        memory_step.tool_observations = None
         for tool_output in [outputs[k] for k in sorted(outputs.keys())]:
             memory_step.observations += tool_output.observation + "\n"
+            if memory_step.tool_observations is None:
+                memory_step.tool_observations = []
+            memory_step.tool_observations.append(
+                {
+                    "id": tool_output.id,
+                    "name": tool_output.tool_call.name,
+                    "observation": tool_output.observation,
+                }
+            )
         memory_step.observations = (
             memory_step.observations.rstrip("\n") if memory_step.observations else memory_step.observations
         )

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -58,6 +58,7 @@ class ActionStep(MemoryStep):
     model_output: str | list[dict[str, Any]] | None = None
     code_action: str | None = None
     observations: str | None = None
+    tool_observations: list[dict[str, str]] | None = None
     observations_images: list["PIL.Image.Image"] | None = None
     action_output: Any = None
     token_usage: TokenUsage | None = None
@@ -81,6 +82,7 @@ class ActionStep(MemoryStep):
             "model_output": self.model_output,
             "code_action": self.code_action,
             "observations": self.observations,
+            "tool_observations": self.tool_observations,
             "observations_images": [image.tobytes() for image in self.observations_images]
             if self.observations_images
             else None,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2088,6 +2088,38 @@ class TestToolCallingAgent:
                     for tool_call in test_case["tool_calls"]
                 ]
 
+    def test_process_tool_calls_keeps_observations_per_tool_call(self, test_tool):
+        agent = ToolCallingAgent(tools=[test_tool], model=MagicMock())  # model output only needed for monkey patching
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value1"}),
+                ),
+                ChatMessageToolCall(
+                    id="call_2",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": "value2"}),
+                ),
+            ],
+        )
+        memory_step = ActionStep(step_number=10, timing="mock_timing", model_output="")
+
+        list(agent.process_tool_calls(chat_message, memory_step))
+
+        assert memory_step.observations == "Processed: value1\nProcessed: value2"
+        assert memory_step.tool_observations == [
+            {"id": "call_1", "name": "test_tool", "observation": "Processed: value1"},
+            {"id": "call_2", "name": "test_tool", "observation": "Processed: value2"},
+        ]
+        assert memory_step.tool_calls == [
+            ToolCall(name="test_tool", arguments={"input": "value1"}, id="call_1"),
+            ToolCall(name="test_tool", arguments={"input": "value2"}, id="call_2"),
+        ]
+
 
 class TestCodeAgent:
     def test_code_agent_instructions(self):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -116,6 +116,29 @@ def test_action_step_dict():
     assert action_step_dict["action_output"] == "Output"
 
 
+def test_action_step_dict_with_tool_observations():
+    action_step = ActionStep(
+        model_input_messages=[ChatMessage(role=MessageRole.USER, content="Hello")],
+        tool_calls=[ToolCall(id="id", name="get_weather", arguments={"location": "Paris"})],
+        timing=Timing(start_time=0.0, end_time=1.0),
+        step_number=1,
+        error=None,
+        model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content="Hi"),
+        model_output="Hi",
+        observations="This is a nice observation",
+        tool_observations=[
+            {"id": "id", "name": "get_weather", "observation": "This is a nice observation"},
+        ],
+        observations_images=[Image.new("RGB", (100, 100))],
+        action_output="Output",
+        token_usage=TokenUsage(input_tokens=10, output_tokens=20),
+    )
+    action_step_dict = action_step.dict()
+    assert action_step_dict["tool_observations"] == [
+        {"id": "id", "name": "get_weather", "observation": "This is a nice observation"},
+    ]
+
+
 def test_action_step_to_messages():
     action_step = ActionStep(
         model_input_messages=[ChatMessage(role=MessageRole.USER, content="Hello")],


### PR DESCRIPTION
Fixes #2365

## Summary
When a tool-calling action runs more than one tool call, `ActionStep.observations` keeps the combined observation text. That is still useful for existing consumers, but it makes it hard to tell which observation came from which tool call.

This keeps the existing `observations` string behavior and adds `tool_observations` as structured per-tool metadata on the action step. Each entry stores the tool call id, tool name, and observation text. The field is also included in `ActionStep.dict()` serialization.

## Tests
* `python -m pytest tests/test_agents.py -k "process_tool_calls and not stream" -q`
* `python -m pytest tests/test_memory.py -q`
* `uv run --with ruff ruff check src/smolagents/agents.py src/smolagents/memory.py tests/test_agents.py tests/test_memory.py`
* `uv run --with ruff ruff format --check src/smolagents/agents.py src/smolagents/memory.py tests/test_agents.py tests/test_memory.py`
* `git diff --check`