### PR TITLE
fix(agents): append final action step to memory before final_answer_checks

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -586,10 +586,14 @@ You have been provided with these additional arguments, that you can access dire
                             level=LogLevel.INFO,
                         )
 
-                        if self.final_answer_checks:
-                            self._validate_final_answer(final_answer)
                         returned_final_answer = True
                         action_step.is_final_answer = True
+                        # Finalize and append the step BEFORE running final_answer_checks
+                        # so that checks can inspect the current step in memory.
+                        self._finalize_step(action_step)
+                        self.memory.steps.append(action_step)
+                        if self.final_answer_checks:
+                            self._validate_final_answer(final_answer)
 
             except AgentGenerationError as e:
                 # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
@@ -598,8 +602,9 @@ You have been provided with these additional arguments, that you can access dire
                 # Other AgentError types are caused by the Model, so we should log them and iterate.
                 action_step.error = e
             finally:
-                self._finalize_step(action_step)
-                self.memory.steps.append(action_step)
+                if not returned_final_answer:
+                    self._finalize_step(action_step)
+                    self.memory.steps.append(action_step)
                 yield action_step
                 self.step_number += 1
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -683,6 +683,29 @@ nested_answer()
         assert len([step for step in agent.memory.steps if isinstance(step, ActionStep)]) == 2
         assert error_string not in str(agent.write_memory_to_messages())
 
+    def test_final_answer_checks_see_current_step_in_memory(self):
+        """Test that final_answer_checks can access the current action step already stored in memory."""
+        check_called = False
+
+        def check_step_in_memory(final_answer, memory, agent):
+            nonlocal check_called
+            check_called = True
+            action_steps = [step for step in memory.steps if isinstance(step, ActionStep)]
+            assert len(action_steps) > 0, "Expected action step to be in memory during final answer check"
+            last_step = action_steps[-1]
+            assert last_step.is_final_answer, "Expected last step to be marked as final answer"
+            return True
+
+        agent = CodeAgent(
+            model=FakeCodeModel(),
+            tools=[],
+            final_answer_checks=[check_step_in_memory],
+            max_steps=2,
+        )
+        output = agent.run("Dummy task.")
+        assert output == 7.2904  # Should pass the check
+        assert check_called, "Expected final answer check to be called"
+
     def test_final_answer_checks_with_agent_access(self):
         """Test that final answer checks can access agent properties."""
 


### PR DESCRIPTION
## Problem

`final_answer_checks` in `MultiStepAgent._run_stream` were executed before the current `ActionStep` was appended to `self.memory.steps`. This meant critic/guardrail callbacks that tried to inspect the step they were validating could only see previous steps, not the final step itself. This was reported in #1374.

## Fix

When the stream yields a final `ActionOutput`:

1. Mark `returned_final_answer = True` and `action_step.is_final_answer = True`.
2. Finalize and append the action step to memory before running `_validate_final_answer`.
3. In the `finally` block, only finalize/append the step if it has not already been finalized (guard with `if not returned_final_answer`).

This keeps the existing control flow intact while giving `final_answer_checks` access to the current step in `memory.steps`.

## Tests

Added `test_final_answer_checks_see_current_step_in_memory` in `tests/test_agents.py`, which verifies that a `final_answer_checks` callback can find the current `ActionStep` in `memory.steps` and that it is marked as `is_final_answer`.

All existing `final_answer_checks` tests continue to pass.

Fixes #1374