### PR TITLE
Fix Docker executor cleanup on process exit

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atexit
 import base64
 import inspect
 import json
@@ -582,6 +583,8 @@ class DockerExecutor(RemotePythonExecutor):
         dockerfile_content: str | None = None,
     ):
         super().__init__(additional_imports, logger, allow_pickle)
+        self._cleaned_up = False
+        self._cleanup_registered = False
         try:
             import docker
         except ModuleNotFoundError:
@@ -650,6 +653,8 @@ class DockerExecutor(RemotePythonExecutor):
             container_kwargs["environment"] = env
 
             self.container = self.client.containers.run(self.image_name, **container_kwargs)
+            atexit.register(self.cleanup)
+            self._cleanup_registered = True
 
             retries = 0
             while self.container.status != "running" and retries < 5:
@@ -693,6 +698,9 @@ class DockerExecutor(RemotePythonExecutor):
 
     def cleanup(self):
         """Clean up the Docker container and resources."""
+        if getattr(self, "_cleaned_up", False):
+            return
+        self._cleaned_up = True
         try:
             if hasattr(self, "container"):
                 self.logger.log(f"Stopping and removing container {self.container.short_id}...", level=LogLevel.INFO)
@@ -702,9 +710,20 @@ class DockerExecutor(RemotePythonExecutor):
                 del self.container
         except Exception as e:
             self.logger.log_error(f"Error during cleanup: {e}")
+        finally:
+            if getattr(self, "_cleanup_registered", False):
+                try:
+                    atexit.unregister(self.cleanup)
+                except ValueError:
+                    pass
+                self._cleanup_registered = False
 
     def delete(self):
         """Ensure cleanup on deletion."""
+        self.cleanup()
+
+    def __del__(self):
+        """Best-effort cleanup on garbage collection."""
         self.cleanup()
 
     def _wait_for_server(self, token: str):

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -233,6 +233,8 @@ class TestDockerExecutorUnit:
         """Test that cleanup properly stops and removes the container"""
         logger = MagicMock()
         with (
+            patch("smolagents.remote_executors.atexit.register"),
+            patch("smolagents.remote_executors.atexit.unregister"),
             patch("docker.from_env") as mock_docker_client,
             patch("requests.get") as mock_get,
             patch("requests.post") as mock_post,
@@ -259,6 +261,67 @@ class TestDockerExecutorUnit:
             # Verify container was stopped and removed
             mock_container.stop.assert_called_once()
             mock_container.remove.assert_called_once()
+
+    def test_cleanup_is_registered_for_process_exit(self):
+        """Test that Docker containers are cleaned up on normal interpreter exit."""
+        logger = MagicMock()
+        with (
+            patch("smolagents.remote_executors.atexit.register") as mock_register,
+            patch("smolagents.remote_executors.atexit.unregister") as mock_unregister,
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+        ):
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+
+            executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+
+            mock_register.assert_called_once_with(executor.cleanup)
+
+            executor.cleanup()
+
+            mock_unregister.assert_called_once_with(executor.cleanup)
+
+    def test_cleanup_is_idempotent(self):
+        """Test that repeated cleanup does not stop/remove the same container twice."""
+        logger = MagicMock()
+        with (
+            patch("smolagents.remote_executors.atexit.register"),
+            patch("smolagents.remote_executors.atexit.unregister") as mock_unregister,
+            patch("docker.from_env") as mock_docker_client,
+            patch("requests.get") as mock_get,
+            patch("requests.post") as mock_post,
+            patch("websocket.create_connection"),
+        ):
+            mock_container = MagicMock()
+            mock_container.status = "running"
+            mock_container.short_id = "test123"
+
+            mock_docker_client.return_value.containers.run.return_value = mock_container
+            mock_docker_client.return_value.images.get.return_value = MagicMock()
+
+            mock_get.return_value.status_code = 200
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {"id": "test-kernel-id"}
+
+            executor = DockerExecutor(additional_imports=[], logger=logger, build_new_image=False)
+
+            executor.cleanup()
+            executor.cleanup()
+
+            mock_container.stop.assert_called_once()
+            mock_container.remove.assert_called_once()
+            mock_unregister.assert_called_once_with(executor.cleanup)
 
 
 class CommonDockerExecutorIntegration:


### PR DESCRIPTION
## Summary

- Register `DockerExecutor.cleanup()` with `atexit` after a container starts, so normal interpreter shutdown can stop and remove the Jupyter container.
- Make Docker cleanup idempotent and unregister the exit hook after manual cleanup to avoid double stop/remove calls.
- Add a `__del__` best-effort cleanup path for garbage collection.

Refs #2050. This improves cleanup for normal process exit paths such as uncaught exceptions or `KeyboardInterrupt`; it does not claim to handle hard process termination such as `SIGKILL` or forcibly killing the Python process from outside the interpreter.

## Validation

```text
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with docker --with websocket-client --with pillow --with rich pytest tests/test_remote_executors.py::TestDockerExecutorUnit -q
# 3 passed in 0.09s

env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with ruff ruff check src/smolagents/remote_executors.py tests/test_remote_executors.py
# All checks passed!

env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run python -m py_compile src/smolagents/remote_executors.py tests/test_remote_executors.py
# passed

env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with ruff ruff format --check src/smolagents/remote_executors.py tests/test_remote_executors.py
# 2 files already formatted

git diff --check
# passed
```
