### PR TITLE
fix(executor): reject oversized integer results before ** / << / *

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -56,6 +56,7 @@ ERRORS = {
 
 DEFAULT_MAX_LEN_OUTPUT = 50000
 MAX_OPERATIONS = 10000000
+MAX_INT_RESULT_BITS = 10_000_000
 MAX_WHILE_ITERATIONS = 1000000
 MAX_EXECUTION_TIME_SECONDS = 30
 ALLOWED_DUNDER_METHODS = ["__init__", "__str__", "__repr__"]
@@ -744,12 +745,28 @@ def evaluate_binop(
     elif isinstance(binop.op, ast.Sub):
         return left_val - right_val
     elif isinstance(binop.op, ast.Mult):
+        if isinstance(left_val, int) and isinstance(right_val, int) and left_val and right_val:
+            estimated_bits = left_val.bit_length() + right_val.bit_length()
+            if estimated_bits > MAX_INT_RESULT_BITS:
+                raise InterpreterError(
+                    f"Integer result would exceed the maximum allowed bit length of {MAX_INT_RESULT_BITS} bits."
+                )
         return left_val * right_val
     elif isinstance(binop.op, ast.Div):
         return left_val / right_val
     elif isinstance(binop.op, ast.Mod):
         return left_val % right_val
     elif isinstance(binop.op, ast.Pow):
+        if (
+            isinstance(left_val, int)
+            and isinstance(right_val, int)
+            and abs(left_val) >= 2
+            and right_val >= 2
+            and right_val * left_val.bit_length() > MAX_INT_RESULT_BITS
+        ):
+            raise InterpreterError(
+                f"Integer result would exceed the maximum allowed bit length of {MAX_INT_RESULT_BITS} bits."
+            )
         return left_val**right_val
     elif isinstance(binop.op, ast.FloorDiv):
         return left_val // right_val
@@ -760,6 +777,16 @@ def evaluate_binop(
     elif isinstance(binop.op, ast.BitXor):
         return left_val ^ right_val
     elif isinstance(binop.op, ast.LShift):
+        if (
+            isinstance(left_val, int)
+            and isinstance(right_val, int)
+            and left_val != 0
+            and right_val > 0
+            and left_val.bit_length() + right_val > MAX_INT_RESULT_BITS
+        ):
+            raise InterpreterError(
+                f"Integer result would exceed the maximum allowed bit length of {MAX_INT_RESULT_BITS} bits."
+            )
         return left_val << right_val
     elif isinstance(binop.op, ast.RShift):
         return left_val >> right_val

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -28,6 +28,7 @@ from smolagents.default_tools import BASE_PYTHON_TOOLS, FinalAnswerTool
 from smolagents.local_python_executor import (
     DANGEROUS_FUNCTIONS,
     DANGEROUS_MODULES,
+    MAX_INT_RESULT_BITS,
     ExecutionTimeoutError,
     InterpreterError,
     LocalPythonExecutor,
@@ -377,6 +378,31 @@ for result in search_results:
         result, _ = evaluate_python_code(code, {}, state=state)
         assert result == 9
         self.assertDictEqualNoPrint(state, {"x": 3, "y": 6, "_operations_count": {"counter": 4}})
+
+    def test_oversized_int_result_pow_is_rejected(self):
+        with pytest.raises(InterpreterError, match="exceed the maximum allowed bit length"):
+            evaluate_python_code(f"10 ** {MAX_INT_RESULT_BITS // 3}", {}, state={})
+
+    def test_oversized_int_result_left_shift_is_rejected(self):
+        with pytest.raises(InterpreterError, match="exceed the maximum allowed bit length"):
+            evaluate_python_code(f"1 << {MAX_INT_RESULT_BITS}", {}, state={})
+
+    def test_oversized_int_result_mult_is_rejected(self):
+        large_int = 1 << (MAX_INT_RESULT_BITS // 2)
+        with pytest.raises(InterpreterError, match="exceed the maximum allowed bit length"):
+            evaluate_python_code("left * right", {}, state={"left": large_int, "right": large_int})
+
+    @pytest.mark.parametrize(
+        ("code", "expected_result"),
+        [
+            ("2 ** 10", 1024),
+            ("3 << 4", 48),
+            ("6 * 7", 42),
+        ],
+    )
+    def test_normal_int_result_binops(self, code, expected_result):
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == expected_result
 
     def test_recursive_function(self):
         code = """


### PR DESCRIPTION
## Summary

Fixes #2473.

The local Python executor could still freeze on a single oversized integer operation (`**`, `<<`, large `*`) because thread-based timeouts cannot interrupt CPython integer work under the GIL. `MAX_OPERATIONS` does not help for one AST node.

This change estimates result bit length before those operations and raises `InterpreterError` when the estimate exceeds `MAX_INT_RESULT_BITS` (10_000_000).

## Changes

- Add `MAX_INT_RESULT_BITS` next to the existing executor limits
- Guard integer `**`, `<<`, and large `*` in `evaluate_binop`
- Add regression tests for oversized and normal cases

## Verification

- `pytest tests/test_local_python_executor.py -q` (403 passed, 2 skipped)
- ruff check/format clean on touched files

## Backwards compatibility

Normal small integer arithmetic is unchanged. Only results estimated above the bit-length cap are rejected early.
