### PR TITLE
docs: add security example — detect prompt injection and tool poisoning with a step callback

### DIFF
--- a/examples/security_atr_callback.py
+++ b/examples/security_atr_callback.py
@@ -1,0 +1,72 @@
+# Detect prompt injection, tool poisoning and unsafe generated actions during
+# an agent run using a step callback, and keep an audit trail (useful for
+# EU AI Act Article 12 style verifiable event logging) -- without changing any
+# smolagents internals.
+#
+# This uses ATR (Agent Threat Rules), an open, vendor-neutral detection
+# standard for AI agents (MIT licensed; like Sigma, but for prompt injection,
+# tool poisoning, MCP attacks and skill compromise). The rules ship bundled in
+# the pip package, so no network or rule download is needed.
+#
+# The pattern -- a step callback that inspects each step -- is engine-agnostic:
+# ATR is one concrete rule engine you can swap for any other check.
+#
+#   pip install smolagents pyatr
+
+from pyatr import scan
+
+from smolagents import CodeAgent, InferenceClientModel, WebSearchTool
+
+
+# Every finding is recorded here so you keep a tamper-evident trail of what the
+# agent saw and did across the whole run.
+audit_log: list[dict] = []
+
+
+def atr_security_callback(memory_step, agent=None):
+    """Scan each agent step against ATR rules.
+
+    Registered via ``step_callbacks``, this runs at the end of every step. It
+    inspects the model output, the code the CodeAgent is about to run
+    (``code_action``), and any tool observations -- which is where indirect
+    prompt injection from fetched web pages or files lands.
+    """
+    parts = []
+    for attr in ("model_output", "code_action", "observations"):
+        value = getattr(memory_step, attr, None)
+        if value:
+            parts.append(value if isinstance(value, str) else str(value))
+    text = "\n".join(parts)
+    if not text.strip():
+        return
+
+    for match in scan(text):
+        audit_log.append(
+            {
+                "step": getattr(memory_step, "step_number", None),
+                "rule": match.rule_id,
+                "title": match.title,
+                "severity": match.severity,
+            }
+        )
+        # Enforce lane: stop the agent on a critical finding.
+        if match.severity == "critical" and agent is not None:
+            print(f"[ATR] BLOCKED by {match.rule_id}: {match.title}")
+            agent.interrupt()
+        # Hunt lane: record lower-severity findings and let the run continue.
+        else:
+            print(f"[ATR] flagged {match.rule_id} ({match.severity}): {match.title}")
+
+
+agent = CodeAgent(
+    tools=[WebSearchTool()],
+    model=InferenceClientModel(),
+    step_callbacks=[atr_security_callback],
+)
+
+agent.run("Search for today's weather in Paris and summarise it.")
+
+# Inspect everything ATR flagged during the run.
+print("\nAudit trail:")
+for entry in audit_log:
+    print(entry)


### PR DESCRIPTION
This adds a runnable example showing how to detect prompt injection, tool poisoning and unsafe generated actions during an agent run, using the existing step_callbacks mechanism. It changes no smolagents internals and adds no dependency to the library itself.

Motivation

smolagents does not currently ship a native runtime threat-detection or audit example. This echoes the (now closed) request in #2177 for audit-trail hooks, whose motivation was EU AI Act Article 12 style verifiable event logging. Rather than adding new hook points, this example shows that the existing step_callbacks already cover the use case.

What it does

A step callback scans each step's model output, generated code (code_action) and tool observations against ATR (Agent Threat Rules), an open, vendor-neutral detection standard for AI agents (MIT licensed; like Sigma, but for prompt injection, tool poisoning, MCP attacks and skill compromise). Rules ship bundled in the pip package, so no network or rule download is needed.

The example demonstrates two lanes:
- an enforce lane that halts the agent via agent.interrupt() on a critical finding, and
- a hunt lane that records findings to an audit trail and lets the run continue.

Notes

ATR is one concrete rule engine; the pattern (a step callback for runtime security) is engine-agnostic and works with any check you prefer. The example installs pyatr only to run itself, following the same convention as other examples that pip install extra packages.

Run with:

    pip install smolagents pyatr
    python examples/security_atr_callback.py
