### PR TITLE
feat(mcp): add tool_filter predicate to MCPClient

### DIFF
--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -17,12 +17,16 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
+from collections.abc import Callable
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
 from smolagents.tools import Tool
 
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["MCPClient"]
 
@@ -56,6 +60,23 @@ class MCPClient:
             - Structured content handling (structuredContent from MCP responses)
             - JSON parsing fallback for structured data
             If False, uses the original simple text-only behavior for backwards compatibility.
+        tool_filter (Callable[[Tool], bool], optional):
+            An optional callable that receives each :class:`~smolagents.tools.Tool` discovered
+            from the MCP server and returns ``True`` to keep it or ``False`` to drop it.
+            Filtered tools are excluded from the agent's toolset and logged at DEBUG level.
+            Use this to enforce a **local allowlist / denylist** without depending on any
+            external trust-scoring service.
+
+            .. code-block:: python
+
+                # Only expose tools whose name starts with "search_"
+                with MCPClient(params, tool_filter=lambda t: t.name.startswith("search_")) as tools:
+                    ...
+
+                # Denylist specific tools
+                _DENYLIST = {"run_shell", "delete_file"}
+                with MCPClient(params, tool_filter=lambda t: t.name not in _DENYLIST) as tools:
+                    ...
 
     Example:
         ```python
@@ -87,6 +108,7 @@ class MCPClient:
         server_parameters: "StdioServerParameters" | dict[str, Any] | list["StdioServerParameters" | dict[str, Any]],
         adapter_kwargs: dict[str, Any] | None = None,
         structured_output: bool | None = None,
+        tool_filter: Callable[[Tool], bool] | None = None,
     ):
         # Handle future warning for structured_output default value change
         if structured_output is None:
@@ -118,12 +140,19 @@ class MCPClient:
         self._adapter = MCPAdapt(
             server_parameters, SmolAgentsAdapter(structured_output=structured_output), **adapter_kwargs
         )
+        self._tool_filter = tool_filter
         self._tools: list[Tool] | None = None
         self.connect()
 
     def connect(self):
         """Connect to the MCP server and initialize the tools."""
         self._tools: list[Tool] = self._adapter.__enter__()
+        if self._tool_filter is not None and self._tools:
+            before = len(self._tools)
+            self._tools = [t for t in self._tools if self._tool_filter(t)]
+            after = len(self._tools)
+            if after < before:
+                logger.debug("MCPClient tool_filter dropped %d of %d tools", before - after, before)
 
     def disconnect(
         self,

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -50,6 +50,34 @@ def structured_output_server_script():
     )
 
 
+@pytest.fixture
+def multi_tool_server_script():
+    return dedent(
+        '''
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("Multi Tool Server")
+
+        @mcp.tool()
+        def search_docs(query: str) -> str:
+            """Search documentation"""
+            return f"Results for: {query}"
+
+        @mcp.tool()
+        def run_shell(cmd: str) -> str:
+            """Run a shell command"""
+            return f"Ran: {cmd}"
+
+        @mcp.tool()
+        def delete_file(path: str) -> str:
+            """Delete a file"""
+            return f"Deleted: {path}"
+
+        mcp.run()
+        '''
+    )
+
+
 # Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
 @pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
 def test_mcp_client_with_syntax(echo_server_script: str):
@@ -129,3 +157,52 @@ def test_multiple_servers(echo_server_script: str):
         assert tools[1].name == "echo_tool"
         assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
         assert tools[1].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
+
+
+# ── tool_filter tests ──────────────────────────────────────────────
+
+
+def test_tool_filter_allowlist(multi_tool_server_script: str):
+    """tool_filter keeps only tools matching a name prefix."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", multi_tool_server_script])
+    with MCPClient(
+        server_parameters,
+        structured_output=False,
+        tool_filter=lambda t: t.name.startswith("search_"),
+    ) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "search_docs"
+
+
+def test_tool_filter_denylist(multi_tool_server_script: str):
+    """tool_filter drops tools in a denylist."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", multi_tool_server_script])
+    _DENYLIST = {"run_shell", "delete_file"}
+    with MCPClient(
+        server_parameters,
+        structured_output=False,
+        tool_filter=lambda t: t.name not in _DENYLIST,
+    ) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "search_docs"
+
+
+def test_tool_filter_drops_all(multi_tool_server_script: str):
+    """When the filter rejects every tool, get_tools returns an empty list."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", multi_tool_server_script])
+    with MCPClient(
+        server_parameters,
+        structured_output=False,
+        tool_filter=lambda t: False,
+    ) as tools:
+        assert tools == []
+
+
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
+def test_tool_filter_default_none(echo_server_script: str):
+    """Default (no filter) preserves backward compatibility — all tools kept."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
+    with MCPClient(server_parameters) as tools:
+        assert len(tools) == 1
+        assert tools[0].name == "echo_tool"


### PR DESCRIPTION
## What

Add an optional `tool_filter: Callable[[Tool], bool]` parameter to `MCPClient`. When set, every tool discovered from the MCP server is passed through the predicate; tools returning `False` are dropped from the agent tool set.

## Why

`smoagents` MCP client currently exposes **all** tools from a server unconditionally. For untrusted or third-party servers this is risky — a server might advertise `run_shell` or `delete_file` alongside benign tools. The agent has no way to limit exposure without wrapping the entire `MCPClient`.

This adds a **local-only, zero-dependency** mechanism that fits `smolagents` minimal-abstractions philosophy. No external trust-scoring service required.

## How

```python
# Allowlist: only expose search_* tools
with MCPClient(params, tool_filter=lambda t: t.name.startswith("search_")) as tools:
    ...

# Denylist: block dangerous tools
DENYLIST = {"run_shell", "delete_file"}
with MCPClient(params, tool_filter=lambda t: t.name not in DENYLIST) as tools:
    ...
```

- `tool_filter` stored as `self._tool_filter` in `__init__`
- Applied in `connect()` after tools are discovered
- Logs dropped-tool count at DEBUG level
- `None` (default) = no filtering, full backward compatibility

## Tests

4 new tests:
- `test_tool_filter_allowlist` — keep only matching tools
- `test_tool_filter_denylist` — drop specific tools  
- `test_tool_filter_drops_all` — empty result when all rejected
- `test_tool_filter_default_none` — backward compat when no filter

Related: #2303, #2305