### PR TITLE
Fix get_json_schema dropping inner schema for unions of complex types

### DIFF
--- a/src/smolagents/_function_type_hints_utils.py
+++ b/src/smolagents/_function_type_hints_utils.py
@@ -389,9 +389,9 @@ def _parse_union_type(args: tuple[Any, ...]) -> dict:
     if len(subtypes) == 1:
         # A single non-null type can be expressed directly
         return_dict = subtypes[0]
-    elif all(isinstance(subtype["type"], str) for subtype in subtypes):
-        # A union of basic types can be expressed as a list in the schema
-        return_dict = {"type": sorted([subtype["type"] for subtype in subtypes])}
+    elif all(set(subtype) == {"type"} and isinstance(subtype["type"], str) for subtype in subtypes):
+        # A union of plain types (carrying no extra schema info) can be expressed as a list of types
+        return_dict = {"type": sorted({subtype["type"] for subtype in subtypes})}
     else:
         # A union of more complex types requires "anyOf"
         return_dict = {"anyOf": subtypes}

--- a/tests/test_function_type_hints_utils.py
+++ b/tests/test_function_type_hints_utils.py
@@ -149,6 +149,24 @@ def union_types_func():
         return True if isinstance(value, int) else "string result"
 
     return process_union
+    return process_union
+
+
+@pytest.fixture
+def union_complex_types_func():
+    def process_union_complex(value: list[int] | dict[str, float]) -> str:
+        """
+        Process a value that is either a list of ints or a dict of floats.
+
+        Args:
+            value: A list of integers or a dict of floats.
+
+        Returns:
+            Processing result.
+        """
+        return "ok"
+
+    return process_union_complex
 
 
 @pytest.fixture
@@ -385,6 +403,19 @@ class TestGetJsonSchema:
         assert len(value_prop["type"]) == 2
         # Check union in return type: should be converted to "any"
         assert return_prop["type"] == "any"
+
+    def test_union_complex_types(self, union_complex_types_func):
+        """Union of complex types must preserve each member's inner schema (items/additionalProperties)."""
+        schema = get_json_schema(union_complex_types_func)
+        value_prop = schema["function"]["parameters"]["properties"]["value"]
+        # The union of two complex types should be expressed with "anyOf" so that
+        # the array item type and dict value type are not silently dropped.
+        assert "anyOf" in value_prop, value_prop
+        members = value_prop["anyOf"]
+        array_schema = next(m for m in members if m["type"] == "array")
+        object_schema = next(m for m in members if m["type"] == "object")
+        assert array_schema["items"] == {"type": "integer"}
+        assert object_schema["additionalProperties"] == {"type": "number"}
 
     def test_nested_types(self, nested_types_func):
         """Test schema generation for nested complex types."""


### PR DESCRIPTION
### Bug

`get_json_schema()` (via `_parse_union_type`) silently drops nested schema information for unions of complex types.

`_parse_union_type` collapsed *any* union whose members all carried a string `"type"` into a single `{"type": [...]}` list. That branch is only lossless for plain scalar unions. For unions of structured types it discards the members' inner schema, e.g.:

```python
def f(value: list[int] | dict[str, float]): ...
# parameter schema becomes:
{"type": ["array", "object"]}          # items / additionalProperties lost
```

The LLM therefore loses the element type of the list and the value type of the dict. It also produced invalid duplicate type lists, e.g. `list[int] | tuple[int, str]` → `{"type": ["array", "array"]}`.

### Fix

Only collapse a union into a `{"type": [...]}` list when every member is a *plain* single-key `{"type": <str>}` schema (and dedupe the result). Any member that carries extra schema keys (`items`, `additionalProperties`, `prefixItems`, `enum`, ...) now falls through to the existing `"anyOf"` branch, preserving the full per-member schema:

```python
# list[int] | dict[str, float] ->
{"anyOf": [
    {"type": "array", "items": {"type": "integer"}},
    {"type": "object", "additionalProperties": {"type": "number"}},
]}
```

Plain unions are unchanged: `int | str` still yields `{"type": ["integer", "string"]}`.

### Verification

Added `test_union_complex_types` (red before the fix, green after) and ran the affected suite on Linux / Python 3.14:

```
$ python -m pytest tests/test_function_type_hints_utils.py -q
26 passed
```

`ruff check` and `ruff format --check` pass on the changed files.
