### PR TITLE
Fix native tool-call history replay

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -91,12 +91,21 @@ class ActionStep(MemoryStep):
 
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         messages = []
-        if self.model_output is not None and not summary_mode:
+        if self.model_output_message is not None and self.model_output_message.tool_calls and not summary_mode:
             messages.append(
-                ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": self.model_output.strip()}])
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content=self.model_output_message.content or [{"type": "text", "text": ""}],
+                    tool_calls=self.model_output_message.tool_calls,
+                )
             )
+        elif self.model_output is not None and not summary_mode:
+            model_output = self.model_output.strip() if isinstance(self.model_output, str) else str(self.model_output)
+            messages.append(ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": model_output}]))
 
-        if self.tool_calls is not None:
+        if self.tool_calls is not None and not (
+            self.model_output_message is not None and self.model_output_message.tool_calls
+        ):
             messages.append(
                 ChatMessage(
                     role=MessageRole.TOOL_CALL,

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -372,7 +372,12 @@ def get_clean_message_list(
                     else:
                         element["image"] = encode_image_base64(element["image"])
 
-        if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
+        if (
+            len(output_message_list) > 0
+            and message.role == output_message_list[-1]["role"]
+            and not message.tool_calls
+            and not output_message_list[-1].get("tool_calls")
+        ):
             assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
                 output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
@@ -388,12 +393,15 @@ def get_clean_message_list(
                 content = message.content[0]["text"]
             else:
                 content = message.content
-            output_message_list.append(
-                {
-                    "role": message.role,
-                    "content": content,
-                }
-            )
+            output_message = {
+                "role": message.role,
+                "content": content,
+            }
+            if message.tool_calls:
+                output_message["tool_calls"] = [
+                    get_dict_from_nested_dataclasses(tool_call) for tool_call in message.tool_calls
+                ]
+            output_message_list.append(output_message)
     return output_message_list
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -142,6 +142,46 @@ class FakeToolCallModel(Model):
             )
 
 
+class FakeSequentialToolCallModel(Model):
+    def generate(
+        self,
+        messages,
+        stop_sequences=None,
+        response_format=None,
+        tools_to_call_from=None,
+        **kwargs,
+    ):
+        if len(messages) < 3:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=None,
+                tool_calls=[
+                    ChatMessageToolCall(
+                        id="call_0",
+                        type="function",
+                        function=ChatMessageToolCallFunction(name="count", arguments={}),
+                    )
+                ],
+            )
+
+        assert "Calling tools:" not in str(messages)
+        previous_tool_messages = [message for message in messages if message.tool_calls]
+        assert previous_tool_messages[0].tool_calls is not None
+        assert previous_tool_messages[0].tool_calls[0].id == "call_0"
+        assert previous_tool_messages[0].tool_calls[0].function.name == "count"
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="I will return the final answer.",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id="call_1",
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "1"}),
+                )
+            ],
+        )
+
+
 class FakeToolCallModelImage(Model):
     def generate(self, messages, tools_to_call_from=None, stop_sequences=None):
         if len(messages) < 3:
@@ -423,6 +463,16 @@ class TestAgent:
         assert agent.memory.steps[0].task == "What is 2 multiplied by 3.6452?"
         assert "7.2904" in agent.memory.steps[1].observations
         assert agent.memory.steps[2].model_output == "I will return the final answer."
+
+    def test_toolcalling_agent_does_not_replay_native_tool_calls_as_text(self):
+        @tool
+        def count() -> str:
+            """Return the current count."""
+            return "1"
+
+        agent = ToolCallingAgent(tools=[count], model=FakeSequentialToolCallModel())
+
+        assert agent.run("Count once, then answer.") == "1"
 
     def test_toolcalling_agent_handles_image_tool_outputs(self, shared_datadir):
         import PIL.Image

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,7 @@ from smolagents.models import (
     AzureOpenAIModel,
     ChatMessage,
     ChatMessageToolCall,
+    ChatMessageToolCallFunction,
     InferenceClientModel,
     LiteLLMModel,
     LiteLLMRouterModel,
@@ -47,6 +48,37 @@ from .utils.markers import require_run_all
 
 
 class TestModel:
+    def test_get_clean_message_list_preserves_tool_calls(self):
+        messages: list[ChatMessage | dict] = [
+            ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=[{"type": "text", "text": "I will call a tool."}],
+                tool_calls=[
+                    ChatMessageToolCall(
+                        id="call_0",
+                        type="function",
+                        function=ChatMessageToolCallFunction(name="count", arguments={}),
+                    )
+                ],
+            )
+        ]
+
+        clean_messages = get_clean_message_list(messages)
+
+        assert clean_messages == [
+            {
+                "role": MessageRole.ASSISTANT,
+                "content": [{"type": "text", "text": "I will call a tool."}],
+                "tool_calls": [
+                    {
+                        "function": {"arguments": {}, "name": "count", "description": None},
+                        "id": "call_0",
+                        "type": "function",
+                    }
+                ],
+            }
+        ]
+
     def test_prepare_completion_kwargs_parameter_precedence(self):
         """Test that self.kwargs have highest precedence and REMOVE_PARAMETER works correctly"""
         from smolagents.models import REMOVE_PARAMETER


### PR DESCRIPTION
## What does this PR do?

Fixes sequential native tool calling for providers such as LiteLLM `ollama_chat` by preserving assistant messages with structured `tool_calls` in memory/history instead of replaying those calls as `Calling tools:\n...` text.

The textual fallback is kept for model outputs that do not carry native tool-call metadata.

Fixes #938.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

## Test plan

- `uv run --extra test python -m pytest tests/test_agents.py::TestAgent::test_toolcalling_agent_does_not_replay_native_tool_calls_as_text tests/test_models.py::TestModel::test_get_clean_message_list_preserves_tool_calls -q`
- `uv run --extra test python -m pytest tests/test_agents.py::TestAgent::test_fake_toolcalling_agent tests/test_agents.py::TestAgent::test_toolcalling_agent_does_not_replay_native_tool_calls_as_text tests/test_models.py::TestModel::test_get_clean_message_list_preserves_tool_calls -q`
- `uv run ruff check src/smolagents/memory.py src/smolagents/models.py tests/test_agents.py tests/test_models.py`
