### PR TITLE
feat: add chat_history parameter to agent.run() for multi-turn conversations

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -442,6 +442,7 @@ class MultiStepAgent(ABC):
         additional_args: dict | None = None,
         max_steps: int | None = None,
         return_full_result: bool | None = None,
+        chat_history: list[ChatMessage] | None = None,
     ) -> Any | RunResult:
         """
         Run the agent for the given task.
@@ -457,6 +458,8 @@ class MultiStepAgent(ABC):
             max_steps (`int`, *optional*): Maximum number of steps the agent can take to solve the task. if not provided, will use the agent's default value.
             return_full_result (`bool`, *optional*): Whether to return the full [`RunResult`] object or just the final answer output.
                 If `None` (default), the agent's `self.return_full_result` setting is used.
+            chat_history (`list[ChatMessage]`, *optional*): A list of chat messages to prepend as conversation context.
+                Useful for multi-turn conversations where you want to provide prior exchanges without using `reset=False`.
 
         Example:
         ```py
@@ -478,6 +481,11 @@ You have been provided with these additional arguments, that you can access dire
         if reset:
             self.memory.reset()
             self.monitor.reset()
+
+        if chat_history:
+            self.memory.chat_history = chat_history
+        elif reset:
+            self.memory.chat_history = []
 
         self.logger.log_task(
             content=self.task.strip(),
@@ -765,6 +773,8 @@ You have been provided with these additional arguments, that you can access dire
         the LLM.
         """
         messages = self.memory.system_prompt.to_messages(summary_mode=summary_mode)
+        if hasattr(self.memory, "chat_history") and self.memory.chat_history:
+            messages.extend(self.memory.chat_history)
         for memory_step in self.memory.steps:
             messages.extend(memory_step.to_messages(summary_mode=summary_mode))
         return messages

--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -228,10 +228,12 @@ class AgentMemory:
     def __init__(self, system_prompt: str):
         self.system_prompt: SystemPromptStep = SystemPromptStep(system_prompt=system_prompt)
         self.steps: list[TaskStep | ActionStep | PlanningStep] = []
+        self.chat_history: list[ChatMessage] = []
 
     def reset(self):
         """Reset the agent's memory, clearing all steps and keeping the system prompt."""
         self.steps = []
+        self.chat_history = []
 
     def get_succinct_steps(self) -> list[dict]:
         """Return a succinct representation of the agent's steps, excluding model input messages."""


### PR DESCRIPTION
## Summary

Adds a `chat_history` parameter to `agent.run()` that allows users to prepend prior conversation context without manually constructing memory steps or using `reset=False`.

## Motivation

Currently, to build multi-turn agents users must either:
1. Use `reset=False` and accumulate steps across runs (fragile, leaks internal state)
2. Manually construct `ActionStep`/`TaskStep` objects and insert them into `agent.memory.steps` (undocumented, complex)

Neither approach is ergonomic for the common case of "I have a list of prior user/assistant exchanges and want to provide them as context for the next run."

Related #1579

## Changes

**`agents.py`:**
- Added `chat_history: list[ChatMessage] | None = None` parameter to `run()`
- Stores `chat_history` on `self.memory` after reset
- `write_memory_to_messages()` inserts chat_history between system prompt and steps

**`memory.py`:**
- Added `chat_history: list[ChatMessage]` attribute to `AgentMemory`
- `reset()` clears chat_history

## Usage

```python
from smolagents import CodeAgent, ChatMessage, MessageRole

agent = CodeAgent(tools=[...], model=model)

# First turn
result1 = agent.run("What is Python?")

# Second turn — provide prior context
history = [
    ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "What is Python?"}]),
    ChatMessage(role=MessageRole.ASSISTANT, content=[{"type": "text", "text": "Python is a programming language..."}]),
]
result2 = agent.run("How does it compare to JavaScript?", chat_history=history)
```

## Design decisions

- **Non-breaking**: parameter is optional, defaults to None
- **Works with reset=True**: chat_history is separate from step memory, so reset clears steps but the provided history persists for that run
- **Inserted after system prompt**: maintains correct message ordering (system → history → task → steps)
- **Raw ChatMessage list**: maximum flexibility, users control the exact message format

## Test plan

- [ ] Default behavior unchanged (no chat_history)
- [ ] chat_history messages appear in write_memory_to_messages() output
- [ ] chat_history works with reset=True
- [ ] chat_history persists across steps within a single run
- [ ] Empty chat_history has no effect