### PR TITLE
docs: mention HF token in quick demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ agent = CodeAgent(tools=[WebSearchTool()], model=model, stream_outputs=True)
 agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")
 ```
 
+If you use `InferenceClientModel`, set `HF_TOKEN` or pass `token` when you need higher rate limits or access to
+gated models. See the [guided tour](https://huggingface.co/docs/smolagents/guided_tour) for token setup details.
+
 https://github.com/user-attachments/assets/84b149b4-246c-40c9-a48d-ba013b08e600
 
 You can even share your agent to the Hub, as a Space repository:


### PR DESCRIPTION
## What changed

- Added a short note after the README quick demo explaining that `InferenceClientModel` users can set `HF_TOKEN` or pass `token` for higher rate limits or gated models.
- Linked to the guided tour for the existing token setup details.

## Why it changed

The quick demo uses `InferenceClientModel()` but did not mention authentication. Issue #596 points out that this can confuse new users when they hit rate limits or need access to gated models.

## How it was validated

- `git diff --check`
- `curl -I -L --max-time 20 https://huggingface.co/docs/smolagents/guided_tour`

## Related issue

Refs #596
