### PR TITLE
fix: replace assert with explicit check in _validate_final_answer

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -613,9 +613,13 @@ You have been provided with these additional arguments, that you can access dire
     def _validate_final_answer(self, final_answer: Any):
         for check_function in self.final_answer_checks:
             try:
-                assert check_function(final_answer, self.memory, agent=self)
+                result = check_function(final_answer, self.memory, agent=self)
+            except AgentError:
+                raise
             except Exception as e:
                 raise AgentError(f"Check {check_function.__name__} failed with error: {e}", self.logger)
+            if not result:
+                raise AgentError(f"Check {check_function.__name__} returned False for the final answer.", self.logger)
 
     def _finalize_step(self, memory_step: ActionStep | PlanningStep | FinalAnswerStep):
         if not isinstance(memory_step, FinalAnswerStep):

--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -43,6 +43,14 @@ __all__ = ["AgentError"]
 
 @lru_cache
 def _is_package_available(package_name: str) -> bool:
+    """Check whether a Python package is installed and importable.
+
+    Args:
+        package_name: The name of the package to check (e.g. ``"torch"``).
+
+    Returns:
+        ``True`` if the package can be found by the import system, ``False`` otherwise.
+    """
     return importlib.util.find_spec(package_name) is not None
 
 
@@ -428,16 +436,38 @@ def get_source(obj) -> str:
 
 
 def encode_image_base64(image):
+    """Encode a PIL image to a base64-encoded PNG string.
+
+    Args:
+        image: A PIL ``Image`` object to encode.
+
+    Returns:
+        A UTF-8 decoded base64 string of the image in PNG format.
+    """
     buffered = BytesIO()
     image.save(buffered, format="PNG")
     return base64.b64encode(buffered.getvalue()).decode("utf-8")
 
 
 def make_image_url(base64_image):
+    """Wrap a base64-encoded image string into a data URL.
+
+    Args:
+        base64_image: A base64-encoded PNG image string (as returned by :func:`encode_image_base64`).
+
+    Returns:
+        A ``data:image/png;base64,...`` URL string suitable for embedding in HTML or API payloads.
+    """
     return f"data:image/png;base64,{base64_image}"
 
 
 def make_init_file(folder: str | Path):
+    """Create a directory and place an empty ``__init__.py`` file inside it.
+
+    Args:
+        folder: Path to the directory to create. Intermediate directories are
+            created automatically (equivalent to ``mkdir -p``).
+    """
     os.makedirs(folder, exist_ok=True)
     # Create __init__
     with open(os.path.join(folder, "__init__.py"), "w"):
@@ -445,6 +475,22 @@ def make_init_file(folder: str | Path):
 
 
 def is_valid_name(name: str) -> bool:
+    """Check whether a string is a valid Python identifier that is not a reserved keyword.
+
+    Args:
+        name: The string to validate.
+
+    Returns:
+        ``True`` if ``name`` is a valid, non-keyword Python identifier; ``False`` otherwise.
+
+    Example:
+        >>> is_valid_name("my_tool")
+        True
+        >>> is_valid_name("for")  # reserved keyword
+        False
+        >>> is_valid_name("123abc")  # not a valid identifier
+        False
+    """
     return name.isidentifier() and not keyword.iskeyword(name) if isinstance(name, str) else False
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -732,9 +732,22 @@ nested_answer()
 
         # Check that at least one error message contains our check function name
         error_messages = [str(step.error) for step in failed_steps if step.error is not None]
-        assert any("check_uses_agent_state failed" in msg for msg in error_messages), (
+        assert any("check_uses_agent_state" in msg for msg in error_messages), (
             "Expected to find validation error message"
         )
+
+    def test_final_answer_check_returning_false_raises_agent_error(self):
+        # A check that returns False (not raises) must still reject the answer.
+        # Previously this was implemented with `assert`, which is stripped by
+        # python -O, silently disabling all final_answer_checks in production.
+        def check_returns_false(final_answer, memory, agent):
+            return False
+
+        agent = CodeAgent(model=FakeCodeModel(), tools=[], final_answer_checks=[check_returns_false])
+        agent.run("Dummy task.")
+        memory_str = str(agent.write_memory_to_messages())
+        assert "check_returns_false" in memory_str
+        assert "returned False" in memory_str
 
     def test_generation_errors_are_raised(self):
         class FakeCodeModel(Model):


### PR DESCRIPTION
Fixes #2456.

`_validate_final_answer` used `assert check_function(...)` to run final answer checks. Python strips all assert statements when running with `-O` or `-OO` — common in Docker production images and optimized builds. This meant `final_answer_checks` callbacks were silently disabled: no validation ran, no error was raised, any answer passed through.

**Before:**
```python
assert check_function(final_answer, self.memory, agent=self)
```

**After:**
```python
result = check_function(final_answer, self.memory, agent=self)
if not result:
    raise AgentError(
        f"Check {check_function.__name__} returned False for the final answer.", self.logger
    )
```

`AgentError` is re-raised directly so existing error handling in the calling code is unaffected.

**What changed:**
- `src/smolagents/agents.py` — replaced assert with explicit result check in `_validate_final_answer`
- `tests/test_agents.py` — added `test_final_answer_check_returning_false_raises_agent_error` covering the False-return path; updated existing assertion string to match new message format

All existing `final_answer_checks` tests pass.