### PR TITLE
Filter tool messages from managed agent run summaries

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -884,6 +884,8 @@ You have been provided with these additional arguments, that you can access dire
         if self.provide_run_summary:
             answer += "\n\nFor more detail, find below a summary of this agent's work:\n<summary_of_work>\n"
             for message in self.write_memory_to_messages(summary_mode=True):
+                if message.role in (MessageRole.TOOL_CALL, MessageRole.TOOL_RESPONSE):
+                    continue
                 content = message.content
                 answer += "\n" + truncate_content(str(content)) + "\n---"
             answer += "\n</summary_of_work>"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2120,6 +2120,48 @@ class TestCodeAgent:
             )
         assert result == expected_summary
 
+    def test_call_with_provide_run_summary_excludes_tool_messages(self):
+        agent = CodeAgent(tools=[], model=MagicMock(), provide_run_summary=True)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Test output")
+        agent.write_memory_to_messages = MagicMock(
+            return_value=[
+                ChatMessage(role=MessageRole.ASSISTANT, content="Safe summary"),
+                ChatMessage(role=MessageRole.TOOL_CALL, content="Calling tools: SECRET_TOOL_CALL"),
+                ChatMessage(role=MessageRole.TOOL_RESPONSE, content="Observation: SECRET_TOOL_RESPONSE"),
+            ]
+        )
+
+        result = agent("Test request")
+
+        assert "Test output" in result
+        assert "Safe summary" in result
+        assert "SECRET_TOOL_CALL" not in result
+        assert "SECRET_TOOL_RESPONSE" not in result
+        assert "Calling tools:" not in result
+        assert "Observation:" not in result
+
+    def test_call_with_provide_run_summary_filters_tool_messages_from_memory(self):
+        agent = CodeAgent(tools=[], model=MagicMock(), provide_run_summary=True)
+        agent.name = "test_agent"
+        agent.run = MagicMock(return_value="Test output")
+        agent.memory.steps.append(
+            ActionStep(
+                step_number=1,
+                timing=Timing(start_time=0.0),
+                tool_calls=[ToolCall(name="search", arguments={"query": "SECRET_TOOL_CALL"}, id="call_1")],
+                observations="SECRET_TOOL_RESPONSE",
+            )
+        )
+
+        result = agent("Test request")
+
+        assert "Test output" in result
+        assert "SECRET_TOOL_CALL" not in result
+        assert "SECRET_TOOL_RESPONSE" not in result
+        assert "Calling tools:" not in result
+        assert "Observation:" not in result
+
     def test_code_agent_image_output(self):
         from PIL import Image
 


### PR DESCRIPTION
## Summary

Fixes #2424.

`ManagedAgent.__call__` currently appends every message returned by `write_memory_to_messages(summary_mode=True)` into the parent-facing `<summary_of_work>` block. `ActionStep.to_messages(summary_mode=True)` suppresses free-form assistant output, but still emits `MessageRole.TOOL_CALL` and `MessageRole.TOOL_RESPONSE` messages, so nested tool invocations and observations can leak into the parent agent context.

This PR keeps the existing run-summary shape, but skips `TOOL_CALL` and `TOOL_RESPONSE` messages while rendering the managed-agent summary.

## Tests

RED:

```bash
.venv/bin/python -m pytest tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_excludes_tool_messages
```

GREEN:

```bash
.venv/bin/python -m pytest tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_excludes_tool_messages tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary_filters_tool_messages_from_memory tests/test_agents.py::TestCodeAgent::test_call_with_provide_run_summary
.venv/bin/python -m pytest tests/test_agents.py::TestCodeAgent
.venv/bin/ruff check src/smolagents/agents.py tests/test_agents.py
```