### PR TITLE
Register Docker executor cleanup at exit

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atexit
 import base64
 import inspect
 import json
@@ -591,6 +592,8 @@ class DockerExecutor(RemotePythonExecutor):
         self.host = host
         self.port = port
         self.image_name = image_name
+        self._cleaned_up = False
+        self._cleanup_callback = None
 
         self.dockerfile_content = dockerfile_content or dedent(
             """\
@@ -650,6 +653,8 @@ class DockerExecutor(RemotePythonExecutor):
             container_kwargs["environment"] = env
 
             self.container = self.client.containers.run(self.image_name, **container_kwargs)
+            self._cleanup_callback = self.cleanup
+            atexit.register(self._cleanup_callback)
 
             retries = 0
             while self.container.status != "running" and retries < 5:
@@ -693,6 +698,9 @@ class DockerExecutor(RemotePythonExecutor):
 
     def cleanup(self):
         """Clean up the Docker container and resources."""
+        if self._cleaned_up:
+            return
+
         try:
             if hasattr(self, "container"):
                 self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)
@@ -702,6 +710,14 @@ class DockerExecutor(RemotePythonExecutor):
                 del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")
+        finally:
+            if self._cleanup_callback is not None:
+                try:
+                    atexit.unregister(self._cleanup_callback)
+                except Exception:
+                    pass
+                self._cleanup_callback = None
+            self._cleaned_up = True
 
     def delete(self):
         """Ensure cleanup on deletion."""

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -260,6 +260,37 @@ class TestDockerExecutorUnit:
             mock_container.stop.assert_called_once()
             mock_container.remove.assert_called_once()
 
+    def test_cleanup_is_registered_and_idempotent(self):
+        logger = MagicMock()
+        with (
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+            patch("smolagents.remote_executors.atexit.register") as mock_register,
+            patch("smolagents.remote_executors.atexit.unregister") as mock_unregister,
+        ):
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+
+            executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+            mock_register.assert_called_once_with(executor._cleanup_callback)
+
+            executor.cleanup()
+            executor.cleanup()
+
+            mock_container.stop.assert_called_once()
+            mock_container.remove.assert_called_once()
+            mock_unregister.assert_called_once_with(mock_register.call_args.args[0])
+
 
 class CommonDockerExecutorIntegration:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
﻿## Summary

Register `DockerExecutor.cleanup()` with `atexit` after a container is started, and make cleanup idempotent. This gives normal interpreter shutdown and uncaught-exception exits another path to stop and remove the temporary Jupyter container instead of relying only on explicit cleanup or `__del__`.

This does not cover hard process termination such as `SIGKILL`, where Python cleanup hooks cannot run.

Closes #2050

## Tests

- `python -m pytest tests\test_remote_executors.py::TestDockerExecutorUnit::test_cleanup tests\test_remote_executors.py::TestDockerExecutorUnit::test_cleanup_is_registered_and_idempotent -q`
- `python -m ruff check src\smolagents\remote_executors.py tests\test_remote_executors.py`
- `python -m ruff format --check src\smolagents\remote_executors.py tests\test_remote_executors.py`
- `git diff --check`
