### PR TITLE
feat(models): retry on transient server/network errors, not just rate limits

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -39,6 +39,31 @@ RETRY_WAIT = 60
 RETRY_MAX_ATTEMPTS = 3
 RETRY_EXPONENTIAL_BASE = 2
 RETRY_JITTER = True
+# HTTP status codes that are typically transient and safe to retry.
+# Rate limiting (429) is handled separately by `is_rate_limit_error`.
+TRANSIENT_STATUS_CODES = {408, 409, 425, 500, 502, 503, 504}
+# Substrings matched against the exception *type name* (provider-agnostic: openai, litellm, requests, httpx...).
+TRANSIENT_ERROR_NAMES = (
+    "timeout",
+    "connectionerror",
+    "connectionreset",
+    "apiconnectionerror",
+    "serviceunavailable",
+    "internalservererror",
+    "remoteprotocolerror",
+    "badgateway",
+)
+# Substrings matched against the exception message as a last resort, when no status code or type is available.
+TRANSIENT_ERROR_PHRASES = (
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "timed out",
+    "connection reset",
+    "connection aborted",
+    "temporarily unavailable",
+)
 STRUCTURED_GENERATION_PROVIDERS = ["cerebras", "fireworks-ai"]
 CODEAGENT_RESPONSE_FORMAT = {
     "type": "json_schema",
@@ -1154,6 +1179,10 @@ class ApiModel(Model):
             Rate limit in requests per minute.
         retry (`bool`, **optional**):
             Whether to retry on rate limit errors, up to RETRY_MAX_ATTEMPTS times. Defaults to True.
+        retry_on_transient (`bool`, **optional**):
+            Whether to also retry on transient server/network errors (e.g. 5xx, timeouts, connection
+            errors), not just rate limits. Genuine client errors (e.g. 401/404) are never retried.
+            Defaults to True.
         **kwargs:
             Additional keyword arguments to forward to the underlying model completion call.
     """
@@ -1165,18 +1194,20 @@ class ApiModel(Model):
         client: Any | None = None,
         requests_per_minute: float | None = None,
         retry: bool = True,
+        retry_on_transient: bool = True,
         **kwargs,
     ):
         super().__init__(model_id=model_id, **kwargs)
         self.custom_role_conversions = custom_role_conversions or {}
         self.client = client or self.create_client()
         self.rate_limiter = RateLimiter(requests_per_minute)
+        retry_predicate = should_retry_api_call if retry_on_transient else is_rate_limit_error
         self.retryer = Retrying(
             max_attempts=RETRY_MAX_ATTEMPTS if retry else 1,
             wait_seconds=RETRY_WAIT,
             exponential_base=RETRY_EXPONENTIAL_BASE,
             jitter=RETRY_JITTER,
-            retry_predicate=is_rate_limit_error,
+            retry_predicate=retry_predicate,
             reraise=True,
             before_sleep_logger=(logger, logging.INFO),
             after_logger=(logger, logging.INFO),
@@ -1200,6 +1231,34 @@ def is_rate_limit_error(exception: BaseException) -> bool:
         or "too many requests" in error_str
         or "rate_limit" in error_str
     )
+
+
+def is_transient_error(exception: BaseException) -> bool:
+    """Check if the exception looks like a transient server/network error worth retrying.
+
+    This prefers structured signals (HTTP status code, exception type name) over raw string
+    matching, so that genuine client errors (e.g. 401/404) or unrelated bugs are not retried.
+    Rate limiting is intentionally excluded here: it is handled by `is_rate_limit_error`.
+    """
+    # 1. HTTP status code, read from the exception itself or its attached response object.
+    status = getattr(exception, "status_code", None)
+    if status is None:
+        response = getattr(exception, "response", None)
+        status = getattr(response, "status_code", None)
+    if isinstance(status, int) and status in TRANSIENT_STATUS_CODES:
+        return True
+    # 2. Exception type name (covers openai/litellm/requests/httpx timeout & connection errors).
+    type_name = type(exception).__name__.lower()
+    if any(name in type_name for name in TRANSIENT_ERROR_NAMES):
+        return True
+    # 3. Last-resort phrase match for providers that only expose a plain message.
+    error_str = str(exception).lower()
+    return any(phrase in error_str for phrase in TRANSIENT_ERROR_PHRASES)
+
+
+def should_retry_api_call(exception: BaseException) -> bool:
+    """Combined retry predicate: retry on rate-limit OR transient server/network errors."""
+    return is_rate_limit_error(exception) or is_transient_error(exception)
 
 
 class LiteLLMModel(ApiModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,9 @@ from huggingface_hub import ChatCompletionOutputMessage
 
 from smolagents.default_tools import FinalAnswerTool
 from smolagents.models import (
+    RETRY_WAIT,
     AmazonBedrockModel,
+    ApiModel,
     AzureOpenAIModel,
     ChatMessage,
     ChatMessageToolCall,
@@ -37,8 +39,11 @@ from smolagents.models import (
     get_clean_message_list,
     get_tool_call_from_text,
     get_tool_json_schema,
+    is_rate_limit_error,
+    is_transient_error,
     parse_json_if_needed,
     remove_content_after_stop_sequences,
+    should_retry_api_call,
     supports_stop_parameter,
 )
 from smolagents.tools import tool
@@ -1078,3 +1083,93 @@ def test_tool_calls_json_serialization(model_class, model_id):
     assert len(data["tool_calls"]) > 0
     assert data["tool_calls"][0]["function"]["name"] == "final_answer"
     assert data["tool_calls"][0]["function"]["arguments"] == "test_result"
+
+
+class _FakeApiError(Exception):
+    """Minimal exception mimicking a provider SDK error that carries an HTTP status code."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TestApiModelRetry:
+    @pytest.mark.parametrize(
+        "exception, expected",
+        [
+            # Structured status codes
+            (_FakeApiError("503 Service Unavailable", status_code=503), True),
+            (_FakeApiError("500 Internal Server Error", status_code=500), True),
+            (_FakeApiError("408 Request Timeout", status_code=408), True),
+            # Exception type names
+            (TimeoutError("read operation timed out"), True),
+            (ConnectionError("connection reset by peer"), True),
+            # Plain-message fallback
+            (_FakeApiError("Bad Gateway"), True),
+            # Should NOT be treated as transient
+            (_FakeApiError("401 Unauthorized", status_code=401), False),
+            (_FakeApiError("404 Not Found", status_code=404), False),
+            (_FakeApiError("invalid request: missing field"), False),
+            # Rate-limit is handled by is_rate_limit_error, not here
+            (_FakeApiError("429 Too Many Requests", status_code=429), False),
+        ],
+    )
+    def test_is_transient_error(self, exception, expected):
+        assert is_transient_error(exception) is expected
+
+    @pytest.mark.parametrize(
+        "exception, expected",
+        [
+            (_FakeApiError("429 Too Many Requests", status_code=429), True),  # rate limit
+            (_FakeApiError("rate_limit_exceeded"), True),  # rate limit
+            (_FakeApiError("502 Bad Gateway", status_code=502), True),  # transient
+            (TimeoutError("timed out"), True),  # transient
+            (_FakeApiError("401 Unauthorized", status_code=401), False),  # client error
+            (_FakeApiError("404 Not Found", status_code=404), False),  # client error
+        ],
+    )
+    def test_should_retry_api_call(self, exception, expected):
+        assert should_retry_api_call(exception) is expected
+
+    def test_transient_error_reads_status_from_response_attribute(self):
+        # requests/httpx-style errors expose the status code on an attached response object
+        exception = _FakeApiError("server exploded")
+        exception.response = type("Resp", (), {"status_code": 503})()
+        assert is_transient_error(exception) is True
+
+    def test_apimodel_default_retries_transient(self):
+        model = ApiModel(model_id="dummy", client=object())  # retry_on_transient defaults to True
+        assert model.retryer.retry_predicate is should_retry_api_call
+        assert model.retryer.wait_seconds == RETRY_WAIT
+
+    def test_apimodel_rate_limit_only_when_transient_disabled(self):
+        model = ApiModel(model_id="dummy", client=object(), retry_on_transient=False)
+        assert model.retryer.retry_predicate is is_rate_limit_error
+        assert model.retryer.wait_seconds == RETRY_WAIT
+
+    def test_apimodel_retries_transient_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr("smolagents.utils.time.sleep", lambda *_: None)
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _FakeApiError("503 Service Unavailable", status_code=503)
+            return "ok"
+
+        model = ApiModel(model_id="dummy", client=object(), retry_on_transient=True)
+        assert model.retryer(flaky) == "ok"
+        assert calls["n"] == 3
+
+    def test_apimodel_does_not_retry_client_error(self, monkeypatch):
+        monkeypatch.setattr("smolagents.utils.time.sleep", lambda *_: None)
+        calls = {"n": 0}
+
+        def always_401():
+            calls["n"] += 1
+            raise _FakeApiError("401 Unauthorized", status_code=401)
+
+        model = ApiModel(model_id="dummy", client=object(), retry_on_transient=True)
+        with pytest.raises(_FakeApiError):
+            model.retryer(always_401)
+        assert calls["n"] == 1  # no retry on genuine client error


### PR DESCRIPTION
## Summary
- **Why**: `ApiModel` only retried on rate-limit (429) errors, so a single transient failure (5xx / request timeout / connection reset) aborted an entire multi-step agent run. Long runs against flaky or self-hosted endpoints failed unnecessarily.
- Add `is_transient_error()` that classifies retryable failures by **HTTP status code and exception type first**, falling back to message matching only as a last resort.
- Add `should_retry_api_call()` (rate-limit OR transient) and wire it into `ApiModel` behind a new `retry_on_transient: bool = True` flag.
- The existing rate-limit detection and backoff timing are unchanged; the new behavior is fully opt-out via `retry_on_transient=False`.

## Test Plan
- `pytest tests/test_models.py::TestApiModelRetry` — 21 cases: status-code / type-name / message classification, `response.status_code` lookup, 401/404 not retried, 429 routed to the rate-limit path, predicate + backoff wiring, and end-to-end "retry transient then succeed" / "client error -> no retry".
- `pytest "tests/test_models.py::TestLiteLLMModel::test_retry_on_rate_limit_error"` — pre-existing rate-limit retry test still passes unchanged (backoff timing preserved).
- `ruff check src/smolagents/models.py tests/test_models.py` — clean.

## Security Notes
- Not a security fix; no new external input is trusted, logged, or executed.
- Retries remain bounded by the existing `RETRY_MAX_ATTEMPTS` + exponential backoff, so this does not enable unbounded request amplification.
- The predicate deliberately excludes auth/authorization and other 4xx client errors, so misconfigured credentials still fail fast rather than being retried.
- No change to the code-execution / sandbox model.
