### PR TITLE
fix: retry empty LiteLLM choices responses

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -67,6 +67,10 @@ CODEAGENT_RESPONSE_FORMAT = {
 }
 
 
+class EmptyChoicesError(RuntimeError):
+    """Raised when a model provider returns a chat completion with no choices."""
+
+
 def get_dict_from_nested_dataclasses(obj, ignore_key=None):
     def convert(obj):
         if hasattr(obj, "__dataclass_fields__"):
@@ -1176,7 +1180,7 @@ class ApiModel(Model):
             wait_seconds=RETRY_WAIT,
             exponential_base=RETRY_EXPONENTIAL_BASE,
             jitter=RETRY_JITTER,
-            retry_predicate=is_rate_limit_error,
+            retry_predicate=is_retryable_model_error,
             reraise=True,
             before_sleep_logger=(logger, logging.INFO),
             after_logger=(logger, logging.INFO),
@@ -1199,6 +1203,26 @@ def is_rate_limit_error(exception: BaseException) -> bool:
         or "rate limit" in error_str
         or "too many requests" in error_str
         or "rate_limit" in error_str
+    )
+
+
+def is_retryable_model_error(exception: BaseException) -> bool:
+    """Check if a model error is transient enough to retry."""
+    return is_rate_limit_error(exception) or isinstance(exception, EmptyChoicesError)
+
+
+def get_empty_choices_error_message(model_id: str | None, response: Any) -> str:
+    if hasattr(response, "model_dump"):
+        response_details = response.model_dump()
+    elif hasattr(response, "dict") and callable(response.dict):
+        response_details = response.dict()
+    else:
+        response_details = response
+
+    return (
+        f"Unexpected API response: model '{model_id}' returned no choices. "
+        " This may indicate a possible API or upstream issue. "
+        f"Response details: {response_details}"
     )
 
 
@@ -1284,14 +1308,14 @@ class LiteLLMModel(ApiModel):
             **kwargs,
         )
         self._apply_rate_limit()
-        response = self.retryer(self.client.completion, **completion_kwargs)
 
-        if not response.choices:
-            raise RuntimeError(
-                f"Unexpected API response: model '{self.model_id}' returned no choices. "
-                " This may indicate a possible API or upstream issue. "
-                f"Response details: {response.model_dump()}"
-            )
+        def completion_with_choices(**kwargs):
+            response = self.client.completion(**kwargs)
+            if not response.choices:
+                raise EmptyChoicesError(get_empty_choices_error_message(self.model_id, response))
+            return response
+
+        response = self.retryer(completion_with_choices, **completion_kwargs)
         content = response.choices[0].message.content
         if stop_sequences is not None and not self.supports_stop_parameter:
             content = remove_content_after_stop_sequences(content, stop_sequences)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -429,18 +429,18 @@ class TestLiteLLMModel:
 
     def test_retry_on_rate_limit_error(self):
         """Test that the retry mechanism does trigger on 429 rate limit errors"""
-        import time
-
-        # Patch RETRY_WAIT to 1 second for faster testing
         mock_litellm = MagicMock()
 
         with (
             patch("smolagents.models.RETRY_WAIT", 0.1),
             patch("smolagents.utils.random.random", side_effect=[0.1, 0.1]),
+            patch("smolagents.utils.time.sleep") as mock_sleep,
             patch("smolagents.models.LiteLLMModel.create_client", return_value=mock_litellm),
         ):
             model = LiteLLMModel(model_id="test-model")
-            messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Test message"}])]
+            messages: list[ChatMessage | dict] = [
+                ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Test message"}])
+            ]
 
             # Create a mock response for successful call
             mock_success_response = MagicMock()
@@ -458,10 +458,7 @@ class TestLiteLLMModel:
             # Mock the litellm client to raise an error twice, and then succeed
             model.client.completion.side_effect = [rate_limit_error, rate_limit_error, mock_success_response]
 
-            # Measure time to verify retry wait time
-            start_time = time.time()
             result = model.generate(messages)
-            elapsed_time = time.time() - start_time
 
             # Verify that completion was called thrice (twice failed, once succeeded)
             assert model.client.completion.call_count == 3
@@ -469,11 +466,8 @@ class TestLiteLLMModel:
             assert result.token_usage.input_tokens == 10
             assert result.token_usage.output_tokens == 20
 
-            # Verify that the wait time was around
-            # 0.22s (1st retry) [0.1 * 2.0 * (1 + 1 * 0.1)]
-            # + 0.48s (2nd retry) [0.22 * 2.0 * (1 + 1 * 0.1)]
-            # = 0.704s (allow some tolerance)
-            assert 0.67 <= elapsed_time <= 0.73
+            # Verify the exponential backoff delays without relying on wall-clock time.
+            assert [call.args[0] for call in mock_sleep.call_args_list] == pytest.approx([0.22, 0.484])
 
     def test_passing_flatten_messages(self):
         model = LiteLLMModel(model_id="groq/llama-3.3-70b", flatten_messages_as_text=False)
@@ -481,6 +475,35 @@ class TestLiteLLMModel:
 
         model = LiteLLMModel(model_id="fal/llama-3.3-70b", flatten_messages_as_text=True)
         assert model.flatten_messages_as_text
+
+    def test_retries_empty_choices_response(self):
+        empty_response = MagicMock()
+        empty_response.choices = []
+        empty_response.model_dump.return_value = {"choices": []}
+
+        success_response = MagicMock()
+        success_response.choices = [MagicMock()]
+        success_response.choices[0].message.content = "Success response"
+        success_response.choices[0].message.role = "assistant"
+        success_response.choices[0].message.tool_calls = None
+        success_response.usage.prompt_tokens = 10
+        success_response.usage.completion_tokens = 20
+
+        mock_litellm = MagicMock()
+        mock_litellm.completion.side_effect = [empty_response, success_response]
+
+        with (
+            patch("smolagents.models.RETRY_WAIT", 0),
+            patch("smolagents.models.LiteLLMModel.create_client", return_value=mock_litellm),
+        ):
+            model = LiteLLMModel(model_id="test-model")
+            messages: list[ChatMessage | dict] = [
+                ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Test message"}])
+            ]
+            result = model.generate(messages)
+
+        assert mock_litellm.completion.call_count == 2
+        assert result.content == "Success response"
 
 
 class TestLiteLLMRouterModel:


### PR DESCRIPTION
## Summary

- Retry LiteLLM completions when the provider returns an empty `choices` list.
- Keep the final failure descriptive by raising `EmptyChoicesError`, a `RuntimeError` subclass, after retry attempts are exhausted.
- Add a regression test for the transient empty-choices case and make the existing retry backoff test deterministic by mocking sleep.

Fixes #1127

## Verification

- RED: `uv run pytest tests/test_models.py::TestLiteLLMModel::test_retries_empty_choices_response -q` failed before the fix with `RuntimeError: ... returned no choices` after the first empty response.
- GREEN: `uv run pytest tests/test_models.py::TestLiteLLMModel::test_retries_empty_choices_response -q` passed.
- `uv run pytest tests/test_models.py::TestLiteLLMModel -q` passed, 6 passed.
- `uv run pytest tests/test_models.py::TestModel::test_prepare_completion_kwargs_parameter_precedence tests/test_models.py::test_supports_stop_parameter -q` passed, 42 passed.
- `uv run pytest tests/test_models.py -q` passed before formatting, 116 passed, 5 skipped, 2 warnings.
- `uv run make quality` passed.
- `git diff --check` passed.

## Second-agent review

- Preferred reviewer `claude -p` was unavailable: authentication error 401.
- Fallback reviewer `hermes chat -Q` reviewed `/tmp/oss-pr-second-agent-review.diff` containing the actual working diff.
- Result: CLEAN, no blocking findings. The reviewer noted the change is narrowly scoped, keeps final failure as a `RuntimeError` subtype, and adds targeted regression coverage.

## Notes

I checked for overlap before opening this PR:

- No open PR matched issue #1127 / Gemini / LiteLLM empty choices.
- #1683 already added a descriptive empty-choices error for LiteLLM and was merged.
- #2034 attempted a broader all-backends guard and was closed unmerged.

This PR keeps the scope tighter: for the selected LiteLLM/Gemini failure mode, transient empty `choices` responses are retried instead of immediately stopping the agent flow.