### PR TITLE
Add ScavioSearchTool

### DIFF
--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -11,6 +11,7 @@ The built-in tools can be categorized by their primary functions:
   - [`ApiWebSearchTool`]
   - [`DuckDuckGoSearchTool`]
   - [`GoogleSearchTool`]
+  - [`ScavioSearchTool`]
   - [`WebSearchTool`]
   - [`WikipediaSearchTool`]
 - **Web Interaction**: Fetch and process content from specific web pages.
@@ -43,6 +44,10 @@ The built-in tools can be categorized by their primary functions:
 ## PythonInterpreterTool
 
 [[autodoc]] smolagents.default_tools.PythonInterpreterTool
+
+## ScavioSearchTool
+
+[[autodoc]] smolagents.default_tools.ScavioSearchTool
 
 ## SpeechToTextTool
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -290,15 +290,15 @@ class ScavioSearchTool(Tool):
         self.client = ScavioClient(api_key=self.api_key)
 
     def forward(self, query: str) -> str:
-        response = self.client.google.search(query, country_code=self.country_code)
-        results = response.get("results", [])
+        response = self.client.google.search(query, gl=self.country_code)
+        results = response.get("organic_results", [])
         if not results:
             raise Exception(f"No results found for query: '{query}'. Use a less restrictive query.")
         web_snippets = []
         for idx, page in enumerate(results[: self.max_results], start=1):
             title = page.get("title", "")
-            link = page.get("url") or page.get("link", "")
-            snippet = page.get("content") or page.get("description") or page.get("snippet", "")
+            link = page.get("link", "")
+            snippet = page.get("snippet", "")
             web_snippets.append(f"{idx}. [{title}]({link})\n{snippet}")
         return "## Search Results\n\n" + "\n\n".join(web_snippets)
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -246,6 +246,63 @@ class GoogleSearchTool(Tool):
         return "## Search Results\n" + "\n\n".join(web_snippets)
 
 
+class ScavioSearchTool(Tool):
+    """Web search tool that performs searches using the Scavio API (https://scavio.dev).
+
+    Scavio is a unified search API for AI agents. This tool uses its Google web search
+    endpoint and returns the top results as markdown. The same `scavio` SDK also covers
+    YouTube, Amazon, Walmart, Reddit, TikTok and Instagram for users who need them.
+
+    Args:
+        api_key (`str`, *optional*): Scavio API key. Falls back to the `SCAVIO_API_KEY` env variable.
+        max_results (`int`, default `10`): Maximum number of search results to return.
+        country_code (`str`, *optional*): Two-letter country code to localize results (e.g. "us").
+
+    Examples:
+        ```python
+        >>> from smolagents import ScavioSearchTool
+        >>> web_search_tool = ScavioSearchTool(max_results=5)
+        >>> results = web_search_tool("Hugging Face")
+        >>> print(results)
+        ```
+    """
+
+    name = "web_search"
+    description = "Performs a web search using the Scavio API and returns the top results formatted as markdown with titles, links, and descriptions."
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, max_results: int = 10, country_code: str | None = None):
+        super().__init__()
+        import os
+
+        try:
+            from scavio import ScavioClient
+        except ImportError as e:
+            raise ImportError(
+                "You must install package `scavio` to run this tool: for instance run `pip install scavio`."
+            ) from e
+        self.api_key = api_key or os.getenv("SCAVIO_API_KEY")
+        if self.api_key is None:
+            raise ValueError("Missing API key. Make sure you have 'SCAVIO_API_KEY' in your env variables.")
+        self.max_results = max_results
+        self.country_code = country_code
+        self.client = ScavioClient(api_key=self.api_key)
+
+    def forward(self, query: str) -> str:
+        response = self.client.google.search(query, country_code=self.country_code)
+        results = response.get("results", [])
+        if not results:
+            raise Exception(f"No results found for query: '{query}'. Use a less restrictive query.")
+        web_snippets = []
+        for idx, page in enumerate(results[: self.max_results], start=1):
+            title = page.get("title", "")
+            link = page.get("url") or page.get("link", "")
+            snippet = page.get("content") or page.get("description") or page.get("snippet", "")
+            web_snippets.append(f"{idx}. [{title}]({link})\n{snippet}")
+        return "## Search Results\n\n" + "\n\n".join(web_snippets)
+
+
 class ApiWebSearchTool(Tool):
     """Web search tool that performs API-based searches.
     By default, it uses the Brave Search API.
@@ -692,6 +749,7 @@ __all__ = [
     "WebSearchTool",
     "DuckDuckGoSearchTool",
     "GoogleSearchTool",
+    "ScavioSearchTool",
     "VisitWebpageTool",
     "WikipediaSearchTool",
     "SpeechToTextTool",

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -266,9 +266,9 @@ class TestScavioSearchTool:
 
     def test_search_results(self):
         mock_response = {
-            "results": [
-                {"title": "Scavio", "url": "https://scavio.dev", "description": "Search API for AI agents."},
-                {"title": "Hugging Face", "url": "https://huggingface.co", "description": "The AI community."},
+            "organic_results": [
+                {"title": "Scavio", "link": "https://scavio.dev", "snippet": "Search API for AI agents."},
+                {"title": "Hugging Face", "link": "https://huggingface.co", "snippet": "The AI community."},
             ]
         }
         with patch("scavio.ScavioClient") as mock_client_cls:
@@ -286,7 +286,7 @@ class TestScavioSearchTool:
     def test_no_results(self):
         with patch("scavio.ScavioClient") as mock_client_cls:
             mock_client = mock_client_cls.return_value
-            mock_client.google.search.return_value = {"results": []}
+            mock_client.google.search.return_value = {"organic_results": []}
             tool = ScavioSearchTool(api_key="test-key")
             with pytest.raises(Exception, match="No results found"):
                 tool("obscure query")

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -21,6 +21,7 @@ from smolagents.agent_types import _AGENT_TYPE_MAPPING
 from smolagents.default_tools import (
     DuckDuckGoSearchTool,
     PythonInterpreterTool,
+    ScavioSearchTool,
     SpeechToTextTool,
     VisitWebpageTool,
     WebSearchTool,
@@ -252,3 +253,40 @@ def test_wikipedia_search(language, content_type, extract_format, query):
         assert len(result.split()) < 1000, "Summary mode should return a shorter text"
     if content_type == "text":
         assert len(result.split()) > 1000, "Full text mode should return a longer text"
+
+
+class TestScavioSearchTool:
+    """Tests for ScavioSearchTool (Scavio web search)."""
+
+    def test_missing_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("scavio.ScavioClient"):
+                with pytest.raises(ValueError, match="SCAVIO_API_KEY"):
+                    ScavioSearchTool()
+
+    def test_search_results(self):
+        mock_response = {
+            "results": [
+                {"title": "Scavio", "url": "https://scavio.dev", "description": "Search API for AI agents."},
+                {"title": "Hugging Face", "url": "https://huggingface.co", "description": "The AI community."},
+            ]
+        }
+        with patch("scavio.ScavioClient") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.google.search.return_value = mock_response
+            tool = ScavioSearchTool(api_key="test-key", max_results=2)
+            result = tool("test query")
+
+        assert "## Search Results" in result
+        assert "[Scavio](https://scavio.dev)" in result
+        assert "[Hugging Face](https://huggingface.co)" in result
+        assert "Search API for AI agents." in result
+        mock_client.google.search.assert_called_once()
+
+    def test_no_results(self):
+        with patch("scavio.ScavioClient") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.google.search.return_value = {"results": []}
+            tool = ScavioSearchTool(api_key="test-key")
+            with pytest.raises(Exception, match="No results found"):
+                tool("obscure query")


### PR DESCRIPTION
## What does this PR do?

Adds `ScavioSearchTool`, a web search tool backed by the [Scavio](https://scavio.dev) API, alongside the existing `GoogleSearchTool` / `DuckDuckGoSearchTool` / `ApiWebSearchTool`.

- New `ScavioSearchTool(Tool)` in `src/smolagents/default_tools.py`, mirroring the existing search-tool pattern (markdown output, API key from `SCAVIO_API_KEY` or `api_key=`, optional dependency guard on the `scavio` SDK).
- Exported in `__all__`; not added to `TOOL_MAPPING` (needs an API key, like `GoogleSearchTool`).
- Unit tests in `tests/test_default_tools.py` (`TestScavioSearchTool`): missing-key error, result formatting, no-results.
- Docs entry in `docs/source/en/reference/default_tools.md`.

Scavio is a unified search API for AI agents; this tool uses its Google web-search endpoint. The same `scavio` SDK also covers YouTube, Amazon, Walmart, Reddit, TikTok and Instagram for users who need them.

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Checks

- `ruff check` / `ruff format` clean
- `pytest tests/test_default_tools.py::TestScavioSearchTool` passes (3 tests)
- Verified end-to-end: a `ToolCallingAgent` with this tool calls `web_search` and returns live results.
