### PR TITLE
fix: mark ctypes as dangerous executor module

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -129,6 +129,7 @@ BASE_PYTHON_TOOLS = {
 # Non-exhaustive list of dangerous modules that should not be imported
 DANGEROUS_MODULES = [
     "builtins",
+    "ctypes",
     "io",
     "multiprocessing",
     "os",

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2438,6 +2438,15 @@ class TestLocalPythonExecutor:
 
 
 class TestLocalPythonExecutorSecurity:
+    def test_ctypes_is_tracked_as_dangerous_module(self):
+        import ctypes  # noqa: F401
+
+        assert "ctypes" in DANGEROUS_MODULES
+
+        executor = LocalPythonExecutor(["sys"])
+        with pytest.raises(InterpreterError, match=".*Forbidden access to module: ctypes"):
+            executor('import sys; sys.modules["ctypes"]')
+
     @pytest.mark.parametrize(
         "additional_authorized_imports, expected_error",
         [([], InterpreterError("Import of os is not allowed")), (["os"], None)],


### PR DESCRIPTION
## Summary
- Add `ctypes` to `DANGEROUS_MODULES` in `LocalPythonExecutor`
- Add a regression test covering `ctypes` access via `sys.modules`

## Test plan
- `uv run --extra test pytest tests/test_local_python_executor.py::TestLocalPythonExecutorSecurity::test_ctypes_is_tracked_as_dangerous_module -q`
- `uv run --extra test pytest tests/test_local_python_executor.py::TestLocalPythonExecutorSecurity -q`
- `uv run --extra test pytest tests/test_local_python_executor.py -q`
- `uv run --extra quality ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py`

Draft because #2094 notes the original Huntr report may still need coordination before a standalone fix is merged.

Fixes #2094