### PR TITLE
fix: nest multiple for-clauses in generator expressions

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1349,32 +1349,17 @@ def evaluate_generatorexp(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> Generator[Any]:
-    def generator():
-        for gen in genexp.generators:
-            iter_value = evaluate_ast(gen.iter, state, static_tools, custom_tools, authorized_imports)
-            for value in iter_value:
-                new_state = state.copy()
-                set_value(
-                    gen.target,
-                    value,
-                    new_state,
-                    static_tools,
-                    custom_tools,
-                    authorized_imports,
-                )
-                if all(
-                    evaluate_ast(if_clause, new_state, static_tools, custom_tools, authorized_imports)
-                    for if_clause in gen.ifs
-                ):
-                    yield evaluate_ast(
-                        genexp.elt,
-                        new_state,
-                        static_tools,
-                        custom_tools,
-                        authorized_imports,
-                    )
-
-    return generator()
+    # Reuse the shared, recursive comprehension helper so that multiple `for` clauses are
+    # properly nested (e.g. `(x + y for x in a for y in b)`), matching list/set/dict
+    # comprehensions. The helper is itself a generator, so laziness is preserved.
+    return _evaluate_comprehensions(
+        genexp.generators,
+        lambda comp_state: evaluate_ast(genexp.elt, comp_state, static_tools, custom_tools, authorized_imports),
+        state,
+        static_tools,
+        custom_tools,
+        authorized_imports,
+    )
 
 
 def evaluate_delete(

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -576,6 +576,17 @@ simple_set = {
         assert isinstance(result, types.GeneratorType)
         assert list(result) == [0, 1, 2]
 
+    def test_generatorexp_with_multiple_clauses(self):
+        # A generator expression with several `for` clauses must nest them (like the
+        # equivalent list comprehension), not iterate them independently.
+        code = "list(x + y for x in [1, 2] for y in [10, 20])"
+        result, _ = evaluate_python_code(code, {"list": list}, state={})
+        assert result == [11, 21, 12, 22]
+        # Later clauses may depend on earlier targets.
+        code = "list(j for i in range(3) for j in range(i))"
+        result, _ = evaluate_python_code(code, {"list": list, "range": range}, state={})
+        assert result == [0, 0, 1]
+
     def test_generatorexp_with_infinite_sequence(self):
         """Test that generator expressions handle infinite sequences correctly without hanging."""
         code = dedent(


### PR DESCRIPTION
No linked issue — found while reading `local_python_executor.py`.

### Summary

A generator expression with multiple `for` clauses is evaluated incorrectly by the local Python executor: the clauses are iterated as a flat, sequential loop instead of being nested. A later clause can't see an earlier clause's target, so the expression raises where CPython succeeds:

```python
list(x + y for x in [1, 2] for y in [10, 20])
# executor: InterpreterError: The variable 'y' is not defined
# CPython:  [11, 21, 12, 22]
```

The equivalent list comprehension `[x + y for x in [1, 2] for y in [10, 20]]` works fine in the executor, which makes the inconsistency clear. This affects a common idiom — flattening nested loops in a generator, e.g. `sum(i for row in matrix for i in row)`.

### Root cause

`evaluate_generatorexp` hand-rolls a `for gen in genexp.generators` loop that flattens the clauses. List, set, and dict comprehensions were migrated to the recursive `_evaluate_comprehensions` helper (which nests clauses correctly), but generator expressions were left on the old flat implementation.

### Fix

Delegate to the same `_evaluate_comprehensions` helper so generator expressions nest their clauses like the other comprehensions. The helper is itself a generator, so laziness is preserved (the existing `test_generatorexp` and infinite-sequence tests still pass).

### Test

Added `test_generatorexp_with_multiple_clauses` to `tests/test_local_python_executor.py` (fails before, passes after). The full `tests/test_local_python_executor.py` suite passes; the only failures in my environment are the pre-existing `test_can_import_scipy` / `test_can_import_sklearn` cases, which require those optional packages to be installed and fail identically on `main`. `ruff` check + format are clean.
