### PR TITLE
fix: spread starred elements in list/tuple/set literals in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1413,6 +1413,23 @@ def evaluate_delete(
             raise InterpreterError(f"Deletion of {type(target).__name__} targets is not supported")
 
 
+def _evaluate_display_elements(
+    elts: list[ast.expr],
+    state: dict[str, Any],
+    static_tools: dict[str, Callable],
+    custom_tools: dict[str, Callable],
+    authorized_imports: list[str],
+) -> list[Any]:
+    """Evaluate the elements of a list/tuple/set display, spreading ``*`` unpackings (PEP 448)."""
+    values: list[Any] = []
+    for elt in elts:
+        if isinstance(elt, ast.Starred):
+            values.extend(evaluate_ast(elt.value, state, static_tools, custom_tools, authorized_imports))
+        else:
+            values.append(evaluate_ast(elt, state, static_tools, custom_tools, authorized_imports))
+    return values
+
+
 @safer_eval
 def evaluate_ast(
     expression: ast.AST,
@@ -1462,7 +1479,7 @@ def evaluate_ast(
         # Constant -> just return the value
         return expression.value
     elif isinstance(expression, ast.Tuple):
-        return tuple((evaluate_ast(elt, *common_params) for elt in expression.elts))
+        return tuple(_evaluate_display_elements(expression.elts, *common_params))
     elif isinstance(expression, ast.GeneratorExp):
         return evaluate_generatorexp(expression, *common_params)
     elif isinstance(expression, ast.ListComp):
@@ -1521,7 +1538,7 @@ def evaluate_ast(
         return "".join([str(evaluate_ast(v, *common_params)) for v in expression.values])
     elif isinstance(expression, ast.List):
         # List -> evaluate all elements
-        return [evaluate_ast(elt, *common_params) for elt in expression.elts]
+        return _evaluate_display_elements(expression.elts, *common_params)
     elif isinstance(expression, ast.Name):
         # Name -> pick up the value in the state
         return evaluate_name(expression, *common_params)
@@ -1557,7 +1574,7 @@ def evaluate_ast(
     elif isinstance(expression, ast.With):
         return evaluate_with(expression, *common_params)
     elif isinstance(expression, ast.Set):
-        return set((evaluate_ast(elt, *common_params) for elt in expression.elts))
+        return set(_evaluate_display_elements(expression.elts, *common_params))
     elif isinstance(expression, ast.Return):
         raise ReturnException(evaluate_ast(expression.value, *common_params) if expression.value else None)
     elif isinstance(expression, ast.Pass):

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -457,6 +457,26 @@ for block in text_block:
         result, _ = evaluate_python_code(code, {"len": len, "range": range}, state={})
         assert result == "THESEAGULL"
 
+    def test_list_display_unpacking(self):
+        result, _ = evaluate_python_code("a = [1, 2]\nb = [3, 4]\n[0, *a, *b, 9]", {}, state={})
+        assert result == [0, 1, 2, 3, 4, 9]
+
+    def test_tuple_display_unpacking(self):
+        result, _ = evaluate_python_code("a = [1, 2]\n(*a, 3)", {}, state={})
+        assert result == (1, 2, 3)
+
+    def test_set_display_unpacking(self):
+        result, _ = evaluate_python_code("a = {1, 2}\nb = {2, 3}\n{*a, *b}", {}, state={})
+        assert result == {1, 2, 3}
+
+    def test_display_unpacking_of_non_list_iterable(self):
+        result, _ = evaluate_python_code("[*range(3), 9]", {"range": range}, state={})
+        assert result == [0, 1, 2, 9]
+
+    def test_nested_display_unpacking(self):
+        result, _ = evaluate_python_code("a = [1, 2]\n[*[*a], 3]", {}, state={})
+        assert result == [1, 2, 3]
+
     def test_tuples(self):
         code = "x = (1, 2, 3)\nx[1]"
         result, _ = evaluate_python_code(code, {}, state={})


### PR DESCRIPTION
## What

`evaluate_ast` builds list/tuple/set displays by mapping `evaluate_ast` over each element, so a starred element (PEP 448 iterable unpacking) was inserted as a single item instead of being spread:

```python
a = [1, 2]
[*a, 3]         # -> [[1, 2], 3]           (should be [1, 2, 3])
(*a, 3)         # -> ([1, 2], 3)           (should be (1, 2, 3))
{*a, 3}         # -> InterpreterError       (unhashable list)
[*range(3), 9]  # -> [range(0, 3), 9]      (should be [0, 1, 2, 9])
```

This is common in agent-generated code (`merged = [*a, *b]`, `[*range(n), x]`, …).

## Change

Add a small helper that flattens starred entries when evaluating list/tuple/set displays, used by the three branches. Assignment-target unpacking (`a, *b = ...`) is a separate code path (`set_value`) and is unaffected.

## Tests

Adds tests for starred unpacking in list, tuple and set literals, including a non-list iterable (`range`) and nesting. Existing collection/comprehension tests still pass.