### PR TITLE
docs: add Groq via LiteLLMModel guide and runnable example

### DIFF
--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -115,3 +115,86 @@ model_mini = LiteLLMModel(
     max_tokens=1000
 )
 ```
+
+## Using Groq Models
+
+[Groq](https://groq.com/) is a popular LLM inference provider, valued for its low latency and free tier.
+`smolagents` does not ship a dedicated Groq model class — Groq is supported through [`LiteLLMModel`]
+by using the `groq/` model-id prefix.
+
+First, install the required dependencies:
+```bash
+pip install 'smolagents[litellm]'
+```
+
+Then, [get a Groq API key](https://console.groq.com/keys) and set it in your code:
+```python
+GROQ_API_KEY = <YOUR-GROQ-API-KEY>
+```
+
+Now, you can initialize a Groq model using the `LiteLLMModel` class with a `groq/...` `model_id`:
+```python
+from smolagents import LiteLLMModel
+
+model = LiteLLMModel(
+    model_id="groq/llama-3.3-70b-versatile",
+    api_key=GROQ_API_KEY,
+    temperature=0.1,  # recommended for more consistent code generation
+)
+```
+
+> [!TIP]
+> `smolagents` automatically sets `flatten_messages_as_text=True` for any `model_id` starting with
+> `groq/`, `ollama/` or `cerebras/`, so you do not need to pass it manually.
+
+### Available Groq models
+
+Groq's catalog changes often; the [current model list](https://console.groq.com/docs/models) is the source of truth. As of writing, the most common picks are:
+
+| Model | `model_id` | Notes |
+| --- | --- | --- |
+| Llama 3.3 70B Versatile | `groq/llama-3.3-70b-versatile` | Good default for `CodeAgent` |
+| Llama 3.1 8B Instant | `groq/llama-3.1-8b-instant` | Fastest, weaker on multi-step reasoning |
+| Mixtral 8x7B | `groq/mixtral-8x7b-32768` | Strong long-context option (32k) |
+| DeepSeek R1 Distill | `groq/deepseek-r1-distill-llama-70b` | Reasoning-style, slower but more accurate |
+
+### Prefer `CodeAgent` over `ToolCallingAgent` with Groq
+
+`ToolCallingAgent` has known tool-call format incompatibilities with the Groq API (tracked in
+issue [#1119](https://github.com/huggingface/smolagents/issues/1119)). When using Groq, prefer
+`CodeAgent` — it asks the model to write Python that calls the tools, which Groq models handle
+reliably. If you do need native tool calling, validate the result on a real task before shipping.
+
+A minimal end-to-end example with a custom tool:
+```python
+from smolagents import CodeAgent, LiteLLMModel, tool
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: Name of the city.
+    """
+    return f"Sunny, 25°C in {city}"  # replace with a real call
+
+agent = CodeAgent(
+    tools=[get_weather],
+    model=LiteLLMModel(
+        model_id="groq/llama-3.3-70b-versatile",
+        api_key=GROQ_API_KEY,
+        temperature=0.1,
+    ),
+    max_steps=6,  # cap the loop to stay within Groq's free-tier rate limits
+)
+
+print(agent.run("What is the weather in Paris?"))
+```
+
+A runnable version of this example lives at [`examples/groq_via_litellm.py`](https://github.com/huggingface/smolagents/blob/main/examples/groq_via_litellm.py).
+
+### Common gotchas
+
+- **Rate limits on the free tier.** Groq throttles aggressively; if your agent loops a lot, raise `max_steps` only when needed and consider switching to a paid tier for long runs.
+- **No `stop` parameter.** Like the xAI Grok family, Groq's OpenAI-compatible surface does not accept `stop` — don't pass it to `LiteLLMModel` (smolagents does not send one by default).
+- **Temperature = 0 is not always stable.** Llama-3.x on Groq is more deterministic at `temperature=0.1` than at exactly `0` (subtle difference, but observed by multiple users).

--- a/examples/groq_via_litellm.py
+++ b/examples/groq_via_litellm.py
@@ -1,0 +1,77 @@
+"""Example: running a smolagents CodeAgent against Groq via LiteLLMModel.
+
+Groq (https://groq.com/) is supported through the ``LiteLLMModel`` class by passing a
+``groq/<model-id>`` ``model_id``. There is no dedicated Groq model class in smolagents.
+
+Setup:
+    pip install 'smolagents[litellm]'
+    export GROQ_API_KEY=<your-key>     # get one at https://console.groq.com/keys
+
+Why ``CodeAgent`` and not ``ToolCallingAgent``?
+    ``ToolCallingAgent`` has known tool-call format incompatibilities with the Groq API
+    (see https://github.com/huggingface/smolagents/issues/1119). With Groq, prefer
+    ``CodeAgent`` — it asks the model to write Python that calls the tools, which Groq
+    models handle reliably. ``flatten_messages_as_text=True`` is set automatically for
+    ``groq/``-prefixed model ids, so you do not need to pass it.
+
+The free Groq tier is rate-limited; we cap ``max_steps`` to keep the demo well within
+the default per-minute quota.
+"""
+
+import os
+
+from smolagents import CodeAgent, LiteLLMModel, tool
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: Name of the city.
+    """
+    # Replace with a real weather API call. The body just needs to return a string.
+    return f"Sunny, 25°C in {city}"
+
+
+@tool
+def get_population(country: str) -> str:
+    """Get the approximate population of a country.
+
+    Args:
+        country: Name of the country.
+    """
+    # Toy values for demo purposes; replace with a real lookup.
+    table = {
+        "france": "~68 million",
+        "japan": "~125 million",
+        "brazil": "~215 million",
+    }
+    return table.get(country.lower(), "unknown")
+
+
+def main() -> None:
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "GROQ_API_KEY is not set. Get a key at https://console.groq.com/keys "
+            "and export it before running this example."
+        )
+
+    model = LiteLLMModel(
+        model_id="groq/llama-3.3-70b-versatile",
+        api_key=api_key,
+        temperature=0.1,  # recommended for more consistent code generation
+    )
+
+    agent = CodeAgent(
+        tools=[get_weather, get_population],
+        model=model,
+        max_steps=6,  # stay well within Groq's free-tier rate limits
+    )
+    answer = agent.run("What is the weather in Paris, and roughly how many people live in France?")
+    print(answer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Adds documentation and a runnable multi-tool example for using [Groq](https://groq.com/) as the LLM provider through `LiteLLMModel`. This plugs the most-requested gap in the multi-provider docs (the same pattern matches OpenAI, xAI, Anthropic etc. that all sit behind LiteLLM).

## Why
Groq is a popular inference provider (low latency + free tier), but the only guidance currently in the repo is buried in closed issues. New users regularly:
1. Search the repo for "groq" → find nothing
2. Try `ToolCallingAgent` with Groq → hit the tool-call format incompatibility (issue #1119)
3. File a duplicate issue

This PR plugs that gap at the docs/examples layer, where it belongs.

Refs #2163

## How
- New section **"Using Groq Models"** in `docs/source/en/examples/using_different_models.md`, placed after the existing Gemini / OpenRouter / xAI Grok sections and following the same template. It now covers:
  - `pip install 'smolagents[litellm]'`
  - Setting `GROQ_API_KEY`
  - `LiteLLMModel` snippet with `model_id="groq/llama-3.3-70b-versatile"`, `temperature=0.1`
  - A **model-picker table** of the four most common Groq ids (Llama 3.3 70B, Llama 3.1 8B, Mixtral 8x7B, DeepSeek R1 Distill), linking to Groq's live catalog as source of truth
  - Why `CodeAgent` is preferred over `ToolCallingAgent` with Groq, with a link to the tracking issue
  - A self-contained end-to-end snippet using `max_steps=6` to stay within the free-tier rate limit
  - A **"Common gotchas"** subsection: rate limits, the missing `stop` parameter (analogous to xAI Grok), and the empirical `temperature=0.1` vs `0` quirk
  - A note that `flatten_messages_as_text=True` is auto-set for `groq/...` ids
- New file `examples/groq_via_litellm.py`: a copy-pastable, runnable script that:
  - Reads `GROQ_API_KEY` from the env and exits with a helpful message if missing
  - Wires `LiteLLMModel` + `CodeAgent` + **two** custom tools (`get_weather` and `get_population`) so the agent has to chain tool calls — a more representative demo than a single-tool one
  - Calls `agent.run("What is the weather in Paris, and roughly how many people live in France?")` and prints the result
  - Has a module docstring explaining the `CodeAgent` vs `ToolCallingAgent` choice and pointing to issue #1119

## Testing
- [x] `ruff check examples/groq_via_litellm.py` → All checks passed
- [x] `ruff format --check examples/groq_via_litellm.py` → already formatted
- [x] `ast.parse` on the new example and on the Python code block embedded in the docs → both parse cleanly
- [x] Spot-checked the docs file builds against the existing toctree entry (no nav changes needed, the file path `examples/using_different_models` is already registered)
- [x] No code-only files modified, no public API change, no dependency change

## Out of scope (intentionally)
- No code change in `models.py` — the existing `LiteLLMModel` already does the right thing (auto `flatten_messages_as_text=True` for `groq/` prefix, and a clean error if `litellm` is not installed). This PR is docs + an example only.
- The reference docs (`docs/source/en/reference/...`) and the toctree were intentionally **not** touched, to keep the diff small.

## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Linked the issue (Refs #2163)
- [x] Commit message follows Conventional Commits
- [x] No unrelated changes
- [x] Lint + format pass on the new example