### PR TITLE
Fix interactive CLI options

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -155,7 +155,7 @@ def interactive_mode():
     model_type = Prompt.ask(
         "[bold]Model type[/]",
         default="InferenceClientModel",
-        choices=["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel"],
+        choices=["InferenceClientModel", "OpenAIModel", "LiteLLMModel", "TransformersModel"],
     )
 
     model_id = Prompt.ask("[bold white]Model ID[/]", default="Qwen/Qwen2.5-Coder-32B-Instruct")
@@ -165,10 +165,9 @@ def interactive_mode():
     api_base = None
     api_key = None
     imports = []
-    action_type = "code"
 
     if Confirm.ask("\n[bold white]Configure advanced options?[/]", default=False):
-        if model_type in ["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel"]:
+        if model_type in ["InferenceClientModel", "OpenAIModel", "LiteLLMModel"]:
             provider = Prompt.ask("[bold white]Provider[/]", default="")
             api_base = Prompt.ask("[bold white]API Base URL[/]", default="")
             api_key = Prompt.ask("[bold white]API Key[/]", default="", password=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from smolagents.cli import load_model
+from smolagents.cli import interactive_mode, load_model
 from smolagents.local_python_executor import CodeOutput, LocalPythonExecutor
 from smolagents.models import InferenceClientModel, LiteLLMModel, OpenAIModel, TransformersModel
 
@@ -59,6 +59,21 @@ def test_load_model_invalid_model_type():
         load_model("InvalidModel", "test_model_id")
 
 
+def test_interactive_mode_preserves_selected_action_type_and_openai_model_type():
+    with (
+        patch(
+            "smolagents.cli.Prompt.ask",
+            side_effect=["tool_calling", "web_search", "OpenAIModel", "test_model_id", "test_prompt"],
+        ),
+        patch("smolagents.cli.Confirm.ask", return_value=False),
+    ):
+        result = interactive_mode()
+
+    assert result[0] == "test_prompt"
+    assert result[2] == "OpenAIModel"
+    assert result[-1] == "tool_calling"
+
+
 def test_cli_main(capsys):
     with patch("smolagents.cli.load_model") as mock_load_model:
         mock_load_model.return_value = "mock_model"
@@ -82,6 +97,24 @@ def test_cli_main(capsys):
     # agent.run
     assert len(mock_code_agent.return_value.run.call_args_list) == 1
     assert mock_code_agent.return_value.run.call_args.args == ("test_prompt",)
+
+
+def test_cli_main_with_tool_calling_agent():
+    with (
+        patch("smolagents.cli.load_model", return_value="mock_model") as mock_load_model,
+        patch("smolagents.cli.ToolCallingAgent") as mock_tool_calling_agent,
+    ):
+        from smolagents.cli import run_smolagent
+
+        run_smolagent("test_prompt", [], "InferenceClientModel", "test_model_id", action_type="tool_calling")
+
+    assert mock_load_model.call_args.args == ("InferenceClientModel", "test_model_id")
+    assert mock_tool_calling_agent.call_args.kwargs == {
+        "tools": [],
+        "model": "mock_model",
+        "stream_outputs": True,
+    }
+    assert mock_tool_calling_agent.return_value.run.call_args.args == ("test_prompt",)
 
 
 def test_vision_web_browser_main():


### PR DESCRIPTION
## Summary
- preserve the selected agent action type in interactive mode
- use `OpenAIModel` consistently in the interactive model prompt
- add regression coverage for both paths

## Why
Interactive setup always reset the selected action type to `code`, and the displayed OpenAI model option did not match the model factory.

## Tests
`PYTHONPATH=src .venv/bin/python -m pytest tests/test_cli.py -k 'interactive_mode_preserves_selected_action_type_and_openai_model_type or cli_main_with_tool_calling_agent'`