### PR TITLE
Fix managed agent raw summary leak

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -881,12 +881,6 @@ You have been provided with these additional arguments, that you can access dire
         answer = populate_template(
             self.prompt_templates["managed_agent"]["report"], variables=dict(name=self.name, final_answer=report)
         )
-        if self.provide_run_summary:
-            answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
-            for message in self.write_memory_to_messages(summary_mode=True):
-                content = message.content
-                answer += "\n" + truncate_content(str(content)) + "\n---"
-            answer += "\n</summary_of_work>"
         return answer
 
     def save(self, output_dir: str | Path, relative_path: str | None = None):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2113,12 +2113,27 @@ class TestCodeAgent:
 
         result = agent("Test request")
         expected_summary = "Here is the final answer from your managed agent 'test_agent':\nTest output"
-        if provide_run_summary:
-            expected_summary += (
-                "\n\nFor more detail, find below a summary of this agent's work:\n"
-                "<summary_of_work>\n\nTest summary\n---\n</summary_of_work>"
-            )
         assert result == expected_summary
+
+    def test_call_with_provide_run_summary_does_not_leak_raw_memory(self):
+        agent = CodeAgent(tools=[], model=MagicMock(), provide_run_summary=True)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Test output")
+        agent.write_memory_to_messages = MagicMock(
+            return_value=[
+                ChatMessage(role=MessageRole.TOOL_CALL, content="Calling tools:\nsearch(secret)"),
+                ChatMessage(role=MessageRole.TOOL_RESPONSE, content="Observation:\nSECRET_TOKEN"),
+            ]
+        )
+
+        result = agent("Test request")
+
+        assert result == "Here is the final answer from your managed agent 'test_agent':\nTest output"
+        assert "Calling tools" not in result
+        assert "Observation:" not in result
+        assert "SECRET_TOKEN" not in result
+        assert "<summary_of_work>" not in result
+        agent.write_memory_to_messages.assert_not_called()
 
     def test_code_agent_image_output(self):
         from PIL import Image


### PR DESCRIPTION
## Summary
- stop appending raw memory messages to a managed agent's returned observation when `provide_run_summary=True`
- keep the wrapped final answer as the managed-agent boundary output
- add a regression test ensuring tool-call/tool-response memory is not included in the parent observation

## Root cause
`MultiStepAgent.__call__` appended `write_memory_to_messages(summary_mode=True)` directly into `<summary_of_work>`. For `ActionStep`, `summary_mode=True` suppresses the assistant free-form `model_output`, but it still emits `TOOL_CALL` and `TOOL_RESPONSE` messages. That meant internal tool calls and raw observations could be fed back into the parent agent.

Fixes #2424.

## Validation
- Reproduced the issue before the fix with the deterministic stub from #2424: the returned parent observation contained `Calling tools`, `Observation:`, `sk-XYZ`, and `alice@internal.example`, and the assertion failed.
- Re-ran the same deterministic repro after the fix: the returned observation only contains the wrapped final answer and no leak markers.
- `uv run pytest tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_does_not_leak_raw_memory -q` -> `3 passed`
- `uv run ruff check src/smolagents/agents.py tests/test_agents.py`
- `uv run ruff format --check src/smolagents/agents.py tests/test_agents.py`

I also ran `uv run pytest tests/test_agents.py -q`; it reached `91 passed, 2 skipped` but failed on local missing optional dependencies (`ddgs`, `torch/transformers`, and `openai`) in unrelated tests.

AI assistance was used to inspect the code path and draft this small fix; I reviewed and validated it locally.