### PR TITLE
feat: add memory summarization to prevent context window overflow

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -54,6 +54,7 @@ from .memory import (
     FinalAnswerStep,
     MemoryStep,
     PlanningStep,
+    SummaryStep,
     SystemPromptStep,
     TaskStep,
     Timing,
@@ -298,6 +299,7 @@ class MultiStepAgent(ABC):
         prompt_templates: PromptTemplates | None = None,
         instructions: str | None = None,
         max_steps: int = 20,
+        max_steps_before_summary: int | None = None,
         add_base_tools: bool = False,
         verbosity_level: LogLevel = LogLevel.INFO,
         managed_agents: list | None = None,
@@ -340,7 +342,7 @@ class MultiStepAgent(ABC):
         self._validate_tools_and_managed_agents(tools, managed_agents)
 
         self.task: str | None = None
-        self.memory = AgentMemory(self.system_prompt)
+        self.memory = AgentMemory(self.system_prompt, max_steps_before_summary=max_steps_before_summary)
 
         if logger is None:
             self.logger = AgentLogger(level=verbosity_level)
@@ -545,6 +547,9 @@ You have been provided with these additional arguments, that you can access dire
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
+
+            # Summarize older steps if memory is growing too large
+            self.memory.summarize_if_needed(self.model)
 
             # Run a planning step if scheduled
             if self.planning_interval is not None and (

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from smolagents.monitoring import AgentLogger
 
 
-__all__ = ["AgentMemory"]
+__all__ = ["AgentMemory", "SummaryStep"]
 
 
 logger = getLogger(__name__)
@@ -211,6 +211,30 @@ class FinalAnswerStep(MemoryStep):
     output: Any
 
 
+@dataclass
+class SummaryStep(MemoryStep):
+    """A step that holds a summary of older steps that were compressed to save context space."""
+
+    summary: str
+    summarized_step_count: int
+
+    def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
+        return [
+            ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=[{"type": "text", "text": f"[Summary of previous {self.summarized_step_count} steps]\n{self.summary}"}],
+            )
+        ]
+
+
+SUMMARIZATION_PROMPT = """Below is the history of previous steps taken by an AI agent. Summarize the key information, decisions, tool results, and findings into a concise paragraph. Preserve important facts, URLs, numbers, and conclusions. Omit redundant reasoning or failed attempts unless the failure is informative.
+
+Steps to summarize:
+{steps_text}
+
+Write a concise summary:"""
+
+
 class AgentMemory:
     """Memory for the agent, containing the system prompt and all steps taken by the agent.
 
@@ -225,13 +249,85 @@ class AgentMemory:
         - **steps** (`list[TaskStep | ActionStep | PlanningStep]`) -- List of steps taken by the agent, which can include tasks, actions, and planning steps.
     """
 
-    def __init__(self, system_prompt: str):
+    def __init__(self, system_prompt: str, max_steps_before_summary: int | None = None):
         self.system_prompt: SystemPromptStep = SystemPromptStep(system_prompt=system_prompt)
-        self.steps: list[TaskStep | ActionStep | PlanningStep] = []
+        self.steps: list[TaskStep | ActionStep | PlanningStep | SummaryStep] = []
+        self.max_steps_before_summary = max_steps_before_summary
 
     def reset(self):
         """Reset the agent's memory, clearing all steps and keeping the system prompt."""
         self.steps = []
+
+    def summarize_if_needed(self, model) -> bool:
+        """Summarize older steps if memory exceeds the configured threshold.
+
+        Keeps the most recent steps intact and replaces older ones with a SummaryStep.
+        Returns True if summarization was performed.
+
+        Args:
+            model: A model instance with a `generate` method to produce the summary.
+        """
+        if self.max_steps_before_summary is None:
+            return False
+
+        action_steps = [s for s in self.steps if isinstance(s, (ActionStep, PlanningStep))]
+        if len(action_steps) <= self.max_steps_before_summary:
+            return False
+
+        keep_recent = self.max_steps_before_summary // 2
+        steps_to_summarize = []
+        steps_to_keep = []
+        action_count = 0
+        for step in reversed(self.steps):
+            if isinstance(step, (ActionStep, PlanningStep)):
+                action_count += 1
+            if action_count <= keep_recent:
+                steps_to_keep.insert(0, step)
+            else:
+                steps_to_summarize.insert(0, step)
+
+        if not steps_to_summarize:
+            return False
+
+        steps_text = self._steps_to_text(steps_to_summarize)
+        prompt = SUMMARIZATION_PROMPT.format(steps_text=steps_text)
+        messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": prompt}])]
+
+        response = model.generate(messages)
+        summary_text = response.content if isinstance(response.content, str) else str(response.content)
+
+        summary_step = SummaryStep(
+            summary=summary_text,
+            summarized_step_count=len(steps_to_summarize),
+        )
+
+        task_steps = [s for s in steps_to_summarize if isinstance(s, TaskStep)]
+        self.steps = task_steps + [summary_step] + steps_to_keep
+        logger.info(f"Summarized {len(steps_to_summarize)} steps into a single summary.")
+        return True
+
+    @staticmethod
+    def _steps_to_text(steps: list) -> str:
+        """Convert a list of steps to a plain text representation for summarization."""
+        parts = []
+        for step in steps:
+            if isinstance(step, TaskStep):
+                parts.append(f"Task: {step.task}")
+            elif isinstance(step, ActionStep):
+                if step.model_output:
+                    output = step.model_output[:500] if len(step.model_output) > 500 else step.model_output
+                    parts.append(f"Thought: {output}")
+                if step.tool_calls:
+                    for tc in step.tool_calls:
+                        parts.append(f"Tool call: {tc.name}({tc.arguments})")
+                if step.observations:
+                    obs = step.observations[:500] if len(step.observations) > 500 else step.observations
+                    parts.append(f"Observation: {obs}")
+                if step.error:
+                    parts.append(f"Error: {step.error}")
+            elif isinstance(step, PlanningStep):
+                parts.append(f"Plan: {step.plan[:500] if len(step.plan) > 500 else step.plan}")
+        return "\n".join(parts)
 
     def get_succinct_steps(self) -> list[dict]:
         """Return a succinct representation of the agent's steps, excluding model input messages."""


### PR DESCRIPTION
## Summary

Adds automatic memory summarization to prevent context window overflow in long-running agent conversations.

## Motivation

Currently, smolagents has no built-in mechanism to manage memory growth. The entire step history is always sent to the model (via `write_memory_to_messages()`), which means long-running agents will eventually exceed the LLM's context window and fail. The existing `summary_mode` parameter only omits certain fields — it does not perform actual summarization.

This PR adds opt-in memory summarization: when `max_steps_before_summary` is set, older steps are automatically compressed into a concise `SummaryStep` using the agent's model.

Related to  #694

## Changes

**`memory.py`:**
- Added `SummaryStep` dataclass with `to_messages()` support
- Added `SUMMARIZATION_PROMPT` template
- Added `AgentMemory.summarize_if_needed(model)` method
- Added `AgentMemory._steps_to_text()` helper
- Added `max_steps_before_summary` parameter to `AgentMemory.__init__`

**`agents.py`:**
- Added `max_steps_before_summary` parameter to `MultiStepAgent.__init__`
- Calls `self.memory.summarize_if_needed(self.model)` at the start of each step loop iteration
- Imported `SummaryStep`

## Usage

```python
from smolagents import CodeAgent

agent = CodeAgent(
    tools=[...],
    model=model,
    max_steps_before_summary=10,  # summarize after 10 action/planning steps
)

# Long-running task — older steps get automatically summarized
agent.run("complex multi-step task")
```

## Design decisions

- **Opt-in**: disabled by default (`max_steps_before_summary=None`)
- **Preserves recent context**: keeps the most recent half of steps intact, only summarizes older ones
- **Preserves TaskSteps**: task descriptions are never summarized away
- **Uses the agent's own model**: no additional model configuration needed
- **Single summarization call**: older steps are replaced with one `SummaryStep`

## Test plan

- [ ] Default behavior unchanged (no summarization when param is None)
- [ ] Summarization triggers at threshold
- [ ] Recent steps preserved after summarization
- [ ] SummaryStep correctly serializes to messages
- [ ] Agent continues working after summarization