### PR TITLE
Fix parsing code fences after Code marker

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -188,10 +188,37 @@ def parse_json_blob(json_blob: str) -> tuple[dict[str, str], str]:
 
 def extract_code_from_text(text: str, code_block_tags: tuple[str, str]) -> str | None:
     """Extract code from the LLM's output."""
+    if code_block_tags[0].startswith("```") and code_block_tags[1].strip() == "```":
+        return _extract_markdown_code_blocks(text)
+
     pattern = rf"{code_block_tags[0]}(.*?){code_block_tags[1]}"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         return "\n\n".join(match.strip() for match in matches)
+    return None
+
+
+def _extract_markdown_code_blocks(text: str, *, allow_empty_language: bool = False) -> str | None:
+    matches: list[str] = []
+    lines = text.splitlines()
+    i = 0
+
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("```"):
+            language = line[3:].strip()
+            if allow_empty_language or language in {"python", "py"}:
+                block: list[str] = []
+                i += 1
+                while i < len(lines) and lines[i].strip() != "```":
+                    block.append(lines[i])
+                    i += 1
+                if i < len(lines):
+                    matches.append("\n".join(block).strip())
+        i += 1
+
+    if matches:
+        return "\n\n".join(matches)
     return None
 
 
@@ -211,7 +238,11 @@ def parse_code_blobs(text: str, code_block_tags: tuple[str, str]) -> str:
     """
     matches = extract_code_from_text(text, code_block_tags)
     if not matches:  # Fallback to markdown pattern
-        matches = extract_code_from_text(text, ("```(?:python|py)", "\n```"))
+        code_sections = re.split(r"(?im)^Code:\s*$", text)
+        if len(code_sections) > 1:
+            matches = _extract_markdown_code_blocks(code_sections[-1], allow_empty_language=True)
+        if not matches:
+            matches = _extract_markdown_code_blocks(text)
     if matches:
         return matches
     # Maybe the LLM outputted a code blob directly

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,52 @@ import numpy as np
         )
         assert output == "import numpy as np"
 
+        # Unlabeled markdown blocks in thoughts should not be treated as code when
+        # a later Code section provides the executable block.
+        output = parse_code_blobs(
+            """
+Thought:
+This reasoning includes a fenced example:
+```
+invalid code
+```
+
+Code:
+```
+print("valid code")
+```
+""",
+            ("<code>", "</code>"),
+        )
+        assert output == 'print("valid code")'
+
+        # Inline triple backticks in code are not closing fences unless they are
+        # alone on their own line.
+        output = parse_code_blobs(
+            '''
+Code:
+```
+final_answer("""
+``` nested ```
+""")
+```
+''',
+            ("<code>", "</code>"),
+        )
+        assert output == 'final_answer("""\n``` nested ```\n""")'
+
+        output = parse_code_blobs(
+            '''
+```python
+final_answer("""
+``` nested ```
+""")
+```
+''',
+            ("```python", "```"),
+        )
+        assert output == 'final_answer("""\n``` nested ```\n""")'
+
     def test_multiple_code_blobs(self):
         test_input = "<code>\nFoo\n</code>\n\n<code>\ncode_a\n</code>\n\n<code>\ncode_b\n</code>"
         result = parse_code_blobs(test_input, ("<code>", "</code>"))


### PR DESCRIPTION
Fixes #1219.

This updates code block parsing so markdown fences are scanned line-by-line instead of with a non-greedy regex. That prevents inline triple backticks inside generated Python code from being mistaken for the closing fence.

When the model output contains a `Code:` section, the parser now prefers fenced code blocks from that section. This avoids accidentally executing fenced examples that appeared earlier in the reasoning/thought text.

Regression tests cover:
- an unlabeled fenced block in `Thought:` followed by the real fenced block in `Code:`
- inline triple backticks inside a `final_answer(...)` string
- the same inline-backtick case with a `python` markdown fence

Validation:
- `git diff --check`
- `python -m py_compile src\smolagents\utils.py tests\test_utils.py`
- manual parse regression checks with `PYTHONPATH=src`

I also tried `PYTHONPATH=src python -m pytest tests\test_utils.py -q`, but this local environment is missing `IPython`, which is imported during test collection. Installing `IPython` into a local target directory was not possible from the available Python 3.14 environment.
