### PR TITLE
fix: replace assert with explicit check in _validate_final_answer

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -613,9 +613,11 @@ You have been provided with these additional arguments, that you can access dire
     def _validate_final_answer(self, final_answer: Any):
         for check_function in self.final_answer_checks:
             try:
-                assert check_function(final_answer, self.memory, agent=self)
+                result = check_function(final_answer, self.memory, agent=self)
             except Exception as e:
                 raise AgentError(f"Check {check_function.__name__} failed with error: {e}", self.logger)
+            if not result:
+                raise AgentError(f"Check {check_function.__name__} returned False.", self.logger)
 
     def _finalize_step(self, memory_step: ActionStep | PlanningStep | FinalAnswerStep):
         if not isinstance(memory_step, FinalAnswerStep):


### PR DESCRIPTION
## Summary

Replace `assert` with explicit `if not result` check in `_validate_final_answer`. The `assert` statement is stripped under `python -O`/`-OO`, silently disabling all final answer validation in production.

## Problem

```python
def _validate_final_answer(self, final_answer: Any):
    for check_function in self.final_answer_checks:
        try:
            assert check_function(final_answer, self.memory, agent=self)
        except Exception as e:
            raise AgentError(...)
```

Running with `python -O` (common in Docker/production) removes the `assert` entirely — checks never execute.

## Fix

Separate the call from the validation:

```python
result = check_function(final_answer, self.memory, agent=self)
# ...
if not result:
    raise AgentError(f"Check {check_function.__name__} returned False.", self.logger)
```

Fixes #2456