### PR TITLE
Fix CI AttributeError: 'str' object has no attribute '__module__'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ toolkit = [
 ]
 transformers = [
   "accelerate",
-  "transformers>=4.0.0",
+  "transformers>=4.0.0,!=5.13.0",  # !=5.13.0 (see GH-2487)
   "smolagents[torch]",
 ]
 vision = [


### PR DESCRIPTION
Fix CI AttributeError: 'str' object has no attribute '__module__':
- Pin transformers != 5.13.0

Fix #2487.

This PR makes a minor update to the `pyproject.toml` file to address a compatibility issue with a specific version of the `transformers` library.

### Changes

- Dependency management:
  * Updated the `transformers` dependency to exclude version `5.13.0` due to a known issue (see GH-2487) in the `transformers` group. (`pyproject.toml`)