### PR TITLE
docs: add HVTracker trust badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ limitations under the License.
     <a href="https://huggingface.co/docs/smolagents"><img alt="Documentation" src="https://img.shields.io/website/http/huggingface.co/docs/smolagents/index.html.svg?down_color=red&down_message=offline&up_message=online"></a>
     <a href="https://github.com/huggingface/smolagents/releases"><img alt="GitHub release" src="https://img.shields.io/github/release/huggingface/smolagents.svg"></a>
     <a href="https://github.com/huggingface/smolagents/blob/main/CODE_OF_CONDUCT.md"><img alt="Contributor Covenant" src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg"></a>
+    <a href="https://hvtracker.net/agents/smolagents/"><img alt="HVTrust" src="https://hvtracker.net/badge/smolagents.svg"></a>
     <a href="https://deepwiki.com/huggingface/smolagents"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 


### PR DESCRIPTION
Adds the optional HVTracker trust badge requested in #2412 to the README badge list.

Validation:
- `rg -n "HVTrust|hvtracker.net/agents/smolagents|hvtracker.net/badge/smolagents.svg" README.md`

Docs-only change; no runtime tests run.

Closes #2412