### PR TITLE
fix: block dangerous dunder methods in class definitions

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -59,6 +59,19 @@ MAX_OPERATIONS = 10000000
 MAX_WHILE_ITERATIONS = 1000000
 MAX_EXECUTION_TIME_SECONDS = 30
 ALLOWED_DUNDER_METHODS = ["__init__", "__str__", "__repr__"]
+FORBIDDEN_CLASS_DUNDER_METHODS = [
+    "__del__",
+    "__new__",
+    "__getattribute__",
+    "__setattr__",
+    "__delattr__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__getstate__",
+    "__setstate__",
+    "__copy__",
+    "__deepcopy__",
+]
 
 
 def custom_print(*args):
@@ -564,6 +577,10 @@ def evaluate_class_def(
 
     for stmt in class_def.body:
         if isinstance(stmt, ast.FunctionDef):
+            if stmt.name in FORBIDDEN_CLASS_DUNDER_METHODS:
+                raise InterpreterError(
+                    f"Defining {stmt.name!r} in a class body is not allowed in the sandbox"
+                )
             class_dict[stmt.name] = evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
         elif isinstance(stmt, ast.AnnAssign):
             if stmt.value:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -225,6 +225,37 @@ test_func(**None)
         assert result == 42
         assert state["instance"].__doc__ == "A class with a value."
 
+    def test_evaluate_class_def_allowed_dunder_methods(self):
+        code = dedent('''\
+            class MyClass:
+                def __init__(self, value):
+                    self.value = value
+
+                def __str__(self):
+                    return "value=" + str(self.value)
+
+                def __repr__(self):
+                    return "MyClass(" + str(self.value) + ")"
+
+                def get_value(self):
+                    return self.value
+
+            instance = MyClass(42)
+            result = (str(instance), repr(instance), instance.get_value())
+        ''')
+        result, _ = evaluate_python_code(code, {"str": str, "repr": repr}, state={})
+        assert result == ("value=42", "MyClass(42)", 42)
+
+    @pytest.mark.parametrize("method_name", ["__del__", "__getattribute__", "__setattr__", "__delattr__", "__new__"])
+    def test_evaluate_class_def_forbidden_dunder_methods(self, method_name):
+        code = dedent(f'''\
+            class MyClass:
+                def {method_name}(self):
+                    pass
+        ''')
+        with pytest.raises(InterpreterError, match=f"Defining '{method_name}' in a class body is not allowed"):
+            evaluate_python_code(code, {}, state={})
+
     def test_evaluate_class_def_with_assign_attribute_target(self):
         """
         Test evaluate_class_def function when stmt is an instance of ast.Assign with ast.Attribute target.


### PR DESCRIPTION
## Problem

`evaluate_class_def` in `LocalPythonExecutor` does not restrict method names when evaluating custom class definitions. This allows definition of dangerous dunder methods like `__del__`, `__new__`, `__getattribute__`, `__setattr__`, and `__delattr__`.

These methods can be triggered implicitly by the host Python runtime (e.g., garbage collection invoking `__del__`) outside the sandbox's execution window, completely bypassing timeout decorators and `MAX_OPERATIONS` limits. This enables sandbox escape via "time bomb" objects.

Fixes #2395

## Changes

- **`src/smolagents/local_python_executor.py`**: Added `FORBIDDEN_CLASS_DUNDER_METHODS` list containing `__del__`, `__new__`, `__getattribute__`, `__setattr__`, `__delattr__`, and pickle/copy-related methods. Added validation in `evaluate_class_def` that raises `InterpreterError` when a class body defines a method from this list.
- **`tests/test_local_python_executor.py`**: Added test for allowed dunder methods (`__init__`, `__str__`, `__repr__`, non-dunder methods) and parametrized test for forbidden dunder methods.

## Design decision

Uses a blacklist approach rather than the existing `ALLOWED_DUNDER_METHODS` whitelist. Commonly-used, safe dunder methods (`__eq__`, `__add__`, `__enter__`, `__exit__`, `__getitem__`, `__iadd__`, `__len__`, etc.) remain allowed because they are only triggered by explicit operations in sandbox code, not implicitly by the host runtime.

## Testing

403 tests pass, 2 skipped. No regressions.