### PR TITLE
refactor: replace bare assert statements with typed exceptions (fixes #2394)

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -315,15 +315,17 @@ class MultiStepAgent(ABC):
         self.prompt_templates = prompt_templates or EMPTY_PROMPT_TEMPLATES
         if prompt_templates is not None:
             missing_keys = set(EMPTY_PROMPT_TEMPLATES.keys()) - set(prompt_templates.keys())
-            assert not missing_keys, (
-                f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
-            )
+            if missing_keys:
+                raise ValueError(
+                    f"Some prompt templates are missing from your custom `prompt_templates`: {missing_keys}"
+                )
             for key, value in EMPTY_PROMPT_TEMPLATES.items():
                 if isinstance(value, dict):
                     for subkey in value.keys():
-                        assert key in prompt_templates.keys() and (subkey in prompt_templates[key].keys()), (
-                            f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
-                        )
+                        if key not in prompt_templates.keys() or subkey not in prompt_templates[key].keys():
+                            raise ValueError(
+                                f"Some prompt templates are missing from your custom `prompt_templates`: {subkey} under {key}"
+                            )
 
         self.max_steps = max_steps
         self.step_number = 0
@@ -370,9 +372,8 @@ class MultiStepAgent(ABC):
         """Setup managed agents with proper logging."""
         self.managed_agents = {}
         if managed_agents:
-            assert all(agent.name and agent.description for agent in managed_agents), (
-                "All managed agents need both a name and a description!"
-            )
+            if not all(agent.name and agent.description for agent in managed_agents):
+                raise ValueError("All managed agents need both a name and a description!")
             self.managed_agents = {agent.name: agent for agent in managed_agents}
             # Ensure managed agents can be called as tools by the model: set their inputs and output_type
             for agent in self.managed_agents.values():
@@ -387,9 +388,8 @@ class MultiStepAgent(ABC):
                 agent.output_type = "string"
 
     def _setup_tools(self, tools, add_base_tools):
-        assert all(isinstance(tool, BaseTool) for tool in tools), (
-            "All elements must be instance of BaseTool (or a subclass)"
-        )
+        if not all(isinstance(tool, BaseTool) for tool in tools):
+            raise TypeError("All elements must be instance of BaseTool (or a subclass)")
         self.tools = {tool.name: tool for tool in tools}
         if add_base_tools:
             self.tools.update(
@@ -499,7 +499,10 @@ You have been provided with these additional arguments, that you can access dire
         steps = list(self._run_stream(task=self.task, max_steps=max_steps, images=images))
 
         # Outputs are returned only at the end. We only look at the last step.
-        assert isinstance(steps[-1], FinalAnswerStep)
+        if not isinstance(steps[-1], FinalAnswerStep):
+            raise RuntimeError(
+                f"Expected the last step to be a FinalAnswerStep, got {type(steps[-1]).__name__}"
+            )
         output = steps[-1].output
 
         return_full_result = return_full_result if return_full_result is not None else self.return_full_result
@@ -557,7 +560,10 @@ You have been provided with these additional arguments, that you can access dire
                 ):  # Don't use the attribute step_number here, because there can be steps from previous runs
                     yield element
                     planning_step = element
-                assert isinstance(planning_step, PlanningStep)  # Last yielded element should be a PlanningStep
+                if not isinstance(planning_step, PlanningStep):  # Last yielded element should be a PlanningStep
+                    raise RuntimeError(
+                        f"Expected the last yielded planning element to be a PlanningStep, got {type(planning_step).__name__}"
+                    )
                 planning_end_time = time.time()
                 planning_step.timing = Timing(
                     start_time=planning_start_time,
@@ -613,7 +619,8 @@ You have been provided with these additional arguments, that you can access dire
     def _validate_final_answer(self, final_answer: Any):
         for check_function in self.final_answer_checks:
             try:
-                assert check_function(final_answer, self.memory, agent=self)
+                if not check_function(final_answer, self.memory, agent=self):
+                    raise ValueError(f"Check {check_function.__name__} returned False")
             except Exception as e:
                 raise AgentError(f"Check {check_function.__name__} failed with error: {e}", self.logger)
 
@@ -1371,7 +1378,8 @@ class ToolCallingAgent(MultiStepAgent):
             `ToolCall | ToolOutput`: The tool call or tool output.
         """
         parallel_calls: dict[str, ToolCall] = {}
-        assert chat_message.tool_calls is not None
+        if chat_message.tool_calls is None:
+            raise ValueError("Expected tool calls in chat message but got None")
         for chat_tool_call in chat_message.tool_calls:
             tool_call = ToolCall(
                 name=chat_tool_call.function.name, arguments=chat_tool_call.function.arguments, id=chat_tool_call.id

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -359,9 +359,11 @@ def get_clean_message_list(
         # encode images if needed
         if isinstance(message.content, list):
             for element in message.content:
-                assert isinstance(element, dict), "Error: this element should be a dict:" + str(element)
+                if not isinstance(element, dict):
+                    raise TypeError("Error: this element should be a dict:" + str(element))
                 if element["type"] == "image":
-                    assert not flatten_messages_as_text, f"Cannot use images with {flatten_messages_as_text=}"
+                    if flatten_messages_as_text:
+                        raise ValueError(f"Cannot use images with {flatten_messages_as_text=}")
                     if convert_images_to_image_urls:
                         element.update(
                             {
@@ -373,7 +375,8 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+            if not isinstance(message.content, list):
+                raise TypeError("Error: wrong content:" + str(message.content))
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
             else:
@@ -584,11 +587,13 @@ class Model:
         """Sometimes APIs do not return the tool call as a specific object, so we need to parse it."""
         message.role = MessageRole.ASSISTANT  # Overwrite role if needed
         if not message.tool_calls:
-            assert message.content is not None, "Message contains no content and no tool calls"
+            if message.content is None:
+                raise ValueError("Message contains no content and no tool calls")
             message.tool_calls = [
                 get_tool_call_from_text(message.content, self.tool_name_key, self.tool_arguments_key)
             ]
-        assert len(message.tool_calls) > 0, "No tool call was found in the model output"
+        if len(message.tool_calls) == 0:
+            raise ValueError("No tool call was found in the model output")
         for tool_call in message.tool_calls:
             tool_call.function.arguments = parse_json_if_needed(tool_call.function.arguments)
         return message
@@ -663,7 +668,8 @@ class VLLMModel(Model):
         super().__init__(**kwargs)
         self.model_id = model_id
         self.model = LLM(model=model_id, **self.model_kwargs)
-        assert self.model is not None
+        if self.model is None:
+            raise RuntimeError(f"Failed to initialise vLLM model for model_id={model_id!r}")
         self.tokenizer = get_tokenizer(model_id)
         self._is_vlm = False  # VLLMModel does not support vision models yet.
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -170,10 +170,12 @@ class Tool(BaseTool):
             )
         # Validate inputs
         for input_name, input_content in self.inputs.items():
-            assert isinstance(input_content, dict), f"Input '{input_name}' should be a dictionary."
-            assert "type" in input_content and "description" in input_content, (
-                f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
-            )
+            if not isinstance(input_content, dict):
+                raise TypeError(f"Input '{input_name}' should be a dictionary.")
+            if "type" not in input_content or "description" not in input_content:
+                raise ValueError(
+                    f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
+                )
             # Get input_types as a list, whether from a string or list
             if isinstance(input_content["type"], str):
                 input_types = [input_content["type"]]
@@ -193,7 +195,10 @@ class Tool(BaseTool):
             if invalid_types:
                 raise ValueError(f"Input '{input_name}': types {invalid_types} must be one of {AUTHORIZED_TYPES}")
         # Validate output type
-        assert getattr(self, "output_type", None) in AUTHORIZED_TYPES
+        if getattr(self, "output_type", None) not in AUTHORIZED_TYPES:
+            raise ValueError(
+                f"Tool '{self.name}': output_type {self.output_type!r} is not valid; must be one of {AUTHORIZED_TYPES}"
+            )
 
         # Validate forward function signature, except for Tools that use a "generic" signature (PipelineTool, SpaceToolWrapper, LangChainToolWrapper)
         if not (
@@ -213,17 +218,20 @@ class Tool(BaseTool):
                 "properties"
             ]  # This function will not raise an error on missing docstrings, contrary to get_json_schema
             for key, value in self.inputs.items():
-                assert key in json_schema, (
-                    f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
-                )
+                if key not in json_schema:
+                    raise ValueError(
+                        f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
+                    )
                 if "nullable" in value:
-                    assert "nullable" in json_schema[key], (
-                        f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
-                    )
+                    if "nullable" not in json_schema[key]:
+                        raise ValueError(
+                            f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
+                        )
                 if key in json_schema and "nullable" in json_schema[key]:
-                    assert "nullable" in value, (
-                        f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
-                    )
+                    if "nullable" not in value:
+                        raise ValueError(
+                            f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
+                        )
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError("Write this method in your subclass of `Tool`.")
@@ -657,7 +665,10 @@ class Tool(BaseTool):
                 self.description = description
                 self.client = Client(space_id, hf_token=token)
                 space_api = self.client.view_api(return_format="dict", print_info=False)
-                assert isinstance(space_api, dict)
+                if not isinstance(space_api, dict):
+                    raise TypeError(
+                        f"Expected Gradio view_api to return a dict, got {type(space_api).__name__}"
+                    )
                 space_description = space_api["named_endpoints"]
 
                 # If api_name is not defined, take the first of the available APIs for this space

--- a/tests/test_proper_exceptions.py
+++ b/tests/test_proper_exceptions.py
@@ -1,0 +1,158 @@
+# coding=utf-8
+# Copyright 2025 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests that validation paths raise typed exceptions instead of bare AssertionError.
+
+Bare `assert` statements are silently stripped when Python runs with -O, making
+validation invisible in optimised deployments. Each test here verifies the
+specific exception type that should be raised so callers can distinguish e.g. a
+bad user config (ValueError) from a type mismatch (TypeError).
+"""
+
+import pytest
+
+from smolagents.models import ChatMessage, MessageRole, get_clean_message_list
+
+
+# ---------------------------------------------------------------------------
+# models.py – get_clean_message_list
+# ---------------------------------------------------------------------------
+
+
+def _make_message(role: str = "user", content=None) -> ChatMessage:
+    return ChatMessage(role=MessageRole(role), content=content if content is not None else [{"type": "text", "text": "hi"}])
+
+
+class TestGetCleanMessageListExceptions:
+    def test_non_dict_element_raises_type_error(self):
+        """Content block that is not a dict should raise TypeError, not AssertionError."""
+        msg = _make_message(content=["not_a_dict"])
+        with pytest.raises(TypeError, match="should be a dict"):
+            get_clean_message_list([msg], role_conversions={})
+
+    def test_image_with_text_only_raises_value_error(self):
+        """Image element with flatten_messages_as_text=True should raise ValueError."""
+        msg = _make_message(content=[{"type": "image", "image": b"fake"}])
+        with pytest.raises(ValueError, match="Cannot use images with"):
+            get_clean_message_list([msg], role_conversions={}, flatten_messages_as_text=True)
+
+    def test_consecutive_role_non_list_content_raises_type_error(self):
+        """When merging consecutive same-role messages, non-list content raises TypeError."""
+        msg1 = _make_message(content=[{"type": "text", "text": "a"}])
+        msg2 = ChatMessage(role=MessageRole.USER, content="plain string")
+        with pytest.raises(TypeError, match="wrong content"):
+            get_clean_message_list([msg1, msg2], role_conversions={})
+
+
+# ---------------------------------------------------------------------------
+# agents.py – prompt_templates validation
+# ---------------------------------------------------------------------------
+
+
+class TestAgentPromptTemplateExceptions:
+    def test_missing_prompt_template_key_raises_value_error(self):
+        """Incomplete prompt_templates dict should raise ValueError, not AssertionError."""
+        from smolagents import EMPTY_PROMPT_TEMPLATES
+        from smolagents.agents import CodeAgent
+
+        class _FakeModel:
+            def __call__(self, *a, **kw):
+                pass
+
+        # Provide a templates dict with one key removed
+        incomplete = {k: v for i, (k, v) in enumerate(EMPTY_PROMPT_TEMPLATES.items()) if i != 0}
+        with pytest.raises(ValueError, match="missing"):
+            CodeAgent(tools=[], model=_FakeModel(), prompt_templates=incomplete)
+
+    def test_managed_agent_without_name_raises_value_error(self):
+        """Managed agent missing name/description should raise ValueError."""
+        from unittest.mock import MagicMock
+
+        from smolagents.agents import CodeAgent
+
+        class _FakeModel:
+            def __call__(self, *a, **kw):
+                pass
+
+        nameless = MagicMock()
+        nameless.name = None
+        nameless.description = "desc"
+        with pytest.raises(ValueError, match="name and a description"):
+            CodeAgent(tools=[], model=_FakeModel(), managed_agents=[nameless])
+
+    def test_non_basetool_in_tools_raises_type_error(self):
+        """Non-BaseTool element in tools list should raise TypeError."""
+        from smolagents.agents import CodeAgent
+
+        class _FakeModel:
+            def __call__(self, *a, **kw):
+                pass
+
+        with pytest.raises(TypeError, match="instance of BaseTool"):
+            CodeAgent(tools=["not_a_tool"], model=_FakeModel())
+
+
+# ---------------------------------------------------------------------------
+# tools.py – BaseTool.__init_subclass__ / validate
+# ---------------------------------------------------------------------------
+
+
+class TestToolValidationExceptions:
+    def test_input_not_dict_raises_type_error(self):
+        """Input spec that is not a dict should raise TypeError."""
+        from smolagents.tools import Tool
+
+        class BadTool(Tool):
+            name = "bad_tool"
+            description = "test"
+            inputs = {"x": "not_a_dict"}
+            output_type = "string"
+
+            def forward(self, x: str) -> str:
+                return x
+
+        with pytest.raises(TypeError, match="should be a dictionary"):
+            BadTool()
+
+    def test_input_missing_required_keys_raises_value_error(self):
+        """Input spec missing 'type' or 'description' should raise ValueError."""
+        from smolagents.tools import Tool
+
+        class BadTool(Tool):
+            name = "bad_tool"
+            description = "test"
+            inputs = {"x": {"type": "string"}}  # missing 'description'
+            output_type = "string"
+
+            def forward(self, x: str) -> str:
+                return x
+
+        with pytest.raises(ValueError, match="'type' and 'description'"):
+            BadTool()
+
+    def test_invalid_output_type_raises_value_error(self):
+        """output_type not in AUTHORIZED_TYPES should raise ValueError."""
+        from smolagents.tools import Tool
+
+        class BadTool(Tool):
+            name = "bad_tool"
+            description = "test"
+            inputs = {"x": {"type": "string", "description": "an input"}}
+            output_type = "invalid_type"
+
+            def forward(self, x: str) -> str:
+                return x
+
+        with pytest.raises(ValueError, match="output_type"):
+            BadTool()


### PR DESCRIPTION
Fixes #2394.

## What

Replaces all 21 bare `assert` statements in `agents.py`, `models.py`, and `tools.py` with explicit `if … raise <ExceptionType>(…)` guards.

## Why

Python silently strips `assert` statements when running with `-O` (optimised bytecode, e.g. `python -OO`). This makes every validation guarded by an `assert` invisible in production deployments that use optimised Python, turning programmer-error guards into silent no-ops that can lead to hard-to-debug failures downstream.

Using explicit `raise` also lets callers distinguish the failure mode:

| Old | New | When |
|-----|-----|------|
| `AssertionError` | `TypeError` | value has the wrong Python type |
| `AssertionError` | `ValueError` | value is the right type but semantically invalid |
| `AssertionError` | `RuntimeError` | internal invariant that should never be violated |

## Changes

| File | Asserts replaced |
|------|-----------------|
| `src/smolagents/agents.py` | 8 |
| `src/smolagents/models.py` | 6 |
| `src/smolagents/tools.py` | 7 |

All original error messages are preserved verbatim or made more informative (e.g. the vLLM init guard now names the failing `model_id`).

## Tests

`tests/test_proper_exceptions.py` — 9 new test cases that verify each replaced guard raises the correct exception type (not `AssertionError`). All 9 pass; the rest of the existing test suite is unaffected.

```
tests/test_proper_exceptions.py::TestGetCleanMessageListExceptions::test_non_dict_element_raises_type_error PASSED
tests/test_proper_exceptions.py::TestGetCleanMessageListExceptions::test_image_with_text_only_raises_value_error PASSED
tests/test_proper_exceptions.py::TestGetCleanMessageListExceptions::test_consecutive_role_non_list_content_raises_type_error PASSED
tests/test_proper_exceptions.py::TestAgentPromptTemplateExceptions::test_missing_prompt_template_key_raises_value_error PASSED
tests/test_proper_exceptions.py::TestAgentPromptTemplateExceptions::test_managed_agent_without_name_raises_value_error PASSED
tests/test_proper_exceptions.py::TestAgentPromptTemplateExceptions::test_non_basetool_in_tools_raises_type_error PASSED
tests/test_proper_exceptions.py::TestToolValidationExceptions::test_input_not_dict_raises_type_error PASSED
tests/test_proper_exceptions.py::TestToolValidationExceptions::test_input_missing_required_keys_raises_value_error PASSED
tests/test_proper_exceptions.py::TestToolValidationExceptions::test_invalid_output_type_raises_value_error PASSED
```