### PR TITLE
Fix planning remaining_steps rendering and run max_steps overrides

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -553,7 +553,10 @@ You have been provided with these additional arguments, that you can access dire
                 planning_start_time = time.time()
                 planning_step = None
                 for element in self._generate_planning_step(
-                    task, is_first_step=len(self.memory.steps) == 1, step=self.step_number
+                    task,
+                    is_first_step=len(self.memory.steps) == 1,
+                    step=self.step_number,
+                    max_steps=max_steps,
                 ):  # Don't use the attribute step_number here, because there can be steps from previous runs
                     yield element
                     planning_step = element
@@ -637,9 +640,10 @@ You have been provided with these additional arguments, that you can access dire
         return final_answer.content
 
     def _generate_planning_step(
-        self, task, is_first_step: bool, step: int
+        self, task, is_first_step: bool, step: int, max_steps: int | None = None
     ) -> Generator[ChatMessageStreamDelta | PlanningStep]:
         start_time = time.time()
+        effective_max_steps = self.max_steps if max_steps is None else max_steps
         if is_first_step:
             input_messages = [
                 ChatMessage(
@@ -704,7 +708,7 @@ You have been provided with these additional arguments, that you can access dire
                                 "task": task,
                                 "tools": self.tools,
                                 "managed_agents": self.managed_agents,
-                                "remaining_steps": (self.max_steps - step),
+                                "remaining_steps": (effective_max_steps - step),
                             },
                         ),
                     }

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -255,7 +255,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -199,7 +199,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -192,7 +192,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1337,6 +1337,11 @@ class TestMultiStepAgent:
             assert isinstance(message.content, list)
             for content, expected_content in zip(message.content, expected_message.content):
                 assert content == expected_content
+        # Built-in templates must interpolate remaining_steps (not leave a literal brace placeholder).
+        if step > 1:
+            update_prompt = planning_step.model_input_messages[-1].content[0]["text"]
+            assert "{remaining_steps}" not in update_prompt
+            assert f"you have {agent.max_steps - step} steps remaining" in update_prompt
         # Test calls to model
         assert len(fake_model.generate.call_args_list) == 1
         for call_args, expected_messages in zip(fake_model.generate.call_args_list, expected_messages_list):
@@ -1351,6 +1356,69 @@ class TestMultiStepAgent:
                 assert isinstance(message.content, list)
                 for content, expected_content in zip(message.content, expected_message.content):
                     assert content == expected_content
+
+    @pytest.mark.parametrize(
+        "agent_factory",
+        [
+            lambda model: CodeAgent(tools=[], model=model, max_steps=20),
+            lambda model: CodeAgent(
+                tools=[], model=model, max_steps=20, use_structured_outputs_internally=True
+            ),
+            lambda model: ToolCallingAgent(tools=[], model=model, max_steps=20),
+        ],
+    )
+    def test_planning_update_renders_remaining_steps(self, agent_factory):
+        """All built-in planning templates interpolate remaining_steps via Jinja."""
+        fake_model = MagicMock()
+        fake_model.generate.return_value = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="updated plan",
+            tool_calls=None,
+            raw="updated plan",
+            token_usage=None,
+        )
+        agent = agent_factory(fake_model)
+        planning_step = list(
+            agent._generate_planning_step("demo", is_first_step=False, step=2, max_steps=3)
+        )[-1]
+        update_prompt = planning_step.model_input_messages[-1].content[0]["text"]
+        assert "{remaining_steps}" not in update_prompt
+        assert "you have 1 steps remaining" in update_prompt
+
+    def test_planning_uses_run_max_steps_override(self):
+        """Planning remaining_steps must use run(... max_steps=N), not the constructor default."""
+
+        class RecordingModel(Model):
+            def __init__(self):
+                super().__init__(model_id="recording")
+                self.calls = []
+
+            def generate(self, messages, **kwargs):
+                self.calls.append(messages)
+                return ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="<code>\nprint('continue')\n</code>",
+                )
+
+        model = RecordingModel()
+        agent = CodeAgent(tools=[], model=model, max_steps=20, planning_interval=1)
+        agent.run("demo", max_steps=3)
+
+        update_prompts = []
+        for messages in model.calls:
+            for message in messages:
+                if not message.content:
+                    continue
+                text = message.content[0]["text"] if isinstance(message.content, list) else str(message.content)
+                if "steps remaining" in text:
+                    update_prompts.append(text)
+
+        assert update_prompts, "expected at least one planning update prompt"
+        for prompt in update_prompts:
+            assert "{remaining_steps}" not in prompt
+            assert "you have 18 steps remaining" not in prompt
+        # First update planning happens at step 2 with effective max_steps=3 → 1 remaining.
+        assert any("you have 1 steps remaining" in prompt for prompt in update_prompts)
 
     @pytest.mark.parametrize(
         "expected_messages_list",


### PR DESCRIPTION
## Summary
- Closes #2510
- Fix `{remaining_steps}` → `{{ remaining_steps }}` in CodeAgent, structured CodeAgent, and ToolCallingAgent planning templates so Jinja interpolates the budget
- Pass the effective per-run `max_steps` into `_generate_planning_step` so planning updates use `run(..., max_steps=N)` instead of the constructor default
- Add regression tests covering all three built-in templates and the per-run override path

## Test plan
- [x] `pytest tests/test_agents.py::TestMultiStepAgent::test_planning_step`
- [x] `pytest tests/test_agents.py::TestMultiStepAgent::test_planning_update_renders_remaining_steps`
- [x] `pytest tests/test_agents.py::TestMultiStepAgent::test_planning_uses_run_max_steps_override`
- [ ] CI full suite on this PR


Made with [Cursor](https://cursor.com)