### PR TITLE
Fix consecutive string message merging

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -373,10 +373,18 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
-            if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+            if isinstance(message.content, str):
+                if flatten_messages_as_text or isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] += "\n" + message.content
+                else:
+                    output_message_list[-1]["content"].append({"type": "text", "text": message.content})
             else:
+                assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
+                if flatten_messages_as_text:
+                    output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                    continue
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -724,6 +724,32 @@ def test_get_clean_message_list_with_dicts(messages, expected_roles, expected_te
         assert msg["content"][0]["text"] == expected_texts[i]
 
 
+def test_get_clean_message_list_merges_consecutive_string_messages():
+    messages = [
+        {"role": "system", "content": "Start with FOO"},
+        {"role": "system", "content": "End with BAR"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+
+    result = get_clean_message_list(messages)
+
+    assert result == [
+        {"role": "system", "content": "Start with FOO\nEnd with BAR"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+
+
+def test_get_clean_message_list_merges_string_with_text_blocks():
+    messages = [
+        {"role": "system", "content": "Start with FOO"},
+        {"role": "system", "content": [{"type": "text", "text": "End with BAR"}]},
+    ]
+
+    result = get_clean_message_list(messages)
+
+    assert result == [{"role": "system", "content": [{"type": "text", "text": "Start with FOO\nEnd with BAR"}]}]
+
+
 def test_get_clean_message_list_role_conversions():
     messages = [
         ChatMessage(role=MessageRole.TOOL_CALL, content=[{"type": "text", "text": "Calling tool..."}]),


### PR DESCRIPTION
Fixes #1972.

## What changed
- Allow `get_clean_message_list` to merge consecutive same-role messages when the later message content is a plain string.
- Preserve the existing text-block merge behavior for list content.
- Convert a previous string content into a text block only when it needs to merge with following structured text blocks.
- Add regression tests for consecutive system string messages and mixed string/text-block messages.

## Why
`get_clean_message_list` already promises to concatenate subsequent messages with the same role, but the merge branch asserted that the later message content must be a list. Consecutive system messages supplied as plain strings therefore raised `AssertionError: Error: wrong content:...` before `LiteLLMModel` could call the provider.

## Validation
- Reproduced before the fix with two consecutive `system` string messages: `AssertionError Error: wrong content:When you say anything End with 'BAR'`.
- After the fix, the same input becomes one merged system message with newline-separated content.
- `uv run pytest tests/test_models.py -q -k 'get_clean_message_list'` -> 9 passed, 113 deselected.
- `uv run ruff check src/smolagents/models.py tests/test_models.py` -> all checks passed.
- `uv run ruff format --check src/smolagents/models.py tests/test_models.py` -> 2 files already formatted.
- `git diff --check` -> clean.

Note: I also tried the full `uv run pytest tests/test_models.py -q`, but this local environment lacks optional extras (`mlx_lm`, `torch`/`transformers`, `litellm`, and `openai`), so the unrelated optional-provider tests fail at import/constructor setup before exercising this change.