### PR TITLE
Fix InferenceClientModel hangs and add retries on overload and loadin…

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -1192,13 +1192,19 @@ class ApiModel(Model):
 
 
 def is_rate_limit_error(exception: BaseException) -> bool:
-    """Check if the exception is a rate limit error."""
+    """Check if the exception is a rate limit error or a transient connection/server error."""
     error_str = str(exception).lower()
     return (
         "429" in error_str
         or "rate limit" in error_str
         or "too many requests" in error_str
         or "rate_limit" in error_str
+        or "503" in error_str
+        or "overloaded" in error_str
+        or "loading" in error_str
+        or "service unavailable" in error_str
+        or "timeout" in error_str
+        or "connection" in error_str
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -475,6 +475,39 @@ class TestLiteLLMModel:
             # = 0.704s (allow some tolerance)
             assert 0.67 <= elapsed_time <= 0.73
 
+    def test_retry_on_overload_and_loading_errors(self):
+        """Test that the retry mechanism triggers on 503, overloaded, and loading errors."""
+        mock_litellm = MagicMock()
+
+        with (
+            patch("smolagents.models.RETRY_WAIT", 0.1),
+            patch("smolagents.utils.random.random", side_effect=[0.1, 0.1]),
+            patch("smolagents.models.LiteLLMModel.create_client", return_value=mock_litellm),
+        ):
+            model = LiteLLMModel(model_id="test-model")
+            messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Test message"}])]
+
+            mock_success_response = MagicMock()
+            mock_success_response.choices = [MagicMock()]
+            mock_success_response.choices[0].message.content = "Success response"
+            mock_success_response.choices[0].message.role = "assistant"
+            mock_success_response.choices[0].message.tool_calls = None
+            mock_success_response.usage.prompt_tokens = 10
+            mock_success_response.usage.completion_tokens = 20
+
+            # Create a 503 overloaded error and a model loading error
+            overloaded_error = Exception("Error code: 503 - Service Unavailable (overloaded)")
+            loading_error = Exception("Model is currently loading")
+
+            # Mock the litellm client to raise overloaded, then loading, then succeed
+            model.client.completion.side_effect = [overloaded_error, loading_error, mock_success_response]
+
+            result = model.generate(messages)
+
+            # Verify that completion was called thrice (twice failed, once succeeded)
+            assert model.client.completion.call_count == 3
+            assert result.content == "Success response"
+
     def test_passing_flatten_messages(self):
         model = LiteLLMModel(model_id="groq/llama-3.3-70b", flatten_messages_as_text=False)
         assert not model.flatten_messages_as_text


### PR DESCRIPTION
                                        
                                                                                                   
  PR Title                                                                                         
                                                                                                   
    models: retry on transient 503, overloaded, loading, and timeout errors                        
                                                                                                   
  PR Description                                                                                   
                                                                                                   
    ### Problem                                                                                    
    When the Hugging Face Inference Endpoint or serverless API is overloaded (returning `503       
  Service Unavailable` or loading status), or if a connection/read timeout occurs,                 
  `InferenceClientModel` (and other `ApiModel` subclasses) either fails immediately or hangs       
  indefinitely.                                                                                    
                                                                                                   
    Currently, the SDK's `retry_predicate` (`is_rate_limit_error`) only retries on `429` rate limit
  status codes, meaning these other common transient errors fail to trigger the retry mechanism.   
                                                                                                   
    Fixes #2432                                                                                    
                                                                                                   
    ### Solution                                                                                   
    - Updated `is_rate_limit_error` to catch transient errors such as:                             
      - `503` (Service Unavailable)                                                                
      - `overloaded`                                                                               
      - `loading` (e.g., when serverless endpoints are loading models)                             
      - `timeout` (connection/read timeouts)                                                       
      - `connection` (connection failures/resets)                                                  
    - Added a unit test `test_retry_on_overload_and_loading_errors` in `tests/test_models.py`      
  verifying that both 503 overloaded and model loading errors are caught by the retry wrapper. 