### PR TITLE
added authorized_imports and max_print_outputs_length to the Args section

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1608,6 +1608,11 @@ def evaluate_python_code(
             A dictionary mapping variable names to values. The `state` should contain the initial inputs but will be
             updated by this function to contain all variables as they are evaluated.
             The print outputs will be stored in the state under the key "_print_outputs".
+        authorized_imports (`List[str]`, *optional*, defaults to `BASE_BUILTIN_MODULES`):
+            The list of modules that can be imported by the code. By default, only a few safe modules are allowed.
+            If it contains "*", it will authorize any import. Use this at your own risk!
+        max_print_outputs_length (`int`, *optional*, defaults to `DEFAULT_MAX_LEN_OUTPUT`):
+            Maximum length of the print outputs.
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """


### PR DESCRIPTION
Fixes #2372

Adds the missing docstring entries for `authorized_imports` and `max_print_outputs_length` in `evaluate_python_code()` (`local_python_executor.py`). Both params exist in the function signature but weren't documented.