### PR TITLE
fix: support starred (PEP 3132) and list-target unpacking in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -803,16 +803,40 @@ def set_value(
         if target.id in static_tools:
             raise InterpreterError(f"Cannot assign to name '{target.id}': doing this would erase the existing tool!")
         state[target.id] = value
-    elif isinstance(target, ast.Tuple):
+    elif isinstance(target, (ast.Tuple, ast.List)):
         if not isinstance(value, tuple):
             if hasattr(value, "__iter__") and not isinstance(value, (str, bytes)):
                 value = tuple(value)
             else:
                 raise InterpreterError("Cannot unpack non-tuple value")
-        if len(target.elts) != len(value):
-            raise InterpreterError("Cannot unpack tuple of wrong size")
-        for i, elem in enumerate(target.elts):
-            set_value(elem, value[i], state, static_tools, custom_tools, authorized_imports)
+        starred_indices = [i for i, elt in enumerate(target.elts) if isinstance(elt, ast.Starred)]
+        if len(starred_indices) > 1:
+            raise InterpreterError("Cannot have multiple starred expressions in assignment")
+        if not starred_indices:
+            if len(target.elts) != len(value):
+                raise InterpreterError("Cannot unpack tuple of wrong size")
+            for elem, item in zip(target.elts, value):
+                set_value(elem, item, state, static_tools, custom_tools, authorized_imports)
+        else:
+            # PEP 3132 extended unpacking: the single starred target absorbs the surplus as a list.
+            star_index = starred_indices[0]
+            n_before = star_index
+            n_after = len(target.elts) - star_index - 1
+            if len(value) < n_before + n_after:
+                raise InterpreterError("Cannot unpack tuple of wrong size")
+            star_stop = len(value) - n_after
+            for elem, item in zip(target.elts[:star_index], value[:n_before]):
+                set_value(elem, item, state, static_tools, custom_tools, authorized_imports)
+            set_value(
+                target.elts[star_index].value,
+                list(value[n_before:star_stop]),
+                state,
+                static_tools,
+                custom_tools,
+                authorized_imports,
+            )
+            for elem, item in zip(target.elts[star_index + 1 :], value[star_stop:]):
+                set_value(elem, item, state, static_tools, custom_tools, authorized_imports)
     elif isinstance(target, ast.Subscript):
         obj = evaluate_ast(target.value, state, static_tools, custom_tools, authorized_imports)
         key = evaluate_ast(target.slice, state, static_tools, custom_tools, authorized_imports)

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2410,6 +2410,50 @@ class TestLocalPythonExecutor:
         with pytest.raises(InterpreterError, match=".*Cannot unpack tuple of wrong size"):
             executor(code)
 
+    def test_starred_assignment_middle(self):
+        result, _ = evaluate_python_code("a, *b, c = [1, 2, 3, 4]\n(a, b, c)", {}, state={})
+        assert result == (1, [2, 3], 4)
+
+    def test_starred_assignment_head(self):
+        result, _ = evaluate_python_code("first, *rest = [10, 20, 30]\n(first, rest)", {}, state={})
+        assert result == (10, [20, 30])
+
+    def test_starred_assignment_tail(self):
+        result, _ = evaluate_python_code("*init, last = [1, 2, 3]\n(init, last)", {}, state={})
+        assert result == ([1, 2], 3)
+
+    def test_starred_assignment_absorbs_empty(self):
+        result, _ = evaluate_python_code("a, *b, c = [1, 2]\n(a, b, c)", {}, state={})
+        assert result == (1, [], 2)
+
+    def test_starred_assignment_from_non_tuple_iterable(self):
+        result, _ = evaluate_python_code("a, *b = range(3)\n(a, b)", {"range": range}, state={})
+        assert result == (0, [1, 2])
+
+    def test_starred_assignment_too_few_values_raises(self):
+        with pytest.raises(InterpreterError, match=".*Cannot unpack tuple of wrong size"):
+            evaluate_python_code("a, *b, c = [1]", {}, state={})
+
+    def test_list_target_assignment(self):
+        result, _ = evaluate_python_code("[x, y] = [1, 2]\n(x, y)", {}, state={})
+        assert result == (1, 2)
+
+    def test_starred_in_for_loop(self):
+        code = dedent(
+            """
+            result = []
+            for x, *ys in [(1, 2, 3), (4, 5, 6)]:
+                result = result + [(x, ys)]
+            result
+            """
+        )
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == [(1, [2, 3]), (4, [5, 6])]
+
+    def test_starred_in_comprehension(self):
+        result, _ = evaluate_python_code("[b for a, *b in [(1, 2, 3), (4, 5)]]", {}, state={})
+        assert result == [[2, 3], [5]]
+
     def test_function_def_recovers_source_code(self):
         executor = LocalPythonExecutor([])
         executor.send_tools({"final_answer": FinalAnswerTool()})


### PR DESCRIPTION
## What

`LocalPythonExecutor`'s `set_value()` only handled `ast.Tuple` assignment targets with an exact-length check. As a result, extended (starred, PEP 3132) unpacking and list targets diverged from CPython. `set_value` is the single binding sink for assignments, `for` loops, and comprehensions, so all three constructs were affected:

| Code | CPython | Before this PR |
|------|---------|----------------|
| `a, *b, c = [1, 2, 3, 4]` | `a=1, b=[2, 3], c=4` | `InterpreterError: Cannot unpack tuple of wrong size` |
| `first, *rest = [10, 20, 30]` | `first=10, rest=[20, 30]` | same error |
| `for x, *ys in rows:` | works | same error |
| `[b for a, *b in pairs]` | works | same error |
| `[x, y] = [1, 2]` | `x=1, y=2` | silently assigns nothing |

## Change

`set_value` now:

- handles a single `ast.Starred` target (PEP 3132) — it absorbs the surplus as a `list`, matching CPython;
- handles `ast.List` targets (`[x, y] = ...`) alongside `ast.Tuple`.

Non-starred size mismatches keep the original `"Cannot unpack tuple of wrong size"` message, so existing behavior is unchanged.

## Tests

Adds tests to `TestLocalPythonExecutor` covering starred assignment (head/middle/tail/empty), list targets, starred `for` loops and comprehensions, iterable coercion, and the too-few-values error. All existing executor tests still pass.