### PR TITLE
Reset print buffer before parsing code

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1378,6 +1378,16 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_resets_print_outputs(self):
+        state = {}
+        evaluate_python_code("print('previous step')", {"print": print}, state=state)
+        assert state["_print_outputs"].value == "previous step\n"
+
+        with pytest.raises(InterpreterError, match="SyntaxError"):
+            evaluate_python_code("print('next step')\ndef broken(", {"print": print}, state=state)
+
+        assert state["_print_outputs"].value == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
## Summary

Fixes the local Python executor so each run resets `_print_outputs` before parsing code. This prevents logs from a previous successful step from appearing again when a later step fails during syntax parsing.

Closes #1998

## Tests

- `python -m pytest tests\test_local_python_executor.py::TestEvaluatePythonCode::test_syntax_error_points_error tests\test_local_python_executor.py::TestEvaluatePythonCode::test_syntax_error_resets_print_outputs -q`
- `python -m ruff check src\smolagents\local_python_executor.py tests\test_local_python_executor.py`
- `python -m ruff format --check src\smolagents\local_python_executor.py tests\test_local_python_executor.py`
- `git diff --check`