### PR TITLE
Block unsafe class dunder methods in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -564,6 +564,8 @@ def evaluate_class_def(
 
     for stmt in class_def.body:
         if isinstance(stmt, ast.FunctionDef):
+            if stmt.name.startswith("__") and stmt.name.endswith("__") and stmt.name not in ALLOWED_DUNDER_METHODS:
+                raise InterpreterError(f"Forbidden class dunder method definition: {stmt.name}")
             class_dict[stmt.name] = evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
         elif isinstance(stmt, ast.AnnAssign):
             if stmt.value:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -225,6 +225,36 @@ test_func(**None)
         assert result == 42
         assert state["instance"].__doc__ == "A class with a value."
 
+    @pytest.mark.parametrize("method_name", ["__del__", "__getattribute__", "__eq__"])
+    def test_evaluate_class_def_rejects_host_implicit_dunder_methods(self, method_name):
+        code = dedent(f"""
+            class TimeBomb:
+                def {method_name}(self):
+                    return True
+        """)
+
+        with pytest.raises(InterpreterError, match=f"Forbidden class dunder method definition: {method_name}"):
+            evaluate_python_code(code, {}, state={})
+
+    def test_evaluate_class_def_allows_explicit_dunder_whitelist(self):
+        code = dedent("""
+            class SafeDisplay:
+                def __init__(self, value):
+                    self.value = value
+
+                def __str__(self):
+                    return self.value
+
+                def __repr__(self):
+                    return self.value
+
+            result = SafeDisplay("ok").value
+        """)
+
+        result, _ = evaluate_python_code(code, {}, state={})
+
+        assert result == "ok"
+
     def test_evaluate_class_def_with_assign_attribute_target(self):
         """
         Test evaluate_class_def function when stmt is an instance of ast.Assign with ast.Attribute target.


### PR DESCRIPTION
## Summary

- Reject class methods whose names are dunder methods unless they are in the existing `ALLOWED_DUNDER_METHODS` whitelist.
- Preserve the current allowed class dunder behavior for `__init__`, `__str__`, and `__repr__`.
- Add regression coverage for host-triggered methods such as `__del__`, `__getattribute__`, and `__eq__`.

Fixes #2395.

## Tests

- `uv run --with pytest --with numpy --with pandas pytest tests/test_local_python_executor.py::TestEvaluatePythonCode::test_evaluate_class_def_rejects_host_implicit_dunder_methods tests/test_local_python_executor.py::TestEvaluatePythonCode::test_evaluate_class_def_allows_explicit_dunder_whitelist tests/test_local_python_executor.py::TestEvaluatePythonCode::test_evaluate_class_def -q`
- `uv run --with pytest --with numpy --with pandas pytest tests/test_local_python_executor.py::TestLocalPythonExecutorSecurity::test_vulnerability_via_dunder_access tests/test_local_python_executor.py::TestLocalPythonExecutorSecurity::test_vulnerability_via_dunder_call -q`
- `uv run --with ruff ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py`
- `uv run --with ruff ruff format --check src/smolagents/local_python_executor.py tests/test_local_python_executor.py && git diff --check`