### PR TITLE
Fix Tool.from_space crash on single list-valued Space outputs

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -716,12 +716,13 @@ class Tool(BaseTool):
                     kwargs[arg_name] = self.sanitize_argument_for_prediction(arg)
 
                 output = self.client.predict(*args, api_name=self.api_name, **kwargs)
-                if isinstance(output, tuple) or isinstance(output, list):
+                # gradio_client returns a tuple only for a multi-output endpoint (e.g. an image plus a generation
+                # seed); a single output that is itself a list (gr.JSON, gr.Gallery, ...) is returned as that list,
+                # and must not be indexed as if it were a (result, message) pair.
+                if isinstance(output, tuple) and len(output) > 1:
                     if isinstance(output[1], str):
                         raise ValueError("The space returned this message: " + output[1])
-                    output = output[
-                        0
-                    ]  # Sometime the space also returns the generation seed, in which case the result is at index 0
+                    output = output[0]  # the result is at index 0; a trailing element is the generation seed
                 IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
                 AUDIO_EXTENSIONS = [".mp3", ".wav", ".ogg", ".m4a", ".flac"]
                 if isinstance(output, str) and any([output.endswith(ext) for ext in IMAGE_EXTENSIONS]):


### PR DESCRIPTION
## Problem

`Tool.from_space(...).forward()` post-processes the Space result with:

```python
output = self.client.predict(*args, api_name=self.api_name, **kwargs)
if isinstance(output, tuple) or isinstance(output, list):
    if isinstance(output[1], str):
        raise ValueError("The space returned this message: " + output[1])
    output = output[0]
```

This assumes any list/tuple output has at least two elements (a `(result, seed)` pair). However,
`gradio_client.Client.predict()` returns the bare value of a single-output endpoint, and `gr.JSON`,
`gr.Gallery`, and `gr.Chatbot` deserialize to a Python `list`. A Space whose single output is a list
therefore reaches this branch and:

- raises `IndexError` when the list has 0 or 1 elements, and
- misreads a list of length >= 2 as `(result, message)` — raising a spurious
  `ValueError("The space returned this message: ...")`, or silently dropping every element after `output[0]`.

Single-output JSON/Gallery Spaces (classification, detection, retrieval results) are common as agent tools,
so this path is reachable in normal use rather than an edge case.

## Fix

`gradio_client` returns a `tuple` only for a multi-output endpoint; a single list-valued output is returned
as a `list`. The `(result, seed/message)` handling is therefore restricted to genuine multi-output tuples,
and a single list output is left untouched.

## Verification

Reproduced end to end against a local Gradio app (gradio 6.19.0, gradio_client 2.5.0):

| Space single output | `predict()` returns | before | after |
| --- | --- | --- | --- |
| `gr.JSON` -> `["x"]` | `['x']` | IndexError | `['x']` |
| `gr.JSON` -> `[]` | `[]` | IndexError | `[]` |
| `gr.JSON` -> `["a", "b"]` | `['a', 'b']` | ValueError (spurious) | `['a', 'b']` |
| two outputs -> `(img, seed)` | `('img.png', 42)` | `'img.png'` | `'img.png'` (unchanged) |
| two outputs -> `(x, "err")` | `('x', 'err')` | ValueError | ValueError (unchanged) |
