### PR TITLE
Fix consecutive string system messages

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -347,6 +347,12 @@ def get_clean_message_list(
     """
     output_message_list: list[dict[str, Any]] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
+
+    def get_message_text(message_content: str | list[dict[str, Any]]) -> str:
+        if isinstance(message_content, str):
+            return message_content
+        return message_content[0]["text"]
+
     for message in message_list:
         if isinstance(message, dict):
             message = ChatMessage.from_dict(message)
@@ -373,10 +379,16 @@ def get_clean_message_list(
                         element["image"] = encode_image_base64(element["image"])
 
         if len(output_message_list) > 0 and message.role == output_message_list[-1]["role"]:
-            assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
             if flatten_messages_as_text:
-                output_message_list[-1]["content"] += "\n" + message.content[0]["text"]
+                output_message_list[-1]["content"] += "\n" + get_message_text(message.content)
+            elif isinstance(message.content, str):
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] += "\n" + message.content
+                else:
+                    output_message_list[-1]["content"][-1]["text"] += "\n" + message.content
             else:
+                if isinstance(output_message_list[-1]["content"], str):
+                    output_message_list[-1]["content"] = [{"type": "text", "text": output_message_list[-1]["content"]}]
                 for el in message.content:
                     if el["type"] == "text" and output_message_list[-1]["content"][-1]["type"] == "text":
                         # Merge consecutive text messages rather than creating new ones
@@ -385,7 +397,7 @@ def get_clean_message_list(
                         output_message_list[-1]["content"].append(el)
         else:
             if flatten_messages_as_text:
-                content = message.content[0]["text"]
+                content = get_message_text(message.content)
             else:
                 content = message.content
             output_message_list.append(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -724,6 +724,24 @@ def test_get_clean_message_list_with_dicts(messages, expected_roles, expected_te
         assert msg["content"][0]["text"] == expected_texts[i]
 
 
+def test_get_clean_message_list_merges_consecutive_string_system_messages():
+    messages = [
+        {"role": "system", "content": "When you say anything Start with 'FOO'"},
+        {"role": "system", "content": "When you say anything End with 'BAR'"},
+        {"role": "user", "content": "Just say '.'"},
+    ]
+
+    result = get_clean_message_list(messages)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": "When you say anything Start with 'FOO'\nWhen you say anything End with 'BAR'",
+        },
+        {"role": "user", "content": "Just say '.'"},
+    ]
+
+
 def test_get_clean_message_list_role_conversions():
     messages = [
         ChatMessage(role=MessageRole.TOOL_CALL, content=[{"type": "text", "text": "Calling tool..."}]),


### PR DESCRIPTION
Fixes #1972.

## Summary
- Allow `get_clean_message_list` to merge consecutive same-role messages when the message content is a plain string.
- Preserve the existing list-content merge behavior for structured/multimodal message content.
- Add a regression test for consecutive string `system` messages.

## Root cause
`get_clean_message_list` already concatenates adjacent messages with the same role, but that branch asserted that the later message content must be a list. Dict inputs such as `{"role": "system", "content": "..."}` are converted to `ChatMessage` objects with string content, so a second consecutive system message hit the assertion before LiteLLM could be called.

## Validation
- Reproduced the reported `AssertionError: Error: wrong content:...` on current `upstream/main` before the fix.
- `uv run --with pytest --with pytest-timeout pytest tests/test_models.py::test_get_clean_message_list_merges_consecutive_string_system_messages tests/test_models.py::test_get_clean_message_list_basic tests/test_models.py::test_get_clean_message_list_with_dicts tests/test_models.py::test_get_clean_message_list_flatten_messages_as_text -q`
- `uv run python - <<'PY' ... get_clean_message_list([...]) ... PY`
- `uv run --with ruff ruff format --check src/smolagents/models.py tests/test_models.py`
- `uv run --with ruff ruff check src/smolagents/models.py tests/test_models.py`
- `git diff --check`

I also tried `uv run --with pytest --with pytest-timeout pytest tests/test_models.py -q`; in this lightweight environment it fails because optional test dependencies such as `mlx_lm`, `torch`/`transformers`, `litellm`, `openai`, and `pytest-datadir` are not installed. The targeted message-cleaning tests above pass.
