### PR TITLE
Fix managed agent config deserialization

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,7 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1594,6 +1594,34 @@ class TestMultiStepAgent:
         assert recreated_managed_agent.description == "A managed agent for testing"
         assert recreated_managed_agent.max_steps == 5
 
+    def test_multiagent_from_dict_preserves_managed_agent_authorized_imports(self):
+        """Test that parent deserialization kwargs do not override managed agent settings."""
+        managed_agent = CodeAgent(
+            tools=[],
+            model=MagicMock(),
+            name="managed_agent",
+            description="A managed agent for testing",
+            additional_authorized_imports=["json"],
+        )
+        main_agent = CodeAgent(
+            tools=[],
+            managed_agents=[managed_agent],
+            model=MagicMock(),
+            additional_authorized_imports=["uuid"],
+        )
+        agent_dict = main_agent.to_dict()
+
+        mock_model_class = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_model_class.from_dict.return_value = mock_model_instance
+
+        with patch.dict("smolagents.models.MODEL_REGISTRY", {"MagicMock": mock_model_class}):
+            recreated_agent = CodeAgent.from_dict(agent_dict)
+
+        recreated_managed_agent = recreated_agent.managed_agents["managed_agent"]
+        assert "json" in recreated_managed_agent.authorized_imports
+        assert "uuid" not in recreated_managed_agent.authorized_imports
+
     def test_from_dict_invalid_model_class(self):
         """Test that from_dict raises ValueError with helpful message for invalid model class."""
         agent_dict = {


### PR DESCRIPTION
## What

Fixes #1849.

`MultiStepAgent.from_dict()` no longer forwards the parent agent's deserialization override kwargs into each serialized managed agent. Managed agents are now reconstructed from their own serialized dictionaries, so child-specific settings such as `authorized_imports` are preserved.

## Why

For `CodeAgent.from_dict()`, the parent agent turns its serialized `authorized_imports` into `additional_authorized_imports` kwargs before delegating to `MultiStepAgent.from_dict()`. Passing those kwargs into each managed agent caused the parent imports to overwrite the child agent's own serialized imports.

I reproduced this on current `main`: a managed `CodeAgent` serialized with a custom import kept that import in `agent_dict["managed_agents"][0]["authorized_imports"]`, but after `CodeAgent.from_dict(agent_dict)` the restored managed agent no longer had it.

## Tests

```bash
uv run --with-editable . --with pytest pytest tests/test_agents.py::TestMultiStepAgent::test_multiagent_from_dict_preserves_managed_agent_authorized_imports tests/test_agents.py::TestMultiStepAgent::test_multiagent_to_dict_from_dict_roundtrip -q
# 2 passed in 0.08s

uv run --with-editable . --with pytest --with numpy --with pandas pytest tests/test_agents.py -q -k 'from_dict or multiagent_to_dict_from_dict_roundtrip or preserves_managed_agent_authorized_imports'
# 6 passed, 92 deselected in 0.12s

uv run --with-editable . --with ruff ruff check src/smolagents/agents.py tests/test_agents.py
# All checks passed!

uv run --with-editable . --with ruff ruff format --check src/smolagents/agents.py tests/test_agents.py
# 2 files already formatted

git diff --check
# passed
```
