### PR TITLE
Avoid leaking tool I/O in managed agent run summaries

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -882,11 +882,19 @@ You have been provided with these additional arguments, that you can access dire
             self.prompt_templates["managed_agent"]["report"], variables=dict(name=self.name, final_answer=report)
         )
         if self.provide_run_summary:
-            answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
-            for message in self.write_memory_to_messages(summary_mode=True):
+            unsafe_summary_roles = {MessageRole.TOOL_CALL, MessageRole.TOOL_RESPONSE}
+            summary_messages = [
+                message
+                for message in self.write_memory_to_messages(summary_mode=True)
+                if message.role not in unsafe_summary_roles
+            ]
+            if summary_messages:
+                answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
+            for message in summary_messages:
                 content = message.content
                 answer += "\n" + truncate_content(str(content)) + "\n---"
-            answer += "\n</summary_of_work>"
+            if summary_messages:
+                answer += "\n</summary_of_work>"
         return answer
 
     def save(self, output_dir: str | Path, relative_path: str | None = None):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2120,6 +2120,27 @@ class TestCodeAgent:
             )
         assert result == expected_summary
 
+    def test_call_with_provide_run_summary_omits_tool_io(self):
+        agent = CodeAgent(tools=[], model=MagicMock(), provide_run_summary=True)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Safe final report")
+        agent.write_memory_to_messages = MagicMock(
+            return_value=[
+                ChatMessage(role=MessageRole.ASSISTANT, content="Safe assistant summary"),
+                ChatMessage(role=MessageRole.TOOL_CALL, content="Calling tools:\nSECRET_TOOL_CALL"),
+                ChatMessage(role=MessageRole.TOOL_RESPONSE, content="Observation:\nSECRET_TOOL_RESPONSE"),
+            ]
+        )
+
+        result = agent("Test request")
+
+        assert "Safe final report" in result
+        assert "Safe assistant summary" in result
+        assert "Calling tools:" not in result
+        assert "Observation:" not in result
+        assert "SECRET_TOOL_CALL" not in result
+        assert "SECRET_TOOL_RESPONSE" not in result
+
     def test_code_agent_image_output(self):
         from PIL import Image
 


### PR DESCRIPTION
## Summary

Fixes #2424.

- Filter tool-call and tool-response messages out of `provide_run_summary=True` managed-agent summaries before they are appended to the parent observation.
- Keep the existing summary block behavior for safe summary messages.
- Add a regression test that proves sentinel tool-call/tool-response content is not returned to the parent while the managed agent final report and safe assistant summary remain visible.

## Root cause

`ManagedAgent.__call__` appended every message returned by `write_memory_to_messages(summary_mode=True)` into the string returned to the parent agent. `summary_mode=True` suppresses the free-form assistant `model_output`, but `ActionStep.to_messages()` still emits `MessageRole.TOOL_CALL` and `MessageRole.TOOL_RESPONSE` messages. As a result, raw inner tool invocations and observations could be included in the parent agent's next observation.

## Validation

- Red test before the fix: `uv run --extra test pytest tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_omits_tool_io -q` failed because `Calling tools:` / `SECRET_TOOL_CALL` appeared in the result.
- `uv run pytest tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_omits_tool_io tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary -q` -> `3 passed`
- `uv run pytest tests/test_agents.py -q` -> `96 passed, 2 skipped, 3 warnings`
- `uv run --extra quality ruff check src/smolagents/agents.py tests/test_agents.py`
- `uv run --extra quality ruff format --check src/smolagents/agents.py tests/test_agents.py`
- `git diff --check`
