### PR TITLE
Make space_sdk configurable in push_to_hub

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1164,6 +1164,7 @@ You have been provided with these additional arguments, that you can access dire
         private: bool | None = None,
         token: bool | str | None = None,
         create_pr: bool = False,
+        space_sdk: str = "gradio",
     ) -> str:
         """
         Upload the agent to the Hub.
@@ -1181,6 +1182,10 @@ You have been provided with these additional arguments, that you can access dire
                 when running `huggingface-cli login` (stored in `~/.huggingface`).
             create_pr (`bool`, *optional*, defaults to `False`):
                 Whether to create a PR with the uploaded files or directly commit.
+            space_sdk (`str`, *optional*, defaults to `"gradio"`):
+                The SDK of the Space to create (e.g. `"gradio"`, `"docker"`, `"static"`). Defaults to `"gradio"`.
+                Use another SDK such as `"static"` when your account cannot create Gradio Spaces (creating a Gradio
+                Space otherwise raises `402 Payment Required`).
         """
         repo_url = create_repo(
             repo_id=repo_id,
@@ -1188,7 +1193,7 @@ You have been provided with these additional arguments, that you can access dire
             private=private,
             exist_ok=True,
             repo_type="space",
-            space_sdk="gradio",
+            space_sdk=space_sdk,
         )
         repo_id = repo_url.repo_id
         metadata_update(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1641,6 +1641,33 @@ class TestMultiStepAgent:
             assert "Unknown agent class" in error_message
             assert "Supported agents:" in error_message
 
+    def test_push_to_hub_defaults_to_gradio_space_sdk(self):
+        """push_to_hub keeps creating a Gradio Space by default (backward compatible)."""
+        agent = CodeAgent(tools=[], model=MagicMock())
+        with (
+            patch("smolagents.agents.create_repo") as mock_create_repo,
+            patch("smolagents.agents.metadata_update"),
+            patch("smolagents.agents.upload_folder") as mock_upload_folder,
+            patch.object(agent, "save"),
+        ):
+            mock_create_repo.return_value = MagicMock(repo_id="user/my-agent")
+            agent.push_to_hub("user/my-agent")
+        assert mock_create_repo.call_args.kwargs["space_sdk"] == "gradio"
+        mock_upload_folder.assert_called_once()
+
+    def test_push_to_hub_forwards_configurable_space_sdk(self):
+        """push_to_hub forwards a custom space_sdk (e.g. "static") to create_repo (#2513)."""
+        agent = CodeAgent(tools=[], model=MagicMock())
+        with (
+            patch("smolagents.agents.create_repo") as mock_create_repo,
+            patch("smolagents.agents.metadata_update"),
+            patch("smolagents.agents.upload_folder"),
+            patch.object(agent, "save"),
+        ):
+            mock_create_repo.return_value = MagicMock(repo_id="user/my-agent")
+            agent.push_to_hub("user/my-agent", space_sdk="static")
+        assert mock_create_repo.call_args.kwargs["space_sdk"] == "static"
+
 
 class TestToolCallingAgent:
     def test_toolcalling_agent_instructions(self):


### PR DESCRIPTION
`push_to_hub()` hardcodes `space_sdk="gradio"` when it creates the Space, so accounts that can no longer create Gradio Spaces get a `402 Payment Required` from `create_repo` even though a Static Space would upload fine.

This adds a `space_sdk` parameter (default `"gradio"`, so existing calls are unchanged) and forwards it to `create_repo`, letting callers pick another SDK:

```python
agent.push_to_hub("username/my-agent", space_sdk="static")
```

Added two tests: one asserting the default stays `"gradio"`, one asserting a custom value is forwarded to `create_repo`.

Closes #2513