### PR TITLE
fix: reject non-serializable tools for remote executors

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -77,7 +77,7 @@ from .monitoring import (
     Monitor,
     TokenUsage,
 )
-from .remote_executors import BlaxelExecutor, DockerExecutor, E2BExecutor, ModalExecutor
+from .remote_executors import BlaxelExecutor, DockerExecutor, E2BExecutor, ModalExecutor, RemotePythonExecutor
 from .tools import BaseTool, Tool, validate_tool_arguments
 from .utils import (
     AgentError,
@@ -1582,6 +1582,8 @@ class CodeAgent(MultiStepAgent):
             )
         self.executor_type = executor_type
         self.executor_kwargs: dict[str, Any] = executor_kwargs or {}
+        if executor is None and self.executor_type in {"blaxel", "e2b", "modal", "docker"} and not self.managed_agents:
+            RemotePythonExecutor.validate_tools_are_remote_serializable(self.tools, self.logger)
         self.python_executor = executor or self.create_python_executor()
 
     def __enter__(self):

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -94,11 +94,12 @@ class RemotePythonExecutor(PythonExecutor):
     def send_tools(self, tools: dict[str, Tool]):
         if "final_answer" in tools:
             self._patch_final_answer_with_exception(tools["final_answer"])
+        tool_dicts, code = self.validate_tools_are_remote_serializable(tools, self.logger)
         # Install tool packages
         packages_to_install = {
             pkg
-            for tool in tools.values()
-            for pkg in tool.to_dict()["requirements"]
+            for tool_dict in tool_dicts.values()
+            for pkg in tool_dict["requirements"]
             if pkg not in self.installed_packages + ["smolagents"]
         }
         if "PIL" in packages_to_install:
@@ -107,10 +108,49 @@ class RemotePythonExecutor(PythonExecutor):
         if packages_to_install:
             self.installed_packages += self.install_packages(list(packages_to_install))
         # Get tool definitions
-        code = get_tools_definition_code(tools)
         if code:
             code_output = self.run_code_raise_errors(code)
             self.logger.log(code_output.logs)
+
+    @classmethod
+    def validate_tools_are_remote_serializable(cls, tools: dict[str, Tool], logger) -> tuple[dict[str, dict], str]:
+        tool_dicts = cls._get_tool_dicts(tools, logger)
+        code = cls._get_tools_definition_code(tools, logger)
+        return tool_dicts, code
+
+    @classmethod
+    def _get_tool_dicts(cls, tools: dict[str, Tool], logger) -> dict[str, dict]:
+        tool_dicts = {}
+        for tool_name, tool in tools.items():
+            try:
+                tool_dicts[tool_name] = tool.to_dict()
+            except Exception as e:
+                cls._raise_remote_tool_serialization_error(tool_name, tool, e, logger)
+        return tool_dicts
+
+    @classmethod
+    def _get_tools_definition_code(cls, tools: dict[str, Tool], logger) -> str:
+        try:
+            return get_tools_definition_code(tools)
+        except Exception as e:
+            for tool_name, tool in tools.items():
+                try:
+                    get_tools_definition_code({tool_name: tool})
+                except Exception as single_tool_error:
+                    cls._raise_remote_tool_serialization_error(tool_name, tool, single_tool_error, logger)
+            raise AgentError(f"Could not send tools to the remote Python executor: {e}", logger) from e
+
+    @staticmethod
+    def _raise_remote_tool_serialization_error(tool_name: str, tool: Tool, error: Exception, logger):
+        error_summary = str(error).splitlines()[0] if str(error) else repr(error)
+        raise AgentError(
+            f"Tool {tool_name!r} ({type(tool).__name__}) cannot be sent to a remote Python executor because it "
+            "cannot be serialized into standalone Python source. Remote executors support self-contained Tool "
+            'subclasses or @tool functions. Use executor_type="local" for runtime adapter tools such as MCP tools, '
+            "or wrap the integration in a serializable Tool subclass that can reconnect from inside the remote "
+            f"environment. Original error: {type(error).__name__}: {error_summary}",
+            logger,
+        ) from error
 
     def send_variables(self, variables: dict[str, Any]):
         """Send variables to the kernel namespace using SafeSerializer.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2247,6 +2247,37 @@ print("Ok, calculation done!")""")
         agent.run("Test run")
         assert "open" in agent.python_executor.static_tools
 
+    def test_remote_executor_rejects_runtime_adapter_tools_before_starting_executor(self):
+        class MCPAdaptTool(Tool):
+            skip_forward_signature_validation = True
+
+            def __init__(self, name: str, description: str, inputs: dict, output_type: str):
+                self.name = name
+                self.description = description
+                self.inputs = inputs
+                self.output_type = output_type
+                super().__init__()
+
+            def forward(self, **kwargs):
+                return kwargs
+
+        tool = MCPAdaptTool(
+            name="list_tables",
+            description="List database tables.",
+            inputs={"ref": {"type": "string", "description": "Database reference."}},
+            output_type="string",
+        )
+
+        with patch("smolagents.agents.E2BExecutor") as mock_executor:
+            with pytest.raises(AgentError) as exception_info:
+                CodeAgent(tools=[tool], model=FakeCodeModel(), executor_type="e2b")
+
+        error_message = str(exception_info.value)
+        assert "list_tables" in error_message
+        assert "MCPAdaptTool" in error_message
+        assert 'executor_type="local"' in error_message
+        mock_executor.assert_not_called()
+
     @pytest.mark.parametrize("agent_dict_version", ["v1.9", "v1.10", "v1.20"])
     def test_from_folder(self, agent_dict_version, get_agent_dict):
         agent_dict = get_agent_dict(agent_dict_version)

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -19,6 +19,7 @@ from smolagents.remote_executors import (
     RemotePythonExecutor,
 )
 from smolagents.serialization import SerializationError
+from smolagents.tools import Tool
 from smolagents.utils import AgentError
 
 from .utils.markers import require_run_all
@@ -85,6 +86,39 @@ class TestRemotePythonExecutor:
         assert executor.run_code_raise_errors.call_count == 2
         assert "!pip install wikipedia-api" == executor.run_code_raise_errors.call_args_list[0].args[0]
         assert "class WikipediaSearchTool(Tool)" in executor.run_code_raise_errors.call_args_list[1].args[0]
+
+    def test_send_tools_rejects_runtime_adapter_tools_with_clear_error(self):
+        class MCPAdaptTool(Tool):
+            skip_forward_signature_validation = True
+
+            def __init__(self, name: str, description: str, inputs: dict, output_type: str):
+                self.name = name
+                self.description = description
+                self.inputs = inputs
+                self.output_type = output_type
+                super().__init__()
+
+            def forward(self, **kwargs):
+                return kwargs
+
+        tool = MCPAdaptTool(
+            name="list_tables",
+            description="List database tables.",
+            inputs={"ref": {"type": "string", "description": "Database reference."}},
+            output_type="string",
+        )
+        executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())
+        executor.run_code_raise_errors = MagicMock()
+
+        with pytest.raises(AgentError) as exception_info:
+            executor.send_tools({"list_tables": tool})
+
+        error_message = str(exception_info.value)
+        assert "list_tables" in error_message
+        assert "MCPAdaptTool" in error_message
+        assert "remote Python executor" in error_message
+        assert 'executor_type="local"' in error_message
+        executor.run_code_raise_errors.assert_not_called()
 
 
 class TestE2BExecutorUnit:


### PR DESCRIPTION
## Summary
- preflight remote executor tools before installing packages or sending source to a remote kernel
- raise an actionable `AgentError` when runtime adapter tools such as MCP tools cannot be serialized for remote execution
- fail `CodeAgent(..., executor_type="e2b"/"docker"/"modal"/"blaxel")` before starting the remote executor when tools are incompatible

Fixes #1739.

## Validation
- `.venv/bin/python -m pytest tests/test_remote_executors.py::TestRemotePythonExecutor tests/test_agents.py::TestCodeAgent::test_remote_executor_rejects_runtime_adapter_tools_before_starting_executor`
- `.venv/bin/python -m pytest tests/test_agents.py::TestCodeAgent`
- `.venv/bin/ruff check src/smolagents/remote_executors.py src/smolagents/agents.py tests/test_remote_executors.py tests/test_agents.py`
- `.venv/bin/ruff format --check src/smolagents/remote_executors.py src/smolagents/agents.py tests/test_remote_executors.py tests/test_agents.py`