### PR TITLE
fix(examples): use StaticPool so in-memory SQLite works across thread   in text_to_sql fix(examples): use StaticPool so in-memory SQLite works across thread…

### DIFF
--- a/examples/text_to_sql.py
+++ b/examples/text_to_sql.py
@@ -10,9 +10,15 @@ from sqlalchemy import (
     inspect,
     text,
 )
+from sqlalchemy.pool import StaticPool
 
-
-engine = create_engine("sqlite:///:memory:")
+# Use StaticPool + check_same_thread=False so the in-memory SQLite engine survives
+# smolagents' CodeAgent sandbox which executes generated code in a different thread.
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
 metadata_obj = MetaData()
 
 # create city SQL table


### PR DESCRIPTION
 
  ## Summary
  - Fix `examples/text_to_sql.py` to handle the cross-thread SQLite
  access
    case that smolagents' CodeAgent sandbox introduces.
  
  ## Problem
  The original example creates an in-memory SQLite engine with
  `create_engine("sqlite:///:memory:")`, then the agent invokes
  `sql_engine`
  through smolagents' CodeAgent sandbox — which executes the generated
  Python in a separate thread.
  
  This triggers:
  sqlite3.ProgrammingError: SQLite objects created in a thread can only
  be used
  in that same thread. The object was created in thread id X and this is
  thread id Y.
  
  The agent then gets stuck in a retry loop trying `SELECT * FROM
  receipts`
  because the engine returns "no such table" / "no such function" for
  the new
  thread, and burns 100K+ tokens before hitting `max_steps`.
  
  ## Fix
  Use `StaticPool` and set `check_same_thread=False` so the in-memory
  SQLite engine connection is shared across the executor thread:
  
  ```python
  engine = create_engine(
      "sqlite:///:memory:",
      connect_args={"check_same_thread": False},
      poolclass=StaticPool,
  )
  
  Test
  
  I verified the fix with a concurrent-thread stress test:
  - Original engine: throws OperationalError / ProgrammingError under 5+
  threads
  - Patched engine: 10 concurrent threads all return correct results
  
  Why this matters
  
  This is the first example someone hits when trying to use the
  Text-to-SQL
  pattern. The example should "just work" out of the box — without this
  fix,
  new users hit the thread error immediately and have to spend time
  debugging
  SQLAlchemy pool configuration just to follow the README.
  
  Fixes the 30-step retry loop reported when running the unmodified
  example.
