### PR TITLE
ci: pin actions in tests.yml to commit SHAs (follow-up to #2149)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## What does this PR do?

Pins `actions/checkout` and `actions/setup-python` in `.github/workflows/tests.yml` to the same commit SHAs that are already used in `.github/workflows/quality.yml`. Tests.yml was the last workflow in the repo still using mutable major-version tags (`@v6`).

This is a small follow-up to #2149 ("🔒 Pin GitHub Actions to commit SHAs") which pinned every other workflow but missed these two lines.

## Why

If `actions/checkout` or `actions/setup-python` get their `v6` tag re-pointed (compromised maintainer account, accidental re-tag, or release rollback), this single workflow would silently start executing different code on every push and PR — including PRs from forks. Every other workflow in the repo is already protected; this closes the gap.

The chosen SHAs are the exact same ones quality.yml uses today:

- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`  # v6.0.2
- `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405`  # v6.2.0

## Before submitting

- [x] This PR fixes a typo or improves the docs (no code change).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/smolagents/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Continues the policy set in #2149.
- [x] Did you make sure to update the documentation with your changes? N/A — CI-only.
- [x] Did you write any new necessary tests? N/A — config-only.

Diff is 2 lines.