### PR TITLE
Add setup, checks, and repo layout to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,38 @@
 # Contributor Guidelines
+
+## Setup
+
+Python 3.10 or newer (CI runs 3.10 and 3.12).
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Checks
+
+Run these before opening a PR. Both are enforced in CI.
+
+```bash
+make quality   # ruff check + ruff format --check on examples/ src/ tests/
+make test      # pytest ./tests/
+```
+
+`make style` auto-fixes lint and formatting — don't hand-format code.
+
+## Repository layout
+
+- `src/smolagents/` — library code
+- `tests/` — pytest suite
+- `examples/` — runnable examples
+- `docs/` — documentation sources
+
+## Code style
+
+- Line length is 119; ruff enforces `E`, `F`, `I`, `W`.
+- Imports are sorted by ruff's isort with `smolagents` as first-party.
+
+## Guidelines
+
 - Follow OOP principles
 - Be Pythonic: follow Python best practices and idiomatic patterns
 - Write unit tests for new functionality


### PR DESCRIPTION
## What

Adds setup, the two CI-enforced checks, and the repo layout to `AGENTS.md`.

## Why

`AGENTS.md` is the file coding agents load on startup. Today it holds three style rules and no operational information, so an agent working from it alone doesn't know how to install the package, how to run the tests, or that `make style` exists — it will hand-format code and open PRs that fail `make quality`.

Everything added is taken from the repo's own sources, not invented:

- `pip install -e ".[dev]"` — `CONTRIBUTING.md`
- `make quality` / `make style` / `make test` — `Makefile`, and the same commands run in `.github/workflows/quality.yml` and `tests.yml`
- Python 3.10+ and the 3.10 / 3.12 CI matrix — `pyproject.toml` and `tests.yml`
- line length 119, ruff `E`/`F`/`I`/`W`, isort first-party — `[tool.ruff]` in `pyproject.toml`

The three existing guidelines are kept verbatim; the change is additive.

## Note

This PR was authored by an AI agent (Claude Code), disclosing it since the diff is about instructions for agents.

---

*Context: found while running a deterministic quality survey of AGENTS.md files across major agent repos — smolagents scored 50/100, entirely for missing operational content. Happy to share the method if it's useful.*
