### PR TITLE
Fix VLLMModel compatibility with recent vLLM

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -656,10 +656,17 @@ class VLLMModel(Model):
             raise ModuleNotFoundError("Please install 'vllm' extra to use VLLMModel: `pip install 'smolagents[vllm]'`")
 
         from vllm import LLM  # type: ignore
-        from vllm.transformers_utils.tokenizer import get_tokenizer  # type: ignore
+
+        try:
+            from vllm.transformers_utils.tokenizer import get_tokenizer  # type: ignore
+        except ModuleNotFoundError:
+            from vllm.tokenizers import get_tokenizer  # type: ignore
 
         self.model_kwargs = model_kwargs or {}
         self.apply_chat_template_kwargs = apply_chat_template_kwargs or {}
+        max_tokens = kwargs.pop("max_tokens", None)
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
         super().__init__(**kwargs)
         self.model_id = model_id
         self.model = LLM(model=model_id, **self.model_kwargs)
@@ -711,6 +718,7 @@ class VLLMModel(Model):
         prepared_stop_sequences = completion_kwargs.pop("stop", [])
         tools = completion_kwargs.pop("tools", None)
         completion_kwargs.pop("tool_choice", None)
+        max_tokens = completion_kwargs.pop("max_tokens", getattr(self, "max_tokens", None))
 
         prompt = self.tokenizer.apply_chat_template(
             messages,
@@ -723,7 +731,7 @@ class VLLMModel(Model):
         sampling_params = SamplingParams(
             n=kwargs.get("n", 1),
             temperature=kwargs.get("temperature", 0.0),
-            max_tokens=kwargs.get("max_tokens", 2048),
+            max_tokens=max_tokens if max_tokens is not None else 2048,
             stop=prepared_stop_sequences,
             structured_outputs=structured_outputs,
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import json
 import sys
+import types
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ from smolagents.models import (
     Model,
     OpenAIModel,
     TransformersModel,
+    VLLMModel,
     get_clean_message_list,
     get_tool_call_from_text,
     get_tool_json_schema,
@@ -44,6 +46,58 @@ from smolagents.models import (
 from smolagents.tools import tool
 
 from .utils.markers import require_run_all
+
+
+class FakeVLLMOutput:
+    text = "vllm output"
+    token_ids = [1, 2]
+
+
+class FakeVLLMGeneration:
+    prompt_token_ids = [1]
+    outputs = [FakeVLLMOutput()]
+
+
+class FakeVLLMTokenizer:
+    def apply_chat_template(self, messages, tools=None, add_generation_prompt=True, tokenize=False, **kwargs):
+        return "prompt"
+
+
+class FakeVLLM:
+    instances = []
+
+    def __init__(self, model, **kwargs):
+        self.model = model
+        self.kwargs = kwargs
+        self.generate_calls = []
+        self.__class__.instances.append(self)
+
+    def generate(self, prompt, sampling_params=None, **kwargs):
+        self.generate_calls.append({"prompt": prompt, "sampling_params": sampling_params, "kwargs": kwargs})
+        return [FakeVLLMGeneration()]
+
+
+class FakeSamplingParams:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def install_fake_vllm(monkeypatch):
+    FakeVLLM.instances = []
+    vllm_module = types.ModuleType("vllm")
+    vllm_module.LLM = FakeVLLM
+    vllm_module.SamplingParams = FakeSamplingParams
+
+    tokenizers_module = types.ModuleType("vllm.tokenizers")
+    tokenizers_module.get_tokenizer = lambda model_id: FakeVLLMTokenizer()
+
+    sampling_params_module = types.ModuleType("vllm.sampling_params")
+    sampling_params_module.StructuredOutputsParams = lambda **kwargs: kwargs
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.tokenizers", tokenizers_module)
+    monkeypatch.setitem(sys.modules, "vllm.sampling_params", sampling_params_module)
+    monkeypatch.setattr("smolagents.models._is_package_available", lambda package_name: package_name == "vllm")
 
 
 class TestModel:
@@ -242,6 +296,24 @@ class TestModel:
         message2 = ChatMessage.from_dict(message_data)
         assert isinstance(message2.role, MessageRole)
         assert message2.role == MessageRole.ASSISTANT
+
+    def test_vllm_model_uses_current_tokenizer_import_path(self, monkeypatch):
+        install_fake_vllm(monkeypatch)
+
+        model = VLLMModel(model_id="test-model")
+
+        assert isinstance(model.tokenizer, FakeVLLMTokenizer)
+
+    def test_vllm_model_constructor_max_tokens_becomes_sampling_param(self, monkeypatch):
+        install_fake_vllm(monkeypatch)
+        model = VLLMModel(model_id="test-model", max_tokens=123)
+
+        output = model.generate([ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Hello"}])])
+
+        generate_call = FakeVLLM.instances[0].generate_calls[0]
+        assert output.content == "vllm output"
+        assert generate_call["sampling_params"].kwargs["max_tokens"] == 123
+        assert "max_tokens" not in generate_call["kwargs"]
 
     @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="requires macOS")
     def test_get_mlx_message_no_tool(self):


### PR DESCRIPTION
## Summary
- support the current `vllm.tokenizers.get_tokenizer` import path while keeping the older `vllm.transformers_utils.tokenizer` path as fallback
- treat `VLLMModel(..., max_tokens=...)` as a sampling parameter instead of leaking it into offline `LLM.generate()` kwargs
- add unit tests with fake vLLM modules, so the compatibility paths are covered without installing/loading vLLM

## Root cause
Recent vLLM versions no longer expose `get_tokenizer` from `vllm.transformers_utils.tokenizer`, so `VLLMModel` fails at import time. Separately, constructor kwargs are stored in `self.kwargs` by the base `Model`; `max_tokens` was then merged into `completion_kwargs` and passed through to `LLM.generate()`, even though offline vLLM expects it inside `SamplingParams`.

Fixes #2417.

## Validation
- Before the fix, the new tokenizer-path regression test failed with `ModuleNotFoundError: No module named 'vllm.transformers_utils'`.
- `uv run pytest tests/test_models.py::TestModel::test_vllm_model_uses_current_tokenizer_import_path tests/test_models.py::TestModel::test_vllm_model_constructor_max_tokens_becomes_sampling_param -q` -> `2 passed`
- `uv run ruff check src/smolagents/models.py tests/test_models.py`
- `uv run ruff format --check src/smolagents/models.py tests/test_models.py`

AI assistance was used to inspect the issue and draft this focused fix; I reviewed and validated it locally.