### PR TITLE
fix: stop ManagedAgent run summary from leaking inner tool calls and responses

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -883,7 +883,12 @@ You have been provided with these additional arguments, that you can access dire
         )
         if self.provide_run_summary:
             answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
-            for message in self.write_memory_to_messages(summary_mode=True):
+            for message in self.write_memory_to_messages():
+                # Only surface the agent's own reasoning, never the raw tool-call and
+                # tool-response messages. The latter can carry secrets, PII or internal IDs
+                # returned by tools, which must not leak into the manager's context.
+                if message.role != MessageRole.ASSISTANT:
+                    continue
                 content = message.content
                 answer += "\n" + truncate_content(str(content)) + "\n---"
             answer += "\n</summary_of_work>"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2120,6 +2120,74 @@ class TestCodeAgent:
             )
         assert result == expected_summary
 
+    def test_managed_agent_run_summary_excludes_tool_io(self):
+        # A managed agent with provide_run_summary=True must not feed raw tool-call and
+        # tool-response messages (which can carry secrets, PII or internal IDs returned by
+        # tools) into the manager's observation. Only the agent's own reasoning and the
+        # wrapped final answer should be surfaced. See issue #2424.
+        class SecretTool(Tool):
+            name = "search"
+            description = "Search internal database."
+            inputs = {"query": {"type": "string", "description": "query string"}}
+            output_type = "string"
+
+            def forward(self, query: str) -> str:
+                return "INTERNAL_DOC_HIT[secret_api_key=sk-LEAK-XYZ]"
+
+        class ScriptedModel(Model):
+            def __init__(self):
+                super().__init__()
+                self._step = 0
+
+            def generate(self, messages, tools_to_call_from=None, stop_sequences=None, **kwargs):
+                self._step += 1
+                if self._step == 1:
+                    return ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="I will search the database.",
+                        tool_calls=[
+                            ChatMessageToolCall(
+                                id="call_0",
+                                type="function",
+                                function=ChatMessageToolCallFunction(name="search", arguments={"query": "user info"}),
+                            )
+                        ],
+                    )
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="I have the answer.",
+                    tool_calls=[
+                        ChatMessageToolCall(
+                            id="call_1",
+                            type="function",
+                            function=ChatMessageToolCallFunction(
+                                name="final_answer", arguments={"answer": "User located."}
+                            ),
+                        )
+                    ],
+                )
+
+        agent = ToolCallingAgent(
+            tools=[SecretTool()],
+            model=ScriptedModel(),
+            name="researcher",
+            description="Looks up user information.",
+            provide_run_summary=True,
+            max_steps=3,
+            verbosity_level=0,
+        )
+        observation = agent("Find the user.")
+
+        # Wrapped final answer is surfaced.
+        assert "User located." in observation
+        # The agent's own reasoning is preserved in the summary.
+        assert "I will search the database." in observation
+        # Raw tool I/O must not leak into the manager's observation.
+        assert "sk-LEAK-XYZ" not in observation
+        assert "INTERNAL_DOC_HIT" not in observation
+        assert "Calling tools" not in observation
+        assert "Observation:" not in observation
+
     def test_code_agent_image_output(self):
         from PIL import Image
 


### PR DESCRIPTION
### What

`ManagedAgent.__call__` builds the string handed back to the manager. When `provide_run_summary=True` it appends `write_memory_to_messages(summary_mode=True)` verbatim under `<summary_of_work>`.

In `summary_mode` the assistant's own text (`model_output`) is dropped, but `TOOL_CALL` and `TOOL_RESPONSE` messages are not. So the summary the manager reads on its next step is a verbatim dump of every inner tool call and every raw tool result — including any secrets, PII or internal IDs those tools returned. See #2424 for a deterministic repro.

### Fix

Keep the summary, but build it from the sub-agent's own reasoning only (`ASSISTANT` messages) and skip the tool-call / tool-response messages.

`summary_mode` itself is left untouched on purpose: it's also used in `_generate_planning_step` (`write_memory_to_messages(summary_mode=True)`), where feeding tool I/O back to the model is intended.

### Test

Added `test_managed_agent_run_summary_excludes_tool_io`: drives a managed `ToolCallingAgent` with a tool that returns a secret and asserts the wrapped final answer and the agent's reasoning are present, while the raw tool output and `Calling tools` / `Observation:` framing are not.

Closes #2424

<!-- oss-radar:idempotency=auto-20260626-100848.w2.huggingface_smolagents.2424 -->
