### PR TITLE
Fix MCP tool export and VLM image processing

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -334,6 +334,7 @@ def get_clean_message_list(
     role_conversions: dict[MessageRole, MessageRole] | dict[str, str] = {},
     convert_images_to_image_urls: bool = False,
     flatten_messages_as_text: bool = False,
+    encode_images: bool = True,
 ) -> list[dict[str, Any]]:
     """
     Creates a list of messages to give as input to the LLM. These messages are dictionaries and chat template compatible with transformers LLM chat template.
@@ -344,6 +345,7 @@ def get_clean_message_list(
         role_conversions (`dict[MessageRole, MessageRole]`, *optional* ): Mapping to convert roles.
         convert_images_to_image_urls (`bool`, default `False`): Whether to convert images to image URLs.
         flatten_messages_as_text (`bool`, default `False`): Whether to flatten messages as text.
+        encode_images (`bool`, default `True`): Whether to encode image inputs as base64 strings.
     """
     output_message_list: list[dict[str, Any]] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
@@ -362,6 +364,8 @@ def get_clean_message_list(
                 assert isinstance(element, dict), "Error: this element should be a dict:" + str(element)
                 if element["type"] == "image":
                     assert not flatten_messages_as_text, f"Cannot use images with {flatten_messages_as_text=}"
+                    if not encode_images:
+                        continue
                     if convert_images_to_image_urls:
                         element.update(
                             {
@@ -508,6 +512,7 @@ class Model:
         custom_role_conversions: dict[str, str] | None = None,
         convert_images_to_image_urls: bool = False,
         tool_choice: str | dict | None = "required",  # Configurable tool_choice parameter
+        encode_images: bool = True,
         **kwargs,
     ) -> dict[str, Any]:
         """
@@ -525,6 +530,7 @@ class Model:
             role_conversions=custom_role_conversions or tool_role_conversions,
             convert_images_to_image_urls=convert_images_to_image_urls,
             flatten_messages_as_text=flatten_messages_as_text,
+            encode_images=encode_images,
         )
         # Start with messages
         completion_kwargs = {
@@ -1010,6 +1016,7 @@ class TransformersModel(Model):
             stop_sequences=stop_sequences,
             tools_to_call_from=tools_to_call_from,
             tool_choice=None,
+            encode_images=not hasattr(self, "processor"),
             **kwargs,
         )
 
@@ -1024,17 +1031,45 @@ class TransformersModel(Model):
             or self.kwargs.get("max_tokens")
             or 1024
         )
-        prompt_tensor = (self.processor if hasattr(self, "processor") else self.tokenizer).apply_chat_template(
-            messages,
-            tools=tools,
-            return_tensors="pt",
-            add_generation_prompt=True,
-            tokenize=True,
-            return_dict=True,
-            **self.apply_chat_template_kwargs,
-        )
+        if hasattr(self, "processor"):
+            images = [
+                element["image"]
+                for message in messages
+                for element in message.get("content", [])
+                if element.get("type") == "image"
+            ]
+            apply_chat_template_kwargs = {
+                "tools": tools,
+                "add_generation_prompt": True,
+                **self.apply_chat_template_kwargs,
+                "tokenize": False,
+            }
+            prompt = self.processor.apply_chat_template(
+                messages,
+                **apply_chat_template_kwargs,
+            )
+            prompt_tensor = self.processor(
+                text=prompt,
+                images=images or None,
+                return_tensors="pt",
+            )
+        else:
+            prompt_tensor = self.tokenizer.apply_chat_template(
+                messages,
+                tools=tools,
+                return_tensors="pt",
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                **self.apply_chat_template_kwargs,
+            )
         prompt_tensor = prompt_tensor.to(self.model.device)  # type: ignore
-        if hasattr(prompt_tensor, "input_ids"):
+        generation_inputs = {}
+        if hasattr(prompt_tensor, "items"):
+            generation_inputs = {key: value for key, value in prompt_tensor.items() if key != "input_ids"}
+        if isinstance(prompt_tensor, dict):
+            prompt_tensor = prompt_tensor["input_ids"]
+        elif hasattr(prompt_tensor, "input_ids"):
             prompt_tensor = prompt_tensor["input_ids"]
 
         model_tokenizer = self.processor.tokenizer if hasattr(self, "processor") else self.tokenizer
@@ -1046,6 +1081,7 @@ class TransformersModel(Model):
             inputs=prompt_tensor,
             use_cache=True,
             stopping_criteria=stopping_criteria,
+            **generation_inputs,
             **completion_kwargs,
         )
 

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -289,10 +289,67 @@ class Tool(BaseTool):
     def to_tool_calling_prompt(self) -> str:
         return f"{self.name}: {self.description}\n    Takes inputs: {self.inputs}\n    Returns an output of type: {self.output_type}"
 
+    def _get_mcp_export_code(self) -> str | None:
+        """Return source for reconnecting to an MCP-backed tool, if this tool came from MCP."""
+        mcp_tool_name = getattr(self, "_mcp_tool_name", None)
+        mcp_server_parameters = getattr(self, "_mcp_server_parameters", None)
+        mcp_structured_output = getattr(self, "_mcp_structured_output", None)
+        if mcp_tool_name is None or mcp_server_parameters is None:
+            return None
+
+        if not isinstance(mcp_server_parameters, dict):
+            raise ValueError(
+                "Cannot serialize MCP tools loaded from stdio server parameters. "
+                "Stdio MCP parameters may contain command arguments or environment variables that should not be "
+                "exported. Recreate these tools with ToolCollection.from_mcp(...) instead."
+            )
+
+        supported_keys = {"url", "transport"}
+        unsupported_keys = set(mcp_server_parameters) - supported_keys
+        if unsupported_keys:
+            raise ValueError(
+                "Cannot serialize MCP tools loaded with custom server parameter keys: "
+                f"{', '.join(sorted(unsupported_keys))}. "
+                "Recreate these tools with ToolCollection.from_mcp(...) instead."
+            )
+        server_parameters_code = repr(mcp_server_parameters)
+
+        return textwrap.dedent(
+            f"""
+            from smolagents import Tool, ToolCollection
+
+
+            class {self.__class__.__name__}(Tool):
+                name = {self.name!r}
+                description = {self.description!r}
+                inputs = {repr(self.inputs)}
+                output_type = {self.output_type!r}
+                skip_forward_signature_validation = True
+
+                def __init__(self):
+                    self.is_initialized = True
+
+                def forward(self, *args, **kwargs):
+                    with ToolCollection.from_mcp(
+                        {server_parameters_code},
+                        trust_remote_code=True,
+                        structured_output={mcp_structured_output!r},
+                    ) as tool_collection:
+                        tool = next(
+                            tool for tool in tool_collection.tools
+                            if getattr(tool, "_mcp_tool_name", tool.name) == {mcp_tool_name!r}
+                        )
+                        return tool(*args, **kwargs)
+            """
+        ).strip()
+
     def to_dict(self) -> dict:
         """Returns a dictionary representing the tool"""
         class_name = self.__class__.__name__
-        if type(self).__name__ == "SimpleTool":
+        mcp_tool_code = self._get_mcp_export_code()
+        if mcp_tool_code is not None:
+            tool_code = mcp_tool_code
+        elif type(self).__name__ == "SimpleTool":
             # Check that imports are self-contained
             source_code = get_source(self.forward).replace("@tool", "")
             forward_node = ast.parse(source_code)
@@ -355,6 +412,8 @@ class Tool(BaseTool):
             tool_code = "from typing import Any, Optional\n" + instance_to_source(self, base_cls=Tool)
 
         requirements = {el for el in get_imports(tool_code) if el not in sys.stdlib_module_names} | {"smolagents"}
+        if mcp_tool_code is not None:
+            requirements.add("mcpadapt")
 
         tool_dict = {"name": self.name, "code": tool_code, "requirements": sorted(requirements)}
 
@@ -1055,6 +1114,11 @@ class ToolCollection:
                 "as it will execute code on your local machine: pass `trust_remote_code=True`."
             )
         with MCPAdapt(server_parameters, SmolAgentsAdapter(structured_output=structured_output)) as tools:
+            for tool in tools:
+                if hasattr(tool, "__dict__"):
+                    tool._mcp_tool_name = getattr(tool, "name", None)
+                    tool._mcp_server_parameters = server_parameters
+                    tool._mcp_structured_output = structured_output
             yield cls(tools)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,7 @@
 import json
 import sys
 from contextlib import ExitStack
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, sentinel
 
 import pytest
 from huggingface_hub import ChatCompletionOutputMessage
@@ -682,6 +682,74 @@ class TestTransformersModel:
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.args == ("test-model",)
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
 
+    def test_prepare_completion_args_for_vlm_keeps_raw_images_for_processor(self):
+        input_ids = MagicMock()
+        input_ids.shape = (1, 3)
+        pixel_values = MagicMock()
+        prompt_tensor = {"input_ids": input_ids, "pixel_values": pixel_values}
+        prompt_tensor_mock = MagicMock()
+        prompt_tensor_mock.to.return_value = prompt_tensor
+
+        processor = MagicMock()
+        processor.apply_chat_template.return_value = "rendered prompt"
+        processor.return_value = prompt_tensor_mock
+        processor.tokenizer = MagicMock()
+
+        model = TransformersModel.__new__(TransformersModel)
+        Model.__init__(model, model_id="test-vlm", flatten_messages_as_text=False, max_new_tokens=8)
+        model.processor = processor
+        model.model = MagicMock()
+        model.model.device = "cpu"
+        model.apply_chat_template_kwargs = {}
+
+        image = sentinel.image
+        messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "image", "image": image}])]
+
+        with patch("smolagents.models.encode_image_base64") as mock_encode:
+            generation_kwargs = model._prepare_completion_args(messages)
+
+        mock_encode.assert_not_called()
+        processor.apply_chat_template.assert_called_once_with(
+            [{"role": MessageRole.USER, "content": [{"type": "image", "image": image}]}],
+            tools=None,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        processor.assert_called_once_with(text="rendered prompt", images=[image], return_tensors="pt")
+        assert generation_kwargs["inputs"] is input_ids
+        assert generation_kwargs["pixel_values"] is pixel_values
+
+    def test_prepare_completion_args_for_vlm_handles_template_kwargs(self):
+        input_ids = MagicMock()
+        input_ids.shape = (1, 3)
+        prompt_tensor_mock = MagicMock()
+        prompt_tensor_mock.to.return_value = {"input_ids": input_ids}
+
+        processor = MagicMock()
+        processor.apply_chat_template.return_value = "rendered prompt"
+        processor.return_value = prompt_tensor_mock
+        processor.tokenizer = MagicMock()
+
+        model = TransformersModel.__new__(TransformersModel)
+        Model.__init__(model, model_id="test-vlm", flatten_messages_as_text=False)
+        model.processor = processor
+        model.model = MagicMock()
+        model.model.device = "cpu"
+        model.apply_chat_template_kwargs = {"add_generation_prompt": False, "tokenize": True}
+
+        messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Describe this"}])]
+
+        generation_kwargs = model._prepare_completion_args(messages)
+
+        processor.apply_chat_template.assert_called_once_with(
+            [{"role": MessageRole.USER, "content": [{"type": "text", "text": "Describe this"}]}],
+            tools=None,
+            add_generation_prompt=False,
+            tokenize=False,
+        )
+        processor.assert_called_once_with(text="rendered prompt", images=None, return_tensors="pt")
+        assert generation_kwargs["inputs"] is input_ids
+
 
 def test_get_clean_message_list_basic():
     messages = [
@@ -792,6 +860,17 @@ def test_get_clean_message_list_image_encoding(convert_images_to_image_urls, exp
         mock_encode.assert_any_call(b"second_image_data")
         assert len(result) == 1
         assert result[0] == expected_clean_message
+
+
+def test_get_clean_message_list_can_keep_raw_images():
+    image = sentinel.image
+    message = ChatMessage(role=MessageRole.USER, content=[{"type": "image", "image": image}])
+
+    with patch("smolagents.models.encode_image_base64") as mock_encode:
+        result = get_clean_message_list([message], encode_images=False)
+
+    mock_encode.assert_not_called()
+    assert result == [{"role": MessageRole.USER, "content": [{"type": "image", "image": image}]}]
 
 
 def test_get_clean_message_list_flatten_messages_as_text():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -328,6 +328,69 @@ class TestTool:
         fail_tool = PassTool()
         fail_tool.to_dict()
 
+    def test_mcp_adapted_tool_to_dict_uses_mcp_proxy(self):
+        server_parameters = {"url": "http://127.0.0.1:8000/sse", "transport": "sse"}
+
+        class MCPAdaptTool(Tool):
+            def __init__(
+                self,
+                name: str,
+                description: str,
+                inputs: dict[str, dict[str, str]],
+                output_type: str,
+            ):
+                self.name = name
+                self.description = description
+                self.inputs = inputs
+                self.output_type = output_type
+                self.is_initialized = True
+                self.skip_forward_signature_validation = True
+
+            def forward(self, *args, **kwargs):
+                return kwargs
+
+        tool = MCPAdaptTool(
+            name="add_numbers",
+            description="Add two numbers",
+            inputs={
+                "a": {"type": "integer", "description": "First integer"},
+                "b": {"type": "integer", "description": "Second integer"},
+            },
+            output_type="object",
+        )
+        tool._mcp_tool_name = "add_numbers"
+        tool._mcp_server_parameters = server_parameters
+        tool._mcp_structured_output = False
+
+        tool_dict = tool.to_dict()
+
+        assert tool_dict["name"] == "add_numbers"
+        assert "ToolCollection.from_mcp" in tool_dict["code"]
+        assert repr(server_parameters) in tool_dict["code"]
+        assert "add_numbers" in tool_dict["code"]
+        assert "mcpadapt" in tool_dict["requirements"]
+
+    def test_mcp_adapted_stdio_tool_to_dict_raises_clear_error(self):
+        class MCPAdaptTool(Tool):
+            def __init__(self):
+                self.name = "add_numbers"
+                self.description = "Add two numbers"
+                self.inputs = {"a": {"type": "integer", "description": "First integer"}}
+                self.output_type = "object"
+                self.is_initialized = True
+                self.skip_forward_signature_validation = True
+
+            def forward(self, *args, **kwargs):
+                return kwargs
+
+        tool = MCPAdaptTool()
+        tool._mcp_tool_name = "add_numbers"
+        tool._mcp_server_parameters = mcp.StdioServerParameters(command="python", args=["-c", "print('ready')"])
+        tool._mcp_structured_output = False
+
+        with pytest.raises(ValueError, match="Cannot serialize MCP tools loaded from stdio"):
+            tool.to_dict()
+
     def test_saving_tool_allows_no_imports_from_outside_methods(self, tmp_path):
         # Test that using imports from outside functions fails
         import numpy as np
@@ -803,8 +866,12 @@ def mock_server_parameters():
 
 @pytest.fixture
 def mock_mcp_adapt():
+    tool1 = MagicMock()
+    tool1.name = "tool1"
+    tool2 = MagicMock()
+    tool2.name = "tool2"
     with patch("mcpadapt.core.MCPAdapt") as mock:
-        mock.return_value.__enter__.return_value = ["tool1", "tool2"]
+        mock.return_value.__enter__.return_value = [tool1, tool2]
         mock.return_value.__exit__.return_value = None
         yield mock
 
@@ -822,8 +889,12 @@ class TestToolCollection:
         with ToolCollection.from_mcp(mock_server_parameters, trust_remote_code=True) as tool_collection:
             assert isinstance(tool_collection, ToolCollection)
             assert len(tool_collection.tools) == 2
-            assert "tool1" in tool_collection.tools
-            assert "tool2" in tool_collection.tools
+            assert tool_collection.tools[0].name == "tool1"
+            assert tool_collection.tools[1].name == "tool2"
+
+            assert tool_collection.tools[0]._mcp_tool_name == "tool1"
+            assert tool_collection.tools[0]._mcp_server_parameters == mock_server_parameters
+            assert tool_collection.tools[0]._mcp_structured_output is False
 
     @require_run_all
     def test_integration_from_mcp(self):


### PR DESCRIPTION
## Summary

- preserve MCP-backed tools when exporting via `Tool.to_dict()` by generating a reconnecting `ToolCollection.from_mcp(...)` proxy for HTTP-style MCP server parameters
- keep raw image objects for `TransformersModel` VLM processors and pass images through the processor call instead of pre-encoding them as base64 text
- forward multimodal processor inputs such as `pixel_values` into generation kwargs

Fixes #1108.
Fixes #841.

## Validation

- `python -m pytest tests/test_tools.py::TestTool::test_mcp_adapted_tool_to_dict_uses_mcp_proxy tests/test_tools.py::TestTool::test_mcp_adapted_stdio_tool_to_dict_raises_clear_error tests/test_tools.py::TestToolCollection::test_from_mcp tests/test_models.py::TestTransformersModel::test_prepare_completion_args_for_vlm_keeps_raw_images_for_processor tests/test_models.py::TestTransformersModel::test_prepare_completion_args_for_vlm_handles_template_kwargs tests/test_models.py::test_get_clean_message_list_can_keep_raw_images -q` - 6 passed
- `ruff check src/smolagents/tools.py src/smolagents/models.py tests/test_tools.py tests/test_models.py`
- `ruff format --check src/smolagents/tools.py src/smolagents/models.py tests/test_tools.py tests/test_models.py`
- `git diff --check HEAD~1..HEAD`

I also attempted a broader local `TestTransformersModel` run, but this environment does not have optional `transformers` installed, so that broader class includes environment-dependent failures unrelated to this patch.

AI disclosure: this PR was prepared by Codex (GPT-5) acting as an AI coding agent on behalf of @luohui1.
