### PR TITLE
fix: surface Returns section in Tool.to_code_prompt

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -46,6 +46,7 @@ from ._function_type_hints_utils import (
     TypeHintParsingException,
     _convert_type_hints_to_json_schema,
     _get_json_schema_type,
+    _parse_google_format_docstring,
     get_imports,
     get_json_schema,
 )
@@ -282,6 +283,14 @@ class Tool(BaseTool):
             indented_schema = textwrap.indent(formatted_schema, "        ")
             returns_doc = f"\nReturns:\n    dict (structured output): This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:\n{indented_schema}"
             tool_doc += f"\n{returns_doc}"
+        else:
+            # Fall back to the return description parsed from the forward docstring.
+            forward_doc = inspect.getdoc(self.forward)
+            if forward_doc:
+                _, _, return_doc = _parse_google_format_docstring(forward_doc)
+                if return_doc:
+                    returns_doc = f"Returns:\n{textwrap.indent(return_doc, '    ')}"
+                    tool_doc += f"\n\n{returns_doc}"
 
         tool_doc = f'"""{tool_doc}\n"""'
         return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"

--- a/tests/fixtures/tools.py
+++ b/tests/fixtures/tools.py
@@ -93,6 +93,23 @@ def example_tool():
 
 
 @pytest.fixture
+def with_returns_doc():
+    @tool
+    def with_returns_doc(input: str) -> str:
+        """Tool with a returns section.
+
+        Args:
+            input: Input text
+
+        Returns:
+            str: The same string as the input
+        """
+        return input
+
+    return with_returns_doc
+
+
+@pytest.fixture
 def boolean_default_tool_class():
     class BooleanDefaultTool(Tool):
         name = "boolean_default_tool"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -139,6 +139,10 @@ class TestTool:
                 "multiline_description_tool",
                 'def multiline_description_tool(input: string) -> string:\n    """This is a tool with\n    multiple lines\n    in the description\n\n    Args:\n        input: Some input\n    """',
             ),
+            (
+                "with_returns_doc",
+                'def with_returns_doc(input: string) -> string:\n    """Tool with a returns section.\n\n    Args:\n        input: Input text\n\n    Returns:\n        The same string as the input\n    """',
+            ),
         ],
     )
     def test_tool_to_code_prompt_output_format(self, tool_fixture, expected_output, request):


### PR DESCRIPTION
Fixes #2437.

## Problem
`Tool.to_code_prompt()` dropped the `Returns:` section for `@tool`-decorated functions, even though the return description is already parsed by `get_json_schema()`. For example, the `Returns:` block below was silently absent from the generated code prompt:

```python
@tool
def get_temperature(city: str) -> float:
    """get the temperature of any city in the world

    Args:
        city: the city name

    Returns:
        float: temperature in Celsius
    """
    return 19.2

print(get_temperature.to_code_prompt())  # 'Returns:' section was missing
```

## Fix
In `Tool.to_code_prompt()`, when a tool has no `output_schema`, re-parse the `Returns:` section from `self.forward`'s docstring and render it with the same indentation as the existing `Args:` block. The new branch is an `else` to the structured-output `Returns:` branch, so the two are mutually exclusive (no double rendering), and it is guarded against missing docstrings and empty return descriptions.

```python
else:
    # Fall back to the return description parsed from the forward docstring.
    forward_doc = inspect.getdoc(self.forward)
    if forward_doc:
        _, _, return_doc = _parse_google_format_docstring(forward_doc)
        if return_doc:
            returns_doc = f"Returns:\n{textwrap.indent(return_doc, '    ')}"
            tool_doc += f"\n\n{returns_doc}"
```

## Tests
Added one parametrized case to `test_tool_to_code_prompt_output_format`:
- `with_returns_doc`: a `@tool` function with a `Returns:` section — asserts the rendered prompt contains the return description.

The existing cases (tools without a `Returns:` section) already guard against spurious `Returns:` blocks being added.