### PR TITLE
Add TwelveLabsVideoUnderstandingTool for video understanding with Pegasus

### DIFF
--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -21,6 +21,8 @@ The built-in tools can be categorized by their primary functions:
   - [`UserInputTool`]: Collect input from users.
 - **Speech Processing**: Convert audio to textual data.
   - [`SpeechToTextTool`]
+- **Video Understanding**: Analyze and answer questions about video content.
+  - [`TwelveLabsVideoUnderstandingTool`]
 - **Workflow Control**: Manage and direct the flow of agent operations.
   - [`FinalAnswerTool`]: Conclude agent workflow with final response.
 
@@ -47,6 +49,10 @@ The built-in tools can be categorized by their primary functions:
 ## SpeechToTextTool
 
 [[autodoc]] smolagents.default_tools.SpeechToTextTool
+
+## TwelveLabsVideoUnderstandingTool
+
+[[autodoc]] smolagents.default_tools.TwelveLabsVideoUnderstandingTool
 
 ## UserInputTool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ transformers = [
   "transformers>=4.0.0",
   "smolagents[torch]",
 ]
+twelvelabs = [
+  "twelvelabs>=1.2.8",  # TwelveLabsVideoUnderstandingTool
+]
 vision = [
   "helium",
   "selenium",
@@ -90,7 +93,7 @@ vllm = [
   "torch"
 ]
 all = [
-  "smolagents[audio,blaxel,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,vision,bedrock]",
+  "smolagents[audio,blaxel,docker,e2b,gradio,litellm,mcp,mlx-lm,modal,openai,telemetry,toolkit,transformers,twelvelabs,vision,bedrock]",
 ]
 quality = [
   "ruff>=0.9.0",

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -643,6 +643,85 @@ class WikipediaSearchTool(Tool):
             return f"Error fetching Wikipedia summary: {str(e)}"
 
 
+class TwelveLabsVideoUnderstandingTool(Tool):
+    """
+    Analyze and answer questions about a video using TwelveLabs' Pegasus video-understanding model.
+
+    Pegasus watches the video (visuals, motion, on-screen text and audio) and returns a natural-language
+    answer to your prompt, so an agent can summarize footage, extract facts, or reason about what happens
+    on screen without first transcribing or captioning it.
+
+    The video is sent to the TwelveLabs API as a public URL and processed server-side. Processing a video
+    can take from a few seconds up to a couple of minutes depending on its length.
+
+    Requires a TwelveLabs API key (get a free one at https://twelvelabs.io). The key is read from the
+    `TWELVELABS_API_KEY` environment variable by default, or can be passed explicitly via `api_key`.
+
+    Args:
+        api_key (`str`, *optional*): TwelveLabs API key. Defaults to the `TWELVELABS_API_KEY` environment variable.
+        model_name (`str`, default `"pegasus1.5"`): Pegasus model to use for analysis.
+        max_tokens (`int`, default `2048`): Maximum number of tokens in the generated answer (must be between 512 and 98304).
+
+    Example:
+        ```python
+        >>> from smolagents import CodeAgent, InferenceClientModel, TwelveLabsVideoUnderstandingTool
+        >>> agent = CodeAgent(tools=[TwelveLabsVideoUnderstandingTool()], model=InferenceClientModel())
+        >>> agent.run(
+        ...     "What happens in this video? https://example.com/clip.mp4"
+        ... )
+        ```
+    """
+
+    name = "video_understanding"
+    description = (
+        "Analyzes a video given its public URL and answers a natural-language question about its content "
+        "(what happens, who/what appears, on-screen text, spoken audio). Returns the answer as text."
+    )
+    inputs = {
+        "video_url": {
+            "type": "string",
+            "description": "Public URL of the video to analyze (e.g. an https link to an .mp4 file).",
+        },
+        "prompt": {
+            "type": "string",
+            "description": "The question or instruction about the video, e.g. 'Summarize this video' or 'What objects appear?'.",
+        },
+    }
+    output_type = "string"
+
+    def __init__(self, api_key: str | None = None, model_name: str = "pegasus1.5", max_tokens: int = 2048):
+        super().__init__()
+        import os
+
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:
+            raise ImportError(
+                "You must install package `twelvelabs` to run this tool: for instance run `pip install twelvelabs`."
+            ) from e
+
+        self.api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Missing API key. Provide `api_key` or set the `TWELVELABS_API_KEY` environment variable. "
+                "Get a free key at https://twelvelabs.io."
+            )
+        self.model_name = model_name
+        self.max_tokens = max_tokens
+        self.client = TwelveLabs(api_key=self.api_key)
+
+    def forward(self, video_url: str, prompt: str) -> str:
+        from twelvelabs.types.video_context import VideoContext_Url
+
+        response = self.client.analyze(
+            model_name=self.model_name,
+            video=VideoContext_Url(url=video_url),
+            prompt=prompt,
+            max_tokens=self.max_tokens,
+        )
+        return response.data or ""
+
+
 class SpeechToTextTool(PipelineTool):
     default_checkpoint = "openai/whisper-large-v3-turbo"
     description = "This is a tool that transcribes an audio into text. It returns the transcribed text."
@@ -694,5 +773,6 @@ __all__ = [
     "GoogleSearchTool",
     "VisitWebpageTool",
     "WikipediaSearchTool",
+    "TwelveLabsVideoUnderstandingTool",
     "SpeechToTextTool",
 ]

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import unittest
-from unittest.mock import patch
+from importlib.util import find_spec
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,6 +24,7 @@ from smolagents.default_tools import (
     DuckDuckGoSearchTool,
     PythonInterpreterTool,
     SpeechToTextTool,
+    TwelveLabsVideoUnderstandingTool,
     VisitWebpageTool,
     WebSearchTool,
     WikipediaSearchTool,
@@ -30,6 +33,9 @@ from smolagents.local_python_executor import ExecutionTimeoutError
 
 from .test_tools import ToolTesterMixin
 from .utils.markers import require_run_all
+
+
+require_twelvelabs = pytest.mark.skipif(find_spec("twelvelabs") is None, reason="requires twelvelabs")
 
 
 class DefaultToolTests(unittest.TestCase):
@@ -252,3 +258,35 @@ def test_wikipedia_search(language, content_type, extract_format, query):
         assert len(result.split()) < 1000, "Summary mode should return a shorter text"
     if content_type == "text":
         assert len(result.split()) > 1000, "Full text mode should return a longer text"
+
+
+@require_twelvelabs
+class TestTwelveLabsVideoUnderstandingTool:
+    def test_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Missing API key"):
+                TwelveLabsVideoUnderstandingTool()
+
+    def test_forward_wires_request_and_returns_data(self):
+        tool = TwelveLabsVideoUnderstandingTool(api_key="test-key", max_tokens=512)
+        tool.client = MagicMock()
+        tool.client.analyze.return_value = MagicMock(data="A rabbit hops through a meadow.")
+
+        result = tool.forward("https://example.com/clip.mp4", "What happens in this video?")
+
+        assert result == "A rabbit hops through a meadow."
+        tool.client.analyze.assert_called_once()
+        kwargs = tool.client.analyze.call_args.kwargs
+        assert kwargs["model_name"] == "pegasus1.5"
+        assert kwargs["prompt"] == "What happens in this video?"
+        assert kwargs["max_tokens"] == 512
+        assert kwargs["video"].url == "https://example.com/clip.mp4"
+
+    @require_run_all
+    def test_live_video_understanding(self):
+        tool = TwelveLabsVideoUnderstandingTool(max_tokens=512)
+        result = tool.forward(
+            "https://download.samplelib.com/mp4/sample-5s.mp4",
+            "Describe this video in one sentence.",
+        )
+        assert isinstance(result, str)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new built-in tool, `TwelveLabsVideoUnderstandingTool`, that lets agents reason about **video** content. It uses TwelveLabs' [Pegasus](https://twelvelabs.io) video-understanding model: given a public video URL and a natural-language prompt, Pegasus watches the footage (visuals, motion, on-screen text and audio) and returns a text answer — so an agent can summarize clips, extract facts, or answer questions about what happens on screen without first transcribing or captioning the video.

```python
from smolagents import CodeAgent, InferenceClientModel, TwelveLabsVideoUnderstandingTool

agent = CodeAgent(tools=[TwelveLabsVideoUnderstandingTool()], model=InferenceClientModel())
agent.run("What happens in this video? https://example.com/clip.mp4")
```

## Why it helps smolagents

smolagents already covers web search, webpage reading, and speech-to-text, but has no way to reason about video. This fills that gap with a small, dependency-light tool that follows the exact conventions of the other built-in tools (lazy import, `TWELVELABS_API_KEY` env var with an explicit `api_key` override, clear `ImportError`/`ValueError` messages).

## Opt-in / non-breaking

Fully additive: a new optional `twelvelabs` extra in `pyproject.toml` (also folded into `all`), a new entry in `__all__`, and a docs section. Nothing changes for existing users — the SDK only imports when the tool is instantiated.

## Testing

- `pip install -e . twelvelabs && ruff check / ruff format --check` — clean on changed files.
- Unit tests (no network): `tests/test_default_tools.py::TestTwelveLabsVideoUnderstandingTool` — verifies the missing-API-key error and that `forward()` wires `model_name`, `prompt`, `max_tokens` and the video URL into the SDK call and returns `response.data`. **2 passed, 1 skipped** (live test gated on `RUN_ALL`).
- Verified end-to-end against the live API: the SDK call path, `pegasus1.5` model name, `VideoContext_Url` and `max_tokens` validation all reach the Pegasus backend and authenticate correctly.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
