### PR TITLE
fix: respect explicit max_steps=0 by using 'is not None' check

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -465,7 +465,7 @@ class MultiStepAgent(ABC):
         agent.run("What is the result of 2 power 3.7384?")
         ```
         """
-        max_steps = max_steps or self.max_steps
+        max_steps = max_steps if max_steps is not None else self.max_steps
         self.task = task
         self.interrupt_switch = False
         if additional_args:


### PR DESCRIPTION
## Summary

`max_steps = max_steps or self.max_steps` silently ignores `max_steps=0` because `0` is falsy in Python.

## Fix

```python
# Before
max_steps = max_steps or self.max_steps

# After
max_steps = max_steps if max_steps is not None else self.max_steps
```

One-line fix. Preserves existing behavior for `max_steps=None` (use default) while respecting explicit `max_steps=0`.

Fixes #2458