### PR TITLE
Update CI huggingface/doc-builder

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
     with:
       commit_sha: ${{ github.sha }}
       package: smolagents

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@0f4784322c564503c4a4d67ccb7fba29e32f111a  # main
     with:
       package_name: smolagents
     secrets:


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to use a newer version of the shared `huggingface/doc-builder` workflows. All references to the reusable workflows have been updated to point to commit `0f4784322c564503c4a4d67ccb7fba29e32f111a`.

Workflow dependency updates:

* `.github/workflows/build_documentation.yml`: Updated the `build_main_documentation.yml` workflow reference to commit `0f4784322c564503c4a4d67ccb7fba29e32f111a`.
* `.github/workflows/build_pr_documentation.yml`: Updated the `build_pr_documentation.yml` workflow reference to commit `0f4784322c564503c4a4d67ccb7fba29e32f111a`.
* `.github/workflows/upload_pr_documentation.yml`: Updated the `upload_pr_documentation.yml` workflow reference to commit `0f4784322c564503c4a4d67ccb7fba29e32f111a`.