### PR TITLE
Fix stale print logs after syntax errors

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1611,6 +1611,13 @@ def evaluate_python_code(
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
     """
+    if state is None:
+        state = {}
+    static_tools = static_tools.copy() if static_tools is not None else {}
+    custom_tools = custom_tools if custom_tools is not None else {}
+    state["_print_outputs"] = PrintContainer()
+    state["_operations_count"] = {"counter": 0}
+
     try:
         expression = ast.parse(code)
     except SyntaxError as e:
@@ -1619,13 +1626,6 @@ def evaluate_python_code(
             f"{e.text}"
             f"{' ' * (e.offset or 0)}^"
         )
-
-    if state is None:
-        state = {}
-    static_tools = static_tools.copy() if static_tools is not None else {}
-    custom_tools = custom_tools if custom_tools is not None else {}
-    state["_print_outputs"] = PrintContainer()
-    state["_operations_count"] = {"counter": 0}
 
     if "final_answer" in static_tools:
         previous_final_answer = static_tools["final_answer"]

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1378,6 +1378,18 @@ shift_intervals
         assert "SyntaxError" in str(e)
         assert "     ^" in str(e)
 
+    def test_syntax_error_resets_print_outputs(self):
+        state = {}
+        evaluate_python_code("print('previous step')", {"print": print}, state=state)
+        assert str(state["_print_outputs"]) == "previous step\n"
+
+        code = "print('current step')\ndef bad_syntax(\n    pass"
+        with pytest.raises(InterpreterError) as e:
+            evaluate_python_code(code, {"print": print}, state=state)
+
+        assert "SyntaxError" in str(e)
+        assert str(state["_print_outputs"]) == ""
+
     def test_close_matches_subscript(self):
         code = 'capitals = {"Czech Republic": "Prague", "Monaco": "Monaco", "Bhutan": "Thimphu"};capitals["Butan"]'
         with pytest.raises(Exception) as e:


### PR DESCRIPTION
Fixes #1998.

## What changed
- Reset the per-run `_print_outputs` and operation counter before parsing code.
- Keep SyntaxError reporting unchanged, but prevent the previous execution logs from leaking when parsing fails before execution starts.
- Add a regression test covering a previous successful print followed by a syntax error in the next execution.

## Why
`evaluate_python_code` initialized `_print_outputs` only after `ast.parse`. When a later step failed during parsing, the executor kept the previous step's print container in shared state, so callers could report stale logs for the syntax-error step.

## Validation
- Reproduced before the fix: after `print('leak me')`, a following SyntaxError left `state['_print_outputs'] == 'leak me\n'`.
- After the fix, the same SyntaxError leaves `state['_print_outputs'] == ''`.
- `uv run pytest tests/test_local_python_executor.py -q -k 'syntax_error or print_outputs'` -> 2 passed, 398 deselected.
- `uv run pytest tests/test_local_python_executor.py -q` -> 398 passed, 2 skipped.
- `uv run ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py` -> all checks passed.
- `uv run ruff format --check src/smolagents/local_python_executor.py tests/test_local_python_executor.py` -> 2 files already formatted.
- `git diff --check` -> clean.