### PR TITLE
Add tested Xquik search tool example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,6 @@ To run tests locally, run this command:
 ```bash
 make test
 ```
-</details>
 
 ## I want to become a maintainer of the project. How do I get there?
 

--- a/examples/xquik_search_tool.py
+++ b/examples/xquik_search_tool.py
@@ -1,0 +1,83 @@
+"""Search public X posts through the Xquik API.
+
+Xquik is a closed-source hosted service. Xquik is an independent third-party
+service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+"""
+
+import os
+
+import requests
+
+from smolagents import CodeAgent, InferenceClientModel, Tool
+
+
+class XquikSearchPostsTool(Tool):
+    name = "xquik_search_posts"
+    description = "Search public X posts with the Xquik API."
+    inputs = {
+        "query": {
+            "type": "string",
+            "description": "Keyword query, username query, post ID, or X status URL.",
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Maximum number of posts to return.",
+            "nullable": True,
+        },
+    }
+    output_type = "string"
+
+    def forward(self, query: str, limit: int | None = 5) -> str:
+        api_key = os.environ.get("XQUIK_API_KEY")
+        if not api_key:
+            return "Set XQUIK_API_KEY before calling this tool."
+
+        max_results = 5 if limit is None else max(1, min(limit, 20))
+        response = requests.get(
+            f"{os.environ.get('XQUIK_BASE_URL', 'https://xquik.com')}/api/v1/x/tweets/search",
+            headers={"x-api-key": api_key},
+            params={"q": query, "limit": max_results},
+            timeout=30,
+        )
+        if response.status_code == 402:
+            return "Xquik returned payment required. Check your Xquik account access."
+        if response.status_code == 401:
+            return "Xquik rejected the API key. Check XQUIK_API_KEY."
+        response.raise_for_status()
+
+        data = response.json()
+        posts = data.get("tweets", data.get("items", []))
+        if not posts:
+            return "No matching posts found."
+
+        return "\n\n".join(format_post(post) for post in posts[:max_results])
+
+
+def format_post(post: dict) -> str:
+    author = post.get("author") or {}
+    username = author.get("username") or post.get("username") or "unknown"
+    text = post.get("text") or post.get("fullText") or ""
+    metrics = []
+    for key, label in [
+        ("likeCount", "likes"),
+        ("replyCount", "replies"),
+        ("retweetCount", "reposts"),
+        ("quoteCount", "quotes"),
+    ]:
+        if key in post:
+            metrics.append(f"{label}: {post[key]}")
+
+    metrics_text = f" ({', '.join(metrics)})" if metrics else ""
+    post_url = post.get("url") or post.get("tweetUrl")
+    url_text = f"\nURL: {post_url}" if post_url else ""
+    return f"@{username}{metrics_text}\n{text}{url_text}"
+
+
+if __name__ == "__main__":
+    agent = CodeAgent(
+        tools=[XquikSearchPostsTool()],
+        model=InferenceClientModel(),
+        stream_outputs=True,
+    )
+
+    agent.run("Find recent public posts about open source AI agents.")

--- a/tests/test_xquik_search_tool.py
+++ b/tests/test_xquik_search_tool.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import Mock, patch
+
+from examples.xquik_search_tool import XquikSearchPostsTool, format_post
+
+
+def test_xquik_search_requires_an_api_key(monkeypatch):
+    monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+
+    assert XquikSearchPostsTool().forward("agents") == "Set XQUIK_API_KEY before calling this tool."
+
+
+def test_xquik_search_bounds_results_and_formats_posts(monkeypatch):
+    monkeypatch.setenv("XQUIK_API_KEY", "xq_test")
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "tweets": [
+            {
+                "author": {"username": "huggingface"},
+                "likeCount": 4,
+                "text": "Small agents are useful.",
+                "url": "https://x.com/huggingface/status/1",
+            }
+        ]
+    }
+
+    with patch("examples.xquik_search_tool.requests.get", return_value=response) as get:
+        result = XquikSearchPostsTool().forward("agents", 100)
+
+    get.assert_called_once_with(
+        "https://xquik.com/api/v1/x/tweets/search",
+        headers={"x-api-key": "xq_test"},
+        params={"q": "agents", "limit": 20},
+        timeout=30,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert result == "@huggingface (likes: 4)\nSmall agents are useful.\nURL: https://x.com/huggingface/status/1"
+
+
+def test_format_post_supports_flat_author_data():
+    assert format_post({"fullText": "Hello", "username": "alice"}) == "@alice\nHello"


### PR DESCRIPTION
## Summary

- Add a standalone smolagents `Tool` example for public X post search through Xquik.
- Read `XQUIK_API_KEY` and optional `XQUIK_BASE_URL` from the environment.
- Bound result counts, use the documented `x-api-key` header, and format returned posts for agent use.
- State clearly that Xquik is a closed-source hosted service independent from X Corp.
- Add focused unit tests for missing credentials, request construction, result bounds, and response formatting.

## Independent Repository Fix

`CONTRIBUTING.md` contained an unmatched `</details>` tag after the test command. Removing it restores balanced disclosure markup and prevents the remainder of the guide from being affected by invalid HTML structure.

## Validation

- `make quality`
- `pytest -q tests/test_xquik_search_tool.py` - 3 passed
- Python compile checks for the example and test
- Balanced `<details>` and `</details>` validation
- HTTP 200 checks for the Xquik API root and public API docs
- `git diff --check`

The branch is rebuilt on current upstream and contains exactly 1 verified signed commit.
