### PR TITLE
fix: use .get() for tool_calls to prevent KeyError with Bedrock cross-region profiles

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -2051,7 +2051,7 @@ class AmazonBedrockModel(ApiModel):
         return ChatMessage(
             role=response["output"]["message"]["role"],
             content=content,
-            tool_calls=response["output"]["message"]["tool_calls"],
+            tool_calls=response["output"]["message"].get("tool_calls"),
             raw=response,
             token_usage=TokenUsage(
                 input_tokens=response["usage"]["inputTokens"],


### PR DESCRIPTION
Fixes #2351. Use dict.get() to safely handle missing tool_calls key in Bedrock response, consistent with line 152.