### PR TITLE
feat: add unique media output naming for images and audio

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -329,6 +329,7 @@ class MultiStepAgent(ABC):
         self.step_number = 0
         self.planning_interval = planning_interval
         self.state: dict[str, Any] = {}
+        self._media_counters: dict[str, int] = {"image": 0, "audio": 0}
         self.name = self._validate_name(name)
         self.description = description
         self.provide_run_summary = provide_run_summary
@@ -1390,11 +1391,17 @@ class ToolCallingAgent(MultiStepAgent):
             tool_call_result = self.execute_tool_call(tool_name, tool_arguments)
             tool_call_result_type = type(tool_call_result)
             if tool_call_result_type in [AgentImage, AgentAudio]:
-                if tool_call_result_type == AgentImage:
-                    observation_name = "image.png"
+                # Check if tool has a custom output_name, otherwise use counter-based naming
+                tool = self.tools.get(tool_name)
+                custom_name = getattr(tool, "output_name", None) if tool else None
+                if custom_name:
+                    observation_name = custom_name
+                elif tool_call_result_type == AgentImage:
+                    self._media_counters["image"] += 1
+                    observation_name = f"image_{self._media_counters['image']}.png"
                 elif tool_call_result_type == AgentAudio:
-                    observation_name = "audio.mp3"
-                # TODO: tool_call_result naming could allow for different names of same type
+                    self._media_counters["audio"] += 1
+                    observation_name = f"audio_{self._media_counters['audio']}.wav"
                 self.state[observation_name] = tool_call_result
                 observation = f"Stored '{observation_name}' in memory."
             else:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -1058,114 +1058,135 @@ class ToolCollection:
             yield cls(tools)
 
 
-def tool(tool_function: Callable) -> Tool:
+def tool(tool_function: Callable | None = None, *, output_name: str | None = None) -> Callable:
     """
     Convert a function into an instance of a dynamically created Tool subclass.
 
     Args:
-        tool_function (`Callable`): Function to convert into a Tool subclass.
+        tool_function (`Callable`, *optional*): Function to convert into a Tool subclass.
             Should have type hints for each input and a type hint for the output.
             Should also have a docstring including the description of the function
             and an 'Args:' part where each argument is described.
+        output_name (`str`, *optional*): Custom filename for media outputs (images/audio).
+            If not provided, counter-based naming is used (e.g., "image_1.png").
+
+    Example:
+        ```python
+        @tool
+        def my_tool(x: int) -> str:
+            return str(x)
+
+        @tool(output_name="my_image.png")
+        def generate_image() -> AgentImage:
+            ...
+        ```
     """
-    tool_json_schema = get_json_schema(tool_function)["function"]
-    if "return" not in tool_json_schema:
-        if len(tool_json_schema["parameters"]["properties"]) == 0:
-            tool_json_schema["return"] = {"type": "null"}
-        else:
-            raise TypeHintParsingException(
-                "Tool return type not found: make sure your function has a return type hint!"
-            )
+    def decorator(func: Callable) -> Tool:
+        tool_json_schema = get_json_schema(func)["function"]
+        if "return" not in tool_json_schema:
+            if len(tool_json_schema["parameters"]["properties"]) == 0:
+                tool_json_schema["return"] = {"type": "null"}
+            else:
+                raise TypeHintParsingException(
+                    "Tool return type not found: make sure your function has a return type hint!"
+                )
 
-    class SimpleTool(Tool):
-        def __init__(self):
-            self.is_initialized = True
-
-    # Set the class attributes
-    SimpleTool.name = tool_json_schema["name"]
-    SimpleTool.description = tool_json_schema["description"]
-    SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
-    SimpleTool.output_type = tool_json_schema["return"]["type"]
-
-    # Set output_schema if it exists in the JSON schema
-    if "output_schema" in tool_json_schema:
-        SimpleTool.output_schema = tool_json_schema["output_schema"]
-    elif "return" in tool_json_schema and "schema" in tool_json_schema["return"]:
-        SimpleTool.output_schema = tool_json_schema["return"]["schema"]
-
-    @wraps(tool_function)
-    def wrapped_function(*args, **kwargs):
-        return tool_function(*args, **kwargs)
-
-    # Bind the copied function to the forward method
-    SimpleTool.forward = staticmethod(wrapped_function)
-
-    # Get the signature parameters of the tool function
-    sig = inspect.signature(tool_function)
-    # - Add "self" as first parameter to tool_function signature
-    new_sig = sig.replace(
-        parameters=[inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)] + list(sig.parameters.values())
-    )
-    # - Set the signature of the forward method
-    SimpleTool.forward.__signature__ = new_sig
-
-    # Create and attach the source code of the dynamically created tool class and forward method
-    # - Get the source code of tool_function
-    tool_source = textwrap.dedent(inspect.getsource(tool_function))
-    # - Remove the tool decorator and function definition line
-    lines = tool_source.splitlines()
-    tree = ast.parse(tool_source)
-    #   - Find function definition
-    func_node = next((node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)), None)
-    if not func_node:
-        raise ValueError(
-            f"No function definition found in the provided source of {tool_function.__name__}. "
-            "Ensure the input is a standard function."
-        )
-    #   - Extract decorator lines
-    decorator_lines = ""
-    if func_node.decorator_list:
-        tool_decorators = [d for d in func_node.decorator_list if isinstance(d, ast.Name) and d.id == "tool"]
-        if len(tool_decorators) > 1:
-            raise ValueError(
-                f"Multiple @tool decorators found on function '{func_node.name}'. Only one @tool decorator is allowed."
-            )
-        if len(tool_decorators) < len(func_node.decorator_list):
-            warnings.warn(
-                f"Function '{func_node.name}' has decorators other than @tool. "
-                "This may cause issues with serialization in the remote executor. See issue #1626."
-            )
-        decorator_start = tool_decorators[0].end_lineno if tool_decorators else 0
-        decorator_end = func_node.decorator_list[-1].end_lineno
-        decorator_lines = "\n".join(lines[decorator_start:decorator_end])
-    #   - Extract tool source body
-    body_start = func_node.body[0].lineno - 1  # AST lineno starts at 1
-    tool_source_body = "\n".join(lines[body_start:])
-    # - Create the forward method source, including def line and indentation
-    forward_method_source = f"def forward{new_sig}:\n{tool_source_body}"
-    # - Create the class source
-    indent = " " * 4  # for class method
-    class_source = (
-        textwrap.dedent(f"""
         class SimpleTool(Tool):
-            name: str = "{tool_json_schema["name"]}"
-            description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
-            inputs: dict[str, dict[str, str]] = {tool_json_schema["parameters"]["properties"]}
-            output_type: str = "{tool_json_schema["return"]["type"]}"
-
             def __init__(self):
                 self.is_initialized = True
 
-        """)
-        + textwrap.indent(decorator_lines, indent)
-        + textwrap.indent(forward_method_source, indent)
-    )
-    # - Store the source code on both class and method for inspection
-    SimpleTool.__source__ = class_source
-    SimpleTool.forward.__source__ = forward_method_source
+        # Set the class attributes
+        SimpleTool.name = tool_json_schema["name"]
+        SimpleTool.description = tool_json_schema["description"]
+        SimpleTool.inputs = tool_json_schema["parameters"]["properties"]
+        SimpleTool.output_type = tool_json_schema["return"]["type"]
+        if output_name is not None:
+            SimpleTool.output_name = output_name
 
-    simple_tool = SimpleTool()
-    return simple_tool
+        # Set output_schema if it exists in the JSON schema
+        if "output_schema" in tool_json_schema:
+            SimpleTool.output_schema = tool_json_schema["output_schema"]
+        elif "return" in tool_json_schema and "schema" in tool_json_schema["return"]:
+            SimpleTool.output_schema = tool_json_schema["return"]["schema"]
+
+        @wraps(func)
+        def wrapped_function(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Bind the copied function to the forward method
+        SimpleTool.forward = staticmethod(wrapped_function)
+
+        # Get the signature parameters of the tool function
+        sig = inspect.signature(func)
+        # - Add "self" as first parameter to tool_function signature
+        new_sig = sig.replace(
+            parameters=[inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)] + list(sig.parameters.values())
+        )
+        # - Set the signature of the forward method
+        SimpleTool.forward.__signature__ = new_sig
+
+        # Create and attach the source code of the dynamically created tool class and forward method
+        # - Get the source code of tool_function
+        tool_source = textwrap.dedent(inspect.getsource(func))
+        # - Remove the tool decorator and function definition line
+        lines = tool_source.splitlines()
+        tree = ast.parse(tool_source)
+        #   - Find function definition
+        func_node = next((node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)), None)
+        if not func_node:
+            raise ValueError(
+                f"No function definition found in the provided source of {func.__name__}. "
+                "Ensure the input is a standard function."
+            )
+        #   - Extract decorator lines
+        decorator_lines = ""
+        if func_node.decorator_list:
+            tool_decorators = [d for d in func_node.decorator_list if isinstance(d, ast.Name) and d.id == "tool"]
+            if len(tool_decorators) > 1:
+                raise ValueError(
+                    f"Multiple @tool decorators found on function '{func_node.name}'. Only one @tool decorator is allowed."
+                )
+            if len(tool_decorators) < len(func_node.decorator_list):
+                warnings.warn(
+                    f"Function '{func_node.name}' has decorators other than @tool. "
+                    "This may cause issues with serialization in the remote executor. See issue #1626."
+                )
+            decorator_start = tool_decorators[0].end_lineno if tool_decorators else 0
+            decorator_end = func_node.decorator_list[-1].end_lineno
+            decorator_lines = "\n".join(lines[decorator_start:decorator_end])
+        #   - Extract tool source body
+        body_start = func_node.body[0].lineno - 1  # AST lineno starts at 1
+        tool_source_body = "\n".join(lines[body_start:])
+        # - Create the forward method source, including def line and indentation
+        forward_method_source = f"def forward{new_sig}:\n{tool_source_body}"
+        # - Create the class source
+        indent = " " * 4  # for class method
+        class_source = (
+            textwrap.dedent(f"""
+            class SimpleTool(Tool):
+                name: str = "{tool_json_schema["name"]}"
+                description: str = {json.dumps(textwrap.dedent(tool_json_schema["description"]).strip())}
+                inputs: dict[str, dict[str, str]] = {tool_json_schema["parameters"]["properties"]}
+                output_type: str = "{tool_json_schema["return"]["type"]}"
+
+                def __init__(self):
+                    self.is_initialized = True
+
+            """)
+            + textwrap.indent(decorator_lines, indent)
+            + textwrap.indent(forward_method_source, indent)
+        )
+        # - Store the source code on both class and method for inspection
+        SimpleTool.__source__ = class_source
+        SimpleTool.forward.__source__ = forward_method_source
+
+        simple_tool = SimpleTool()
+        return simple_tool
+
+    # Handle both @tool and @tool(output_name="...") syntax
+    if tool_function is not None:
+        return decorator(tool_function)
+    return decorator
 
 
 class PipelineTool(Tool):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -160,6 +160,7 @@ class FakeToolCallModelImage(Model):
                 ],
             )
         else:
+            # With counter-based naming, the first image is stored as "image_1.png"
             return ChatMessage(
                 role=MessageRole.ASSISTANT,
                 content="",
@@ -167,7 +168,7 @@ class FakeToolCallModelImage(Model):
                     ChatMessageToolCall(
                         id="call_1",
                         type="function",
-                        function=ChatMessageToolCallFunction(name="final_answer", arguments="image.png"),
+                        function=ChatMessageToolCallFunction(name="final_answer", arguments="image_1.png"),
                     )
                 ],
             )
@@ -442,7 +443,8 @@ class TestAgent:
         agent = ToolCallingAgent(tools=[fake_image_generation_tool], model=FakeToolCallModelImage())
         output = agent.run("Make me an image.")
         assert isinstance(output, AgentImage)
-        assert isinstance(agent.state["image.png"], PIL.Image.Image)
+        # With counter-based naming, the first image is stored as "image_1.png"
+        assert isinstance(agent.state["image_1.png"], PIL.Image.Image)
 
     def test_toolcalling_agent_handles_image_inputs(self, shared_datadir):
         import PIL.Image
@@ -2626,3 +2628,66 @@ def test_tool_calling_agents_raises_agent_execution_error_when_tool_raises():
     agent = ToolCallingAgent(model=FakeToolCallModel(), tools=[_sample_tool])
     with pytest.raises(AgentExecutionError):
         agent.execute_tool_call(_sample_tool.name, "sample")
+
+
+class TestMediaOutputNaming:
+    """Tests for unique media output naming (image/audio counters)."""
+
+    def test_image_counter_increments(self):
+        """Test that image outputs get unique names with incrementing counters."""
+        agent = ToolCallingAgent(model=MagicMock(), tools=[])
+        assert agent._media_counters["image"] == 0
+
+        # Simulate multiple image outputs
+        agent._media_counters["image"] += 1
+        assert agent._media_counters["image"] == 1
+
+        agent._media_counters["image"] += 1
+        assert agent._media_counters["image"] == 2
+
+    def test_audio_counter_increments(self):
+        """Test that audio outputs get unique names with incrementing counters."""
+        agent = ToolCallingAgent(model=MagicMock(), tools=[])
+        assert agent._media_counters["audio"] == 0
+
+        agent._media_counters["audio"] += 1
+        assert agent._media_counters["audio"] == 1
+
+    def test_tool_output_name_attribute(self):
+        """Test that tools can have output_name attribute."""
+
+        @tool(output_name="custom_image.png")
+        def generate_custom_image() -> str:
+            """
+            Generates a custom image.
+
+            Returns:
+                The image data
+            """
+            return "image_data"
+
+        assert hasattr(generate_custom_image, "output_name")
+        assert generate_custom_image.output_name == "custom_image.png"
+
+    def test_tool_without_output_name(self):
+        """Test that tools without output_name work normally."""
+
+        @tool
+        def generate_image() -> str:
+            """
+            Generates an image.
+
+            Returns:
+                The image data
+            """
+            return "image_data"
+
+        assert not hasattr(generate_image, "output_name") or getattr(generate_image, "output_name", None) is None
+
+    def test_media_counters_initialized(self):
+        """Test that media counters are properly initialized in agents."""
+        code_agent = CodeAgent(model=MagicMock(), tools=[])
+        tool_agent = ToolCallingAgent(model=MagicMock(), tools=[])
+
+        assert code_agent._media_counters == {"image": 0, "audio": 0}
+        assert tool_agent._media_counters == {"image": 0, "audio": 0}


### PR DESCRIPTION
## Summary
- Added counter-based naming for media outputs (images/audio)
- Images: `image_1.png`, `image_2.png`, etc.
- Audio: `audio_1.wav`, `audio_2.wav`, etc.
- Backward compatible with custom `output_name`

## Changes
- Added `_media_counters` dict to `MultiStepAgent`
- Updated `process_single_tool_call` for counter-based naming
- Added `output_name` param to `@tool` decorator
- Added 5 unit tests, updated 1 existing test

Closes #2393