### PR TITLE
Fix per-step token usage logging

### DIFF
--- a/src/smolagents/monitoring.py
+++ b/src/smolagents/monitoring.py
@@ -111,7 +111,8 @@ class Monitor:
             self.total_input_token_count += step_log.token_usage.input_tokens
             self.total_output_token_count += step_log.token_usage.output_tokens
             console_outputs += (
-                f"| Input tokens: {self.total_input_token_count:,} | Output tokens: {self.total_output_token_count:,}"
+                f"| Input tokens: {step_log.token_usage.input_tokens:,} "
+                f"| Output tokens: {step_log.token_usage.output_tokens:,}"
             )
         console_outputs += "]"
         self.logger.log(Text(console_outputs, style="dim"), level=1)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -32,7 +32,7 @@ from smolagents.models import (
     MessageRole,
     Model,
 )
-from smolagents.monitoring import AgentLogger, TokenUsage
+from smolagents.monitoring import AgentLogger, Monitor, Timing, TokenUsage
 
 
 class FakeLLMModel(Model):
@@ -184,6 +184,33 @@ def test_code_agent_metrics(agent_class):
 
     assert agent.monitor.total_input_token_count == 10
     assert agent.monitor.total_output_token_count == 20
+
+
+def test_monitor_logs_step_token_usage_while_tracking_run_totals():
+    console = Console(record=True, width=120, highlight=False)
+    logger = AgentLogger(console=console)
+    monitor = Monitor(tracked_model=Model(), logger=logger)
+
+    first_step = ActionStep(
+        step_number=1,
+        timing=Timing(start_time=0.0, end_time=1.0),
+        token_usage=TokenUsage(input_tokens=10, output_tokens=20),
+    )
+    second_step = ActionStep(
+        step_number=2,
+        timing=Timing(start_time=1.0, end_time=2.0),
+        token_usage=TokenUsage(input_tokens=30, output_tokens=40),
+    )
+
+    monitor.update_metrics(first_step)
+    monitor.update_metrics(second_step)
+
+    assert monitor.total_input_token_count == 40
+    assert monitor.total_output_token_count == 60
+
+    rendered = console.export_text()
+    assert "[Step 1: Duration 1.00 seconds| Input tokens: 10 | Output tokens: 20]" in rendered
+    assert "[Step 2: Duration 1.00 seconds| Input tokens: 30 | Output tokens: 40]" in rendered
 
 
 class ReplayTester(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes the token usage line printed by `Monitor.update_metrics()` so it reports the current step's token usage instead of the cumulative run totals.

The monitor still keeps cumulative totals in `total_input_token_count` and `total_output_token_count`; only the per-step terminal log is changed.

Closes #1555

## Verification

- RED: `uv run --extra test pytest tests/test_monitoring.py::test_monitor_logs_step_token_usage_while_tracking_run_totals -q` failed before the fix because step 2 printed cumulative `40 / 60` tokens instead of step-local `30 / 40`.
- GREEN: `uv run --extra test pytest tests/test_monitoring.py::test_monitor_logs_step_token_usage_while_tracking_run_totals -q`
- `uv run --extra test pytest tests/test_monitoring.py -q`
- `git diff --check && uv run --extra quality ruff check src/smolagents/monitoring.py tests/test_monitoring.py`

## Second-agent review

- Preferred reviewer attempted: `claude -p`, but local Claude auth returned 401 invalid credentials.
- Fallback reviewer used: `hermes chat -Q`
- Result: CLEAN
- Note: fallback reviewer found no blocking correctness, regression, security, duplicate/superseded-work, or maintainer-fit issues. It noted that open PR #2143 is token-related but covers cache token fields/aggregation, not this per-step-vs-cumulative console display bug.
