### PR TITLE
fix: avoid deadlock in local_python_executor timeout decorator

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -307,17 +307,18 @@ def timeout(timeout_seconds: int):
             # Create a new ThreadPoolExecutor for each call to avoid threading issues
             executor = ThreadPoolExecutor(max_workers=1)
             future = executor.submit(func, *args, **kwargs)
+            timed_out = False
             try:
                 return future.result(timeout=timeout_seconds)
             except FuturesTimeoutError:
-                # Do not wait for the stuck worker thread: shutdown(wait=True) would deadlock
-                # when the wrapped call hangs indefinitely.
-                executor.shutdown(wait=False)
+                timed_out = True
                 raise ExecutionTimeoutError(
                     f"Code execution exceeded the maximum execution time of {timeout_seconds} seconds"
                 )
-            else:
-                executor.shutdown(wait=True)
+            finally:
+                # Do not wait for the stuck worker thread on timeout: shutdown(wait=True) would
+                # deadlock when the wrapped call hangs indefinitely.
+                executor.shutdown(wait=not timed_out)
 
         return wrapper
 

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -305,15 +305,19 @@ def timeout(timeout_seconds: int):
         @wraps(func)
         def wrapper(*args, **kwargs):
             # Create a new ThreadPoolExecutor for each call to avoid threading issues
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(func, *args, **kwargs)
-                try:
-                    result = future.result(timeout=timeout_seconds)
-                    return result
-                except FuturesTimeoutError:
-                    raise ExecutionTimeoutError(
-                        f"Code execution exceeded the maximum execution time of {timeout_seconds} seconds"
-                    )
+            executor = ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(func, *args, **kwargs)
+            try:
+                return future.result(timeout=timeout_seconds)
+            except FuturesTimeoutError:
+                # Do not wait for the stuck worker thread: shutdown(wait=True) would deadlock
+                # when the wrapped call hangs indefinitely.
+                executor.shutdown(wait=False)
+                raise ExecutionTimeoutError(
+                    f"Code execution exceeded the maximum execution time of {timeout_seconds} seconds"
+                )
+            else:
+                executor.shutdown(wait=True)
 
         return wrapper
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2200,15 +2200,21 @@ class TestTimeout:
 
     def test_timeout_decorator_does_not_deadlock_on_hanging_call(self):
         """Test that a hanging call times out without blocking on executor shutdown."""
+        import threading
+
+        stop_event = threading.Event()
 
         @timeout(1)
         def hanging_task():
-            while True:
+            while not stop_event.is_set():
                 time.sleep(0.01)
 
         start = time.monotonic()
-        with pytest.raises(ExecutionTimeoutError, match="Code execution exceeded the maximum execution time"):
-            hanging_task()
+        try:
+            with pytest.raises(ExecutionTimeoutError, match="Code execution exceeded the maximum execution time"):
+                hanging_task()
+        finally:
+            stop_event.set()
         elapsed = time.monotonic() - start
         assert elapsed < 3
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -2198,6 +2198,20 @@ class TestTimeout:
         with pytest.raises(ExecutionTimeoutError, match="Code execution exceeded the maximum execution time"):
             long_task()
 
+    def test_timeout_decorator_does_not_deadlock_on_hanging_call(self):
+        """Test that a hanging call times out without blocking on executor shutdown."""
+
+        @timeout(1)
+        def hanging_task():
+            while True:
+                time.sleep(0.01)
+
+        start = time.monotonic()
+        with pytest.raises(ExecutionTimeoutError, match="Code execution exceeded the maximum execution time"):
+            hanging_task()
+        elapsed = time.monotonic() - start
+        assert elapsed < 3
+
     def test_evaluate_python_code_with_timeout_completes(self):
         """Test that evaluate_python_code completes within timeout for quick code."""
         code = "result = 2 + 2"


### PR DESCRIPTION
Fixes #2464

## Why (context before the diff)

Agent code that hangs forever (stuck network tool, `while True`, blocked I/O) is supposed to fail with `ExecutionTimeoutError` after `timeout_seconds`. In practice, `future.result(timeout=...)` timed out correctly, but exiting `with ThreadPoolExecutor(...)` still called `executor.shutdown(wait=True)`. Because Python cannot kill a stuck worker thread, shutdown blocked forever and the whole process froze with no exception and no traceback. That is worse than a timeout for anyone running agents in production or on restricted compute nodes.

## What changed

- Update `timeout()` in `src/smolagents/local_python_executor.py` to shut down with `wait=False` on the timeout path (via `timed_out` + `finally`), while keeping `wait=True` on success / non-timeout errors.
- Add `test_timeout_decorator_does_not_deadlock_on_hanging_call` so a non-terminating hang fails fast instead of deadlocking the suite.

## Acceptance criteria

- [x] Tests added for the fixed code path (hanging-call regression)
- [x] Relevant tests passing (`pytest tests/test_local_python_executor.py::TestTimeout`)
- [x] Follows project style (`ruff check` / `ruff format --check` on `examples`, `src`, `tests`)
- [x] No breaking API changes (same public error type; success path unchanged)
- [x] Diff scoped to the issue (2 files only)

## Before / after evidence

**Before:** `@timeout(1)` + long hang → process freezes; no `ExecutionTimeoutError`.

**After:** same call raises `ExecutionTimeoutError` within ~1s; process continues.

```text
pytest tests/test_local_python_executor.py::TestTimeout -v
# test_timeout_decorator_does_not_deadlock_on_hanging_call PASSED
ruff check examples src tests
ruff format --check examples src tests
```

## Test plan

- [x] `pytest tests/test_local_python_executor.py::TestTimeout`
- [x] `ruff check` / `ruff format --check` on `examples`, `src`, `tests`
- [ ] GitHub Actions on this PR after maintainer approves first-time-contributor workflows

## Notes

Copilot review comments were addressed in follow-up commit `4886c2a` (`finally` shutdown + stoppable hanging test thread).