### PR TITLE
fix: don't let user try/except swallow break/continue/return in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1166,6 +1166,12 @@ def evaluate_try(
     try:
         for stmt in try_node.body:
             evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
+    except (BreakException, ContinueException, ReturnException):
+        # break / continue / return are modelled internally as exceptions for
+        # control flow; they are not real exceptions in Python and must never be
+        # caught by a user `except` clause. Re-raise so the enclosing loop or
+        # function handles them. The `finally` block below still runs, as in CPython.
+        raise
     except Exception as e:
         matched = False
         for handler in try_node.handlers:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1421,6 +1421,87 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         assert result == 1
         assert is_final_answer is True
 
+    def test_break_in_try_except_is_not_swallowed(self):
+        code = dedent("""
+            result = []
+            for i in range(5):
+                try:
+                    if i == 2:
+                        break
+                except Exception:
+                    pass
+                result.append(i)
+            result
+        """)
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == [0, 1]
+
+    def test_continue_in_try_except_is_not_swallowed(self):
+        code = dedent("""
+            result = []
+            for i in range(5):
+                try:
+                    if i % 2 == 0:
+                        continue
+                except Exception:
+                    pass
+                result.append(i)
+            result
+        """)
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == [1, 3]
+
+    def test_return_in_try_except_is_not_swallowed(self):
+        code = dedent("""
+            def f():
+                try:
+                    return "early"
+                except Exception:
+                    return "caught"
+            f()
+        """)
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == "early"
+
+    def test_bare_except_does_not_swallow_break(self):
+        code = dedent("""
+            result = []
+            for i in range(3):
+                try:
+                    break
+                except:
+                    pass
+                result.append(i)
+            result
+        """)
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == []
+
+    def test_finally_runs_when_try_body_breaks(self):
+        code = dedent("""
+            log = []
+            for i in range(3):
+                try:
+                    break
+                finally:
+                    log.append("finally")
+            log
+        """)
+        result, _ = evaluate_python_code(code, {"range": range}, state={})
+        assert result == ["finally"]
+
+    def test_try_except_still_catches_real_exceptions(self):
+        code = dedent("""
+            result = None
+            try:
+                x = 1 / 0
+            except ZeroDivisionError:
+                result = "caught"
+            result
+        """)
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == "caught"
+
     def test_dangerous_builtins_are_callable_if_explicitly_added(self):
         dangerous_code = dedent("""
             eval("1 + 1")


### PR DESCRIPTION
## What

`break` / `continue` / `return` are modelled internally as exceptions (`BreakException`, `ContinueException`, `ReturnException`) that subclass `Exception`. `evaluate_try` catches `except Exception`, so a user `try/except Exception` (or a bare `except:`) in agent-generated code silently caught these control-flow signals — loops didn't break/continue and functions didn't return early:

```python
for i in range(5):
    try:
        if i == 2:
            break        # swallowed -> the loop kept going
    except Exception:
        pass
    result.append(i)
# CPython: result == [0, 1]
# before:  result == [0, 1, 2, 3, 4]
```

The same happened for `continue` inside a `try/except` and for `return` inside a function's `try/except`.

## Change

`evaluate_try` now re-raises `BreakException` / `ContinueException` / `ReturnException` before matching user `except` handlers, so they propagate to the enclosing loop or function. The `finally` block still runs, matching CPython, and real exceptions are still handled normally.

This mirrors the `FinalAnswerException` fix (#1905), which excluded `final_answer` from the same generic-`except` capture; this does the analogous thing for the loop/function control-flow signals. The change is scoped to `evaluate_try` and does not alter the exception class hierarchy.

## Tests

Adds tests for `break` / `continue` / `return` inside `try/except`, a bare `except:`, `finally` still running when the `try` body breaks, and that real exceptions (e.g. `ZeroDivisionError`) are still caught.