### PR TITLE
Fix Tool.to_code_prompt() not rendering Returns: section from docstring

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -133,6 +133,7 @@ class Tool(BaseTool):
     inputs: dict[str, dict[str, str | type | bool]]
     output_type: str
     output_schema: dict[str, Any] | None = None
+    output_description: str | None = None
 
     def __init__(self, *args, **kwargs):
         self.is_initialized = False
@@ -282,6 +283,8 @@ class Tool(BaseTool):
             indented_schema = textwrap.indent(formatted_schema, "        ")
             returns_doc = f"\nReturns:\n    dict (structured output): This tool ALWAYS returns a dictionary that strictly adheres to the following JSON schema:\n{indented_schema}"
             tool_doc += f"\n{returns_doc}"
+        elif self.output_description:
+            tool_doc += f"\n\nReturns:\n    {self.output_type}: {self.output_description}"
 
         tool_doc = f'"""{tool_doc}\n"""'
         return f"def {self.name}{tool_signature}:\n{textwrap.indent(tool_doc, '    ')}"
@@ -1092,6 +1095,10 @@ def tool(tool_function: Callable) -> Tool:
         SimpleTool.output_schema = tool_json_schema["output_schema"]
     elif "return" in tool_json_schema and "schema" in tool_json_schema["return"]:
         SimpleTool.output_schema = tool_json_schema["return"]["schema"]
+
+    # Preserve the return description from the docstring for use in to_code_prompt()
+    if "return" in tool_json_schema and "description" in tool_json_schema["return"]:
+        SimpleTool.output_description = tool_json_schema["return"]["description"]
 
     @wraps(tool_function)
     def wrapped_function(*args, **kwargs):

--- a/tests/fixtures/tools.py
+++ b/tests/fixtures/tools.py
@@ -79,6 +79,23 @@ def multiline_description_tool():
 
 
 @pytest.fixture
+def tool_with_return_description():
+    @tool
+    def get_temperature(city: str) -> float:
+        """Get the temperature of any city in the world.
+
+        Args:
+            city: the city name
+
+        Returns:
+            float: temperature in Celsius
+        """
+        return 19.2
+
+    return get_temperature
+
+
+@pytest.fixture
 def example_tool():
     @tool
     def valid_tool_function(input: str) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -139,6 +139,10 @@ class TestTool:
                 "multiline_description_tool",
                 'def multiline_description_tool(input: string) -> string:\n    """This is a tool with\n    multiple lines\n    in the description\n\n    Args:\n        input: Some input\n    """',
             ),
+            (
+                "tool_with_return_description",
+                'def get_temperature(city: string) -> number:\n    """Get the temperature of any city in the world.\n\n    Args:\n        city: the city name\n\n    Returns:\n        number: temperature in Celsius\n    """',
+            ),
         ],
     )
     def test_tool_to_code_prompt_output_format(self, tool_fixture, expected_output, request):


### PR DESCRIPTION
## Problem

When a tool is created with the `@tool` decorator and its function docstring includes a `Returns:` section (Google-style), that documentation is silently dropped from `to_code_prompt()` output.

**Reproducer** (from #2437):

```python
from smolagents import tool

@tool
def get_temperature(city: str) -> float:
    """
    Get the temperature of any city in the world.

    Args:
        city: the city name

    Returns:
        float: temperature in Celsius
    """
    return 19.2

print(get_temperature.to_code_prompt())
# Before fix: no Returns: section in output
# After fix:
# def get_temperature(city: string) -> number:
#     """Get the temperature of any city in the world.
#
#     Args:
#         city: the city name
#
#     Returns:
#         number: temperature in Celsius
#     """
```

## Root cause

The `@tool` decorator calls `get_json_schema()` which correctly parses the `Returns:` block via `_parse_google_format_docstring()` and stores the description in `return_dict["description"]`. However, the decorator only preserved `output_type` (the JSON schema type string) and discarded the return description. Meanwhile, `to_code_prompt()` only rendered a `Returns:` section for structured-output tools (`has_schema=True`), leaving plain return types without any Returns documentation.

## Fix

- Add `output_description: str | None = None` class attribute to `Tool`
- In the `@tool` decorator, save the parsed return description to `SimpleTool.output_description`
- In `to_code_prompt()`, render a `Returns:` section when `output_description` is set (alongside the existing `has_schema` path)

## Tests

Added a new pytest fixture (`tool_with_return_description`) and a parametrized test case to `test_tool_to_code_prompt_output_format` covering the fixed behaviour. All 5 `to_code_prompt` test cases pass.

Fixes #2437