### PR TITLE
Run for/while else clause in local_python_executor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -456,6 +456,9 @@ def evaluate_while(
         iterations += 1
         if iterations > MAX_WHILE_ITERATIONS:
             raise InterpreterError(f"Maximum number of {MAX_WHILE_ITERATIONS} iterations in While loop exceeded")
+    # The test became false without a `break`, so run the `else` clause (if any).
+    for node in while_loop.orelse:
+        evaluate_ast(node, state, static_tools, custom_tools, authorized_imports)
     return None
 
 
@@ -1050,6 +1053,11 @@ def evaluate_for(
                 return result
             except ContinueException:
                 break
+    # The loop completed without `break`, so run the `else` clause (if any).
+    for node in for_loop.orelse:
+        line_result = evaluate_ast(node, state, static_tools, custom_tools, authorized_imports)
+        if line_result is not None:
+            result = line_result
     return result
 
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -371,6 +371,31 @@ for result in search_results:
         assert result == 2
         self.assertDictEqualNoPrint(state, {"x": 2, "i": 2, "_operations_count": {"counter": 11}})
 
+    def test_for_else_clause(self):
+        # for-else: the else clause runs when the loop completes without break,
+        # and is skipped when the loop breaks (CPython semantics).
+        state = {}
+        evaluate_python_code("r = 'no'\nfor i in range(3):\n    pass\nelse:\n    r = 'yes'", {"range": range}, state=state)
+        assert state["r"] == "yes"
+
+        state = {}
+        evaluate_python_code(
+            "r = 'init'\nfor i in range(3):\n    if i == 1:\n        break\nelse:\n    r = 'else'",
+            {"range": range},
+            state=state,
+        )
+        assert state["r"] == "init"
+
+    def test_while_else_clause(self):
+        # while-else: else runs when the test becomes false, skipped on break.
+        state = {}
+        evaluate_python_code("i = 0\nr = 'no'\nwhile i < 2:\n    i += 1\nelse:\n    r = 'yes'", {}, state=state)
+        assert state["r"] == "yes"
+
+        state = {}
+        evaluate_python_code("i = 0\nr = 'init'\nwhile i < 3:\n    if i == 1:\n        break\n    i += 1\nelse:\n    r = 'else'", {}, state=state)
+        assert state["r"] == "init"
+
     def test_evaluate_binop(self):
         code = "y + x"
         state = {"x": 3, "y": 6}


### PR DESCRIPTION
## What

`evaluate_for` and `evaluate_while` in `local_python_executor.py` never execute the loop's `else`
clause, so `for ... else` / `while ... else` bodies are silently dropped — diverging from CPython.

```python
from smolagents.local_python_executor import evaluate_python_code
state = {}
evaluate_python_code("r='no'\nfor i in range(3):\n    pass\nelse:\n    r='yes'", {}, state=state)
print(state["r"])   # executor: 'no'   |  cpython: 'yes'
```

This breaks common search-then-else patterns (`for x in items: if match: break` … `else: not_found()`).

## Fix

Run `orelse` after the loop completes without `break`. The existing `except BreakException: return`
paths already return early, correctly skipping the `else` on break — so the change is just to execute
the `else` body on normal completion.

## Tests

`tests/test_local_python_executor.py::test_for_else_clause` and `::test_while_else_clause` cover both
"runs on normal completion" and "skipped on break". Fail before, pass after; existing loop/break/continue
tests still pass.
