### PR TITLE
Apply f-string conversion field (!s/!r/!a) in local_python_executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1506,6 +1506,13 @@ def evaluate_ast(
     elif isinstance(expression, ast.FormattedValue):
         # Formatted value (part of f-string) -> evaluate the content and format it
         value = evaluate_ast(expression.value, *common_params)
+        # Apply the conversion field (!s / !r / !a) before the format spec, like CPython
+        if expression.conversion == 115:  # !s
+            value = str(value)
+        elif expression.conversion == 114:  # !r
+            value = repr(value)
+        elif expression.conversion == 97:  # !a
+            value = ascii(value)
         # Early return if no format spec
         if not expression.format_spec:
             return value

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -288,6 +288,18 @@ test_func(**None)
             state, {"x": 3.336, "text": "This is x: 3.34.", "_operations_count": {"counter": 8}}
         )
 
+    def test_evaluate_f_string_with_conversion(self):
+        # !r / !s / !a conversion fields must be applied (matching CPython f-strings).
+        result, _ = evaluate_python_code("text = f'{x!r}'", {}, state={"x": "hello"})
+        assert result == "'hello'"
+        result, _ = evaluate_python_code("text = f'{x!s}'", {}, state={"x": 42})
+        assert result == "42"
+        result, _ = evaluate_python_code("text = f'{x!a}'", {}, state={"x": "café"})
+        assert result == "'caf\\xe9'"
+        # conversion combined with a format spec
+        result, _ = evaluate_python_code("text = f'{x!r:>10}'", {}, state={"x": "hi"})
+        assert result == "      'hi'"
+
     def test_evaluate_f_string_with_complex_format(self):
         code = "text = f'This is x: {x:>{width}.{precision}f}.'"
         state = {"x": 3.336, "width": 10, "precision": 2}


### PR DESCRIPTION
## What

The `ast.FormattedValue` branch in `local_python_executor.py` evaluates the value and applies the
format spec, but ignores `expression.conversion`, so f-strings using the `!s` / `!r` / `!a` conversion
fields are silently mis-rendered — diverging from real CPython.

## Reproduce

```python
from smolagents.local_python_executor import evaluate_python_code
print(evaluate_python_code("text = f'{x!r}'", {}, state={"x": "hello"})[0])
# executor: hello
# cpython : 'hello'
print(evaluate_python_code("text = f'{x!a}'", {}, state={"x": "café"})[0])
# executor: café
# cpython : 'caf\xe9'
```

(`!r:>10`, etc. are also affected — the conversion is dropped before the format spec is applied.)

## Fix

Apply the conversion (`str` / `repr` / `ascii`) before the format spec, matching CPython:

```python
if expression.conversion == 115:  # !s
    value = str(value)
elif expression.conversion == 114:  # !r
    value = repr(value)
elif expression.conversion == 97:  # !a
    value = ascii(value)
```

(Complements #660, which added `format_spec` handling but didn't touch `conversion`.)

## Tests

`tests/test_local_python_executor.py::test_evaluate_f_string_with_conversion` covers `!r`, `!s`, `!a`,
and `!r` + format spec. Fails before, passes after; existing f-string tests still pass.
