### PR TITLE
feat: add tool execution callbacks

### DIFF
--- a/docs/source/en/guided_tour.md
+++ b/docs/source/en/guided_tour.md
@@ -401,6 +401,30 @@ This validation mechanism enables:
 - Implementing domain-specific validation rules
 - Creating more robust agents that validate their own outputs
 
+### Auditing and governing tool calls
+
+Use `tool_callbacks` when you need to record, sign, or block tool calls at the execution boundary.
+Each callback receives a `ToolCallEvent` before and after the tool runs. The event contains the phase, tool name, arguments, step number, output, and any error raised by the tool or callback.
+For [`CodeAgent`], `tool_callbacks` are supported with the local executor. Remote executors run tools out-of-process, so they cannot call back into local Python callbacks.
+
+```python
+from smolagents import CodeAgent, InferenceClientModel, ToolCallEvent
+
+def audit_tool_call(event: ToolCallEvent, agent):
+    if event.phase == "before" and event.tool_name == "delete_file":
+        raise PermissionError("delete_file requires manual approval")
+    print(event.phase, event.tool_name, event.arguments, event.output, event.error)
+
+agent = CodeAgent(
+    tools=[...],
+    model=InferenceClientModel(),
+    tool_callbacks=[audit_tool_call],
+)
+```
+
+If a `before` callback raises, the tool is not executed and an `after` event is emitted with the error.
+This lets audit systems record both successful and denied tool calls.
+
 ## Inspecting an agent run
 
 Here are a few useful attributes to inspect what happened after a run:

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -14,7 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import importlib
+import inspect
 import json
 import os
 import tempfile
@@ -120,6 +122,84 @@ class ToolOutput:
     is_final_answer: bool
     observation: str
     tool_call: ToolCall
+
+
+@dataclass
+class ToolCallEvent:
+    """Event passed to tool callbacks before and after a tool executes."""
+
+    phase: Literal["before", "after"]
+    tool_name: str
+    arguments: Any
+    step_number: int | None = None
+    output: Any = None
+    error: Exception | None = None
+
+
+class _ToolCallCallbackWrapper(BaseTool):
+    def __init__(self, tool: BaseTool, agent: "MultiStepAgent"):
+        self._tool = tool
+        self._agent = agent
+        self.name = tool.name
+        self.description = getattr(tool, "description", "")
+        self.inputs = getattr(tool, "inputs", {})
+        self.output_type = getattr(tool, "output_type", "any")
+        self.output_schema = getattr(tool, "output_schema", None)
+
+    def __getattr__(self, attr):
+        if attr in {"_tool", "_agent"}:
+            raise AttributeError(attr)
+        return getattr(self._tool, attr)
+
+    def __deepcopy__(self, memo):
+        return self.__class__(copy.deepcopy(self._tool, memo), self._agent)
+
+    def __call__(self, *args, **kwargs):
+        callback_arguments = self._get_callback_arguments(args, kwargs)
+        try:
+            self._agent._notify_tool_callbacks(
+                ToolCallEvent(
+                    phase="before",
+                    tool_name=self.name,
+                    arguments=callback_arguments,
+                    step_number=self._agent.step_number,
+                )
+            )
+            output = self._tool(*args, **kwargs)
+        except Exception as error:
+            self._agent._notify_tool_callbacks(
+                ToolCallEvent(
+                    phase="after",
+                    tool_name=self.name,
+                    arguments=callback_arguments,
+                    step_number=self._agent.step_number,
+                    error=error,
+                )
+            )
+            raise
+        self._agent._notify_tool_callbacks(
+            ToolCallEvent(
+                phase="after",
+                tool_name=self.name,
+                arguments=callback_arguments,
+                step_number=self._agent.step_number,
+                output=output,
+            )
+        )
+        return output
+
+    @staticmethod
+    def _get_callback_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        kwargs = {key: value for key, value in kwargs.items() if key != "sanitize_inputs_outputs"}
+        if kwargs and not args:
+            return kwargs
+        if args and not kwargs:
+            if len(args) == 1 and isinstance(args[0], dict):
+                return args[0]
+            return args
+        if args and kwargs:
+            return {"args": args, "kwargs": kwargs}
+        return {}
 
 
 class PlanningPromptTemplate(TypedDict):
@@ -280,6 +360,7 @@ class MultiStepAgent(ABC):
         verbosity_level (`LogLevel`, default `LogLevel.INFO`): Level of verbosity of the agent's logs.
         managed_agents (`list`, *optional*): Managed agents that the agent can call.
         step_callbacks (`list[Callable]` | `dict[Type[MemoryStep], Callable | list[Callable]]`, *optional*): Callbacks that will be called at each step.
+        tool_callbacks (`list[Callable]`, *optional*): Callbacks that will be called before and after each tool execution.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         name (`str`, *optional*): Necessary for a managed agent only - the name by which this agent can be called.
         description (`str`, *optional*): Necessary for a managed agent only - the description of this agent.
@@ -302,6 +383,7 @@ class MultiStepAgent(ABC):
         verbosity_level: LogLevel = LogLevel.INFO,
         managed_agents: list | None = None,
         step_callbacks: list[Callable] | dict[Type[MemoryStep], Callable | list[Callable]] | None = None,
+        tool_callbacks: list[Callable] | None = None,
         planning_interval: int | None = None,
         name: str | None = None,
         description: str | None = None,
@@ -335,6 +417,7 @@ class MultiStepAgent(ABC):
         self.final_answer_checks = final_answer_checks if final_answer_checks is not None else []
         self.return_full_result = return_full_result
         self.instructions = instructions
+        self._setup_tool_callbacks(tool_callbacks)
         self._setup_managed_agents(managed_agents)
         self._setup_tools(tools, add_base_tools)
         self._validate_tools_and_managed_agents(tools, managed_agents)
@@ -400,6 +483,26 @@ class MultiStepAgent(ABC):
                 }
             )
         self.tools.setdefault("final_answer", FinalAnswerTool())
+        if self.tool_callbacks:
+            self.tools = {name: _ToolCallCallbackWrapper(tool, self) for name, tool in self.tools.items()}
+
+    def _setup_tool_callbacks(self, tool_callbacks):
+        if tool_callbacks is None:
+            self.tool_callbacks = []
+        elif isinstance(tool_callbacks, list):
+            self.tool_callbacks = tool_callbacks
+        else:
+            raise ValueError("tool_callbacks must be a list")
+
+        if not all(callable(callback) for callback in self.tool_callbacks):
+            raise ValueError("tool_callbacks must contain only callables")
+
+    def _notify_tool_callbacks(self, event: ToolCallEvent):
+        for callback in self.tool_callbacks:
+            if len(inspect.signature(callback).parameters) == 1:
+                callback(event)
+            else:
+                callback(event, self)
 
     def _validate_tools_and_managed_agents(self, tools, managed_agents):
         tool_and_managed_agent_names = [tool.name for tool in tools]
@@ -973,8 +1076,8 @@ You have been provided with these additional arguments, that you can access dire
         Returns:
             `dict`: Dictionary representation of the agent.
         """
-        # TODO: handle serializing step_callbacks and final_answer_checks
-        for attr in ["final_answer_checks", "step_callbacks"]:
+        # TODO: handle serializing step_callbacks, tool_callbacks and final_answer_checks
+        for attr in ["final_answer_checks", "step_callbacks", "tool_callbacks"]:
             if getattr(self, attr, None):
                 self.logger.log(f"This agent has {attr}: they will be ignored by this method.", LogLevel.INFO)
 
@@ -1562,6 +1665,9 @@ class CodeAgent(MultiStepAgent):
             if code_block_tags == "markdown"
             else ("<code>", "</code>")
         )
+
+        if kwargs.get("tool_callbacks") and executor_type != "local":
+            raise ValueError("CodeAgent tool_callbacks are only supported with the local executor.")
 
         super().__init__(
             tools=tools,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import io
 import json
 import os
@@ -44,6 +45,7 @@ from smolagents.agents import (
     MultiStepAgent,
     RunResult,
     ToolCall,
+    ToolCallEvent,
     ToolCallingAgent,
     ToolOutput,
     populate_template,
@@ -230,6 +232,20 @@ final_answer(7.2904)
 </code>
 """,
             )
+
+
+class FakeCodeModelToolCallback(Model):
+    def generate(self, messages, stop_sequences=None):
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="""
+Thought: I should call the audited tool.
+<code>
+value = audited_double(21)
+final_answer(value)
+</code>
+""",
+        )
 
 
 class FakeCodeModelImageGeneration(Model):
@@ -424,6 +440,70 @@ class TestAgent:
         assert "7.2904" in agent.memory.steps[1].observations
         assert agent.memory.steps[2].model_output == "I will return the final answer."
 
+    def test_tool_callbacks_fire_before_and_after_toolcalling_agent_tool_execution(self):
+        events = []
+
+        def tool_callback(event: ToolCallEvent, agent):
+            events.append((event.phase, event.tool_name, event.arguments, event.output, event.error, agent))
+
+        agent = ToolCallingAgent(
+            tools=[PythonInterpreterTool()], model=FakeToolCallModel(), tool_callbacks=[tool_callback]
+        )
+        output = agent.run("What is 2 multiplied by 3.6452?")
+
+        assert "7.2904" in output
+        assert events == [
+            ("before", "python_interpreter", {"code": "2*3.6452"}, None, None, agent),
+            (
+                "after",
+                "python_interpreter",
+                {"code": "2*3.6452"},
+                "Stdout:\n\nOutput: 7.2904",
+                None,
+                agent,
+            ),
+            ("before", "final_answer", {"answer": "7.2904"}, None, None, agent),
+            ("after", "final_answer", {"answer": "7.2904"}, "7.2904", None, agent),
+        ]
+
+    def test_tool_callback_can_block_tool_execution_and_emit_terminal_error_event(self):
+        events = []
+        tool_calls = []
+
+        @tool
+        def risky_tool() -> str:
+            """Runs a risky action."""
+
+            tool_calls.append("called")
+            return "done"
+
+        def tool_callback(event: ToolCallEvent):
+            events.append(event)
+            if event.phase == "before":
+                raise PermissionError("tool call denied")
+
+        agent = ToolCallingAgent(tools=[risky_tool], model=FakeToolCallModel(), tool_callbacks=[tool_callback])
+
+        with pytest.raises(AgentToolExecutionError, match="tool call denied"):
+            agent.execute_tool_call("risky_tool", {})
+
+        assert tool_calls == []
+        assert [
+            (event.phase, event.tool_name, type(event.error).__name__ if event.error else None) for event in events
+        ] == [
+            ("before", "risky_tool", None),
+            ("after", "risky_tool", "PermissionError"),
+        ]
+
+    def test_wrapped_tool_with_callbacks_can_be_deepcopied(self):
+        agent = ToolCallingAgent(
+            tools=[PythonInterpreterTool()], model=FakeToolCallModel(), tool_callbacks=[lambda event: None]
+        )
+
+        copied_tool = copy.deepcopy(agent.tools["python_interpreter"])
+
+        assert copied_tool.name == "python_interpreter"
+
     def test_toolcalling_agent_handles_image_tool_outputs(self, shared_datadir):
         import PIL.Image
 
@@ -472,6 +552,42 @@ class TestAgent:
         assert agent.memory.steps[2].tool_calls == [
             ToolCall(name="python_interpreter", arguments="final_answer(7.2904)", id="call_2")
         ]
+
+    def test_tool_callbacks_fire_for_code_agent_tool_calls_inside_python_executor(self):
+        events = []
+
+        @tool
+        def audited_double(value: int) -> int:
+            """Doubles a number.
+
+            Args:
+                value: The value to double.
+            """
+
+            return value * 2
+
+        def tool_callback(event: ToolCallEvent):
+            events.append((event.phase, event.tool_name, event.arguments, event.output, event.error))
+
+        agent = CodeAgent(tools=[audited_double], model=FakeCodeModelToolCallback(), tool_callbacks=[tool_callback])
+        output = agent.run("Double 21.")
+
+        assert output == 42
+        assert events == [
+            ("before", "audited_double", (21,), None, None),
+            ("after", "audited_double", (21,), 42, None),
+            ("before", "final_answer", (42,), None, None),
+            ("after", "final_answer", (42,), 42, None),
+        ]
+
+    def test_code_agent_tool_callbacks_require_local_executor(self):
+        with pytest.raises(ValueError, match="tool_callbacks.*local executor"):
+            CodeAgent(
+                tools=[],
+                model=FakeCodeModel(),
+                tool_callbacks=[lambda event: None],
+                executor_type="e2b",
+            )
 
     def test_additional_args_added_to_task(self):
         agent = CodeAgent(tools=[], model=FakeCodeModel())


### PR DESCRIPTION
## Summary

Adds an opt-in `tool_callbacks` hook for agent tool execution, so users can audit or govern each tool call at the execution boundary.

- Adds `ToolCallEvent` with `before` / `after` phases, tool name, arguments, step number, output, and error fields
- Wraps tools for `ToolCallingAgent` and local-executor `CodeAgent`, including `final_answer`
- Lets a `before` callback deny execution while still emitting a terminal `after` event with the error
- Documents the API in the guided tour

Fixes #2172.

## Design notes

This deliberately keeps the framework surface small. `tool_callbacks` provide the hook point; downstream audit systems can decide whether to log, sign, hash-chain, or deny calls.

For `CodeAgent`, `tool_callbacks` are limited to the local executor because remote executors run tools out-of-process and cannot call back into local Python callbacks. The constructor raises a clear `ValueError` for unsupported remote-executor combinations rather than failing later during tool serialization.

This does not replace existing `step_callbacks`; it complements them. `step_callbacks` observe completed agent steps, while `tool_callbacks` observe the tool boundary before and after individual calls.

## Tests

- `uv run --extra test pytest tests/test_agents.py::TestAgent::test_tool_callbacks_fire_before_and_after_toolcalling_agent_tool_execution tests/test_agents.py::TestAgent::test_tool_callback_can_block_tool_execution_and_emit_terminal_error_event tests/test_agents.py::TestAgent::test_wrapped_tool_with_callbacks_can_be_deepcopied tests/test_agents.py::TestAgent::test_tool_callbacks_fire_for_code_agent_tool_calls_inside_python_executor tests/test_agents.py::TestAgent::test_code_agent_tool_callbacks_require_local_executor -q`
  - 5 passed
- `uv run --extra test pytest tests/test_agents.py -q`
  - 100 passed, 2 skipped, 3 warnings
- `uv run --extra quality ruff check src/smolagents/agents.py tests/test_agents.py`
  - passed
- `uv run --extra quality ruff format --check src/smolagents/agents.py tests/test_agents.py`
  - passed
- `git diff --check`
  - passed

## Second-agent review

Reviewer: `claude -p`

Result: CLEAN, no blocking findings.

Non-blocking notes from review:
- Managed-agent calls are not included in `tool_callbacks`; this PR scopes the hook to tools only.
- `event.arguments` mirrors the call shape: dictionaries for structured tool calls, tuples for positional Python calls.
- Remote `CodeAgent` executors are intentionally unsupported for local Python callbacks.

## Checklist

- [x] Regression tests added
- [x] Focused agent test suite passes
- [x] Ruff check and format gates pass
- [x] Documentation updated
