### PR TITLE
Handle trailing braces after JSON blobs

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -165,16 +165,20 @@ def make_json_serializable(obj: Any) -> Any:
 
 def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
     "Extracts the JSON blob from the input and returns the JSON data and the rest of the input."
-    try:
-        first_accolade_index = json_blob.find("{")
-        last_accolade_index = [a.start() for a in list(re.finditer("}", json_blob))][-1]
-        json_str = json_blob[first_accolade_index : last_accolade_index + 1]
-        json_data = json.loads(json_str, strict=False)
-        return json_data, json_blob[:first_accolade_index]
-    except IndexError:
+    first_accolade_index = json_blob.find("{")
+    if first_accolade_index == -1:
         raise ValueError("The model output does not contain any JSON blob.")
+
+    try:
+        json_data, json_end = json.JSONDecoder(strict=False).raw_decode(json_blob[first_accolade_index:])
+        trailing_text = json_blob[first_accolade_index + json_end :].lstrip()
+        if trailing_text.startswith((",", "{")):
+            raise ValueError(
+                "JSON is invalid: you probably tried to provide multiple tool calls in one action. PROVIDE ONLY ONE TOOL CALL."
+            )
+        return json_data, json_blob[:first_accolade_index]
     except json.JSONDecodeError as e:
-        place = e.pos
+        place = first_accolade_index + e.pos
         if json_blob[place - 1 : place + 2] == "},\n":
             raise ValueError(
                 "JSON is invalid: you probably tried to provide multiple tool calls in one action. PROVIDE ONLY ONE TOOL CALL."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -462,6 +462,11 @@ def test_e2e_ipython_function_tool_save(tmp_path):
             {"simple": "json"},
             "With text before",
         ),
+        (
+            """With text before{"simple": "json"}Use } only in prose after the call""",
+            {"simple": "json"},
+            "With text before",
+        ),
     ],
 )
 def test_parse_json_blob_with_valid_json(raw_json, expected_data, expected_blob):
@@ -478,6 +483,7 @@ def test_parse_json_blob_with_valid_json(raw_json, expected_data, expected_blob)
         """With text here"simple": "json"}""",
         """{"simple": ""json"}With text after""",
         """{"simple": "json"With text after""",
+        """{"simple": "json"},\n{"second": "call"}""",
         "}}",
     ],
 )


### PR DESCRIPTION
## What changed

This updates `parse_json_blob()` to decode the first complete JSON object starting at the first `{` instead of slicing through the last `}` in the whole model output.

## Why

Model/tool-call text can include a valid JSON action followed by explanatory prose. If that prose contains a `}`, the previous last-brace slicing pulled the prose into the JSON string and rejected an otherwise valid tool call.

The change still rejects likely multiple tool calls such as `{"...": "..."},\n{"...": "..."}`.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_utils.py::test_parse_json_blob_with_valid_json tests/test_utils.py::test_parse_json_blob_with_invalid_json -q`
- `python -m ruff check src/smolagents/utils.py tests/test_utils.py`
- `git diff --check -- src/smolagents/utils.py tests/test_utils.py`