### PR TITLE
Support dict-literal unpacking ({**mapping}) in local_python_executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1493,10 +1493,20 @@ def evaluate_ast(
     elif isinstance(expression, ast.FunctionDef):
         return evaluate_function_def(expression, *common_params)
     elif isinstance(expression, ast.Dict):
-        # Dict -> evaluate all keys and values
-        keys = (evaluate_ast(k, *common_params) for k in expression.keys)
-        values = (evaluate_ast(v, *common_params) for v in expression.values)
-        return dict(zip(keys, values))
+        # Dict -> evaluate all keys and values; a None key denotes unpacking ({**mapping})
+        result = {}
+        for key_node, value_node in zip(expression.keys, expression.values):
+            if key_node is None:
+                mapping = evaluate_ast(value_node, *common_params)
+                try:
+                    result.update(mapping)
+                except (TypeError, ValueError) as e:
+                    raise InterpreterError(
+                        f"Cannot unpack a non-mapping value of type {type(mapping).__name__} in a dict literal"
+                    ) from e
+            else:
+                result[evaluate_ast(key_node, *common_params)] = evaluate_ast(value_node, *common_params)
+        return result
     elif isinstance(expression, ast.Expr):
         # Expression -> evaluate the content
         return evaluate_ast(expression.value, *common_params)

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -263,6 +263,16 @@ test_func(**None)
             state, {"x": 3, "test_dict": {"x": 3, "y": 5}, "_operations_count": {"counter": 7}}
         )
 
+    def test_evaluate_dict_unpacking(self):
+        # {**mapping} dict-literal unpacking (CPython semantics), including override order.
+        result, _ = evaluate_python_code('d = {"a": 1}\nout = {**d, "b": 2}', {}, state={})
+        assert result == {"a": 1, "b": 2}
+        result, _ = evaluate_python_code('a = {"x": 1}\nb = {"y": 2}\nout = {**a, **b}', {}, state={})
+        assert result == {"x": 1, "y": 2}
+        # later entries override earlier ones
+        result, _ = evaluate_python_code('d = {"a": 1}\nout = {**d, "a": 9}', {}, state={})
+        assert result == {"a": 9}
+
     def test_evaluate_expression(self):
         code = "x = 3\ny = 5"
         state = {}


### PR DESCRIPTION
## What

The `ast.Dict` branch in `local_python_executor.py` evaluates every key with `evaluate_ast`, but a
`{**mapping}` spread element has a `None` key in the AST. So the very common dict-unpacking idiom
crashes:

```python
from smolagents.local_python_executor import evaluate_python_code
evaluate_python_code('d = {"a": 1}\nout = {**d, "b": 2}', {}, state={})
# InterpreterError: ... NoneType is not supported
# cpython: {"a": 1, "b": 2}
```

`{**a, **b}` fails the same way.

## Fix

Handle `None` keys as unpacking via `dict.update`, preserving CPython's left-to-right override
semantics, and raise a clear `InterpreterError` if the spread value isn't a mapping.

## Tests

`tests/test_local_python_executor.py::test_evaluate_dict_unpacking` — `{**d, "b": 2}`, `{**a, **b}`,
and override order (`{**d, "a": 9}` -> `{"a": 9}`). Fails before, passes after.
