### PR TITLE
Add KeenableSearchTool (keyless web search)

### DIFF
--- a/docs/source/en/reference/default_tools.md
+++ b/docs/source/en/reference/default_tools.md
@@ -11,6 +11,7 @@ The built-in tools can be categorized by their primary functions:
   - [`ApiWebSearchTool`]
   - [`DuckDuckGoSearchTool`]
   - [`GoogleSearchTool`]
+  - [`KeenableSearchTool`]
   - [`WebSearchTool`]
   - [`WikipediaSearchTool`]
 - **Web Interaction**: Fetch and process content from specific web pages.
@@ -39,6 +40,10 @@ The built-in tools can be categorized by their primary functions:
 ## GoogleSearchTool
 
 [[autodoc]] smolagents.default_tools.GoogleSearchTool
+
+## KeenableSearchTool
+
+[[autodoc]] smolagents.default_tools.KeenableSearchTool
 
 ## PythonInterpreterTool
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -339,6 +339,85 @@ class ApiWebSearchTool(Tool):
         )
 
 
+class KeenableSearchTool(Tool):
+    """Web search tool backed by the Keenable Search API.
+
+    Keyless by default: it queries the public endpoint with no account or API key. Setting an
+    optional API key (the ``KEENABLE_API_KEY`` environment variable by default) only lifts the
+    rate limit; it is never required.
+
+    Args:
+        api_key (`str`, *optional*): Keenable API key. If omitted, the tool reads `api_key_name`
+            from the environment; if that is also unset it stays keyless (public endpoint).
+        api_key_name (`str`, default `"KEENABLE_API_KEY"`): Environment variable holding the key.
+        max_results (`int`, default `10`): Maximum number of search results to return.
+        rate_limit (`float`, default `1.0`): Maximum queries per second. Set to `None` to disable.
+
+    Examples:
+        ```python
+        >>> from smolagents import KeenableSearchTool
+        >>> web_search_tool = KeenableSearchTool()  # keyless
+        >>> results = web_search_tool("Hugging Face")
+        >>> print(results)
+        ```
+    """
+
+    name = "web_search"
+    description = "Performs a web search for a query and returns a string of the top search results formatted as markdown with titles, URLs, and descriptions."
+    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    output_type = "string"
+
+    def __init__(
+        self,
+        api_key: str = "",
+        api_key_name: str = "",
+        max_results: int = 10,
+        rate_limit: float | None = 1.0,
+    ):
+        import os
+
+        super().__init__()
+        self.api_key_name = api_key_name or "KEENABLE_API_KEY"
+        self.api_key = api_key or os.getenv(self.api_key_name)
+        self.max_results = max_results
+        self.rate_limit = rate_limit
+        self._min_interval = 1.0 / rate_limit if rate_limit else 0.0
+        self._last_request_time = 0.0
+
+    def _enforce_rate_limit(self) -> None:
+        import time
+
+        # No rate limit enforced
+        if not self.rate_limit:
+            return
+
+        now = time.time()
+        elapsed = now - self._last_request_time
+        if elapsed < self._min_interval:
+            time.sleep(self._min_interval - elapsed)
+        self._last_request_time = time.time()
+
+    def forward(self, query: str) -> str:
+        import requests
+
+        self._enforce_rate_limit()
+        # Keyless by default; the optional key only lifts the rate limit.
+        endpoint = "https://api.keenable.ai/v1/search" if self.api_key else "https://api.keenable.ai/v1/search/public"
+        headers = {"Content-Type": "application/json", "X-Keenable-Title": "smolagents"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        response = requests.post(endpoint, headers=headers, json={"query": query, "mode": "pro"})
+        response.raise_for_status()
+        data = response.json()
+        results = data.get("results", [])[: self.max_results]
+        if not results:
+            raise Exception("No results found! Try a less restrictive/shorter query.")
+        return "## Search Results\n\n" + "\n\n".join(
+            f"{idx}. [{result.get('title', '')}]({result.get('url', '')})\n{result.get('description', '')}"
+            for idx, result in enumerate(results, start=1)
+        )
+
+
 class WebSearchTool(Tool):
     name = "web_search"
     description = "Performs a web search for a query and returns a string of the top search results formatted as markdown with titles, links, and descriptions."
@@ -686,6 +765,7 @@ TOOL_MAPPING = {
 
 __all__ = [
     "ApiWebSearchTool",
+    "KeenableSearchTool",
     "PythonInterpreterTool",
     "FinalAnswerTool",
     "UserInputTool",

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -413,9 +413,21 @@ class KeenableSearchTool(Tool):
         if not results:
             raise Exception("No results found! Try a less restrictive/shorter query.")
         return "## Search Results\n\n" + "\n\n".join(
-            f"{idx}. [{result.get('title', '')}]({result.get('url', '')})\n{result.get('description', '')}"
+            f"{idx}. [{result.get('title', '')}]({result.get('url', '')})\n{self._result_text(result)}"
             for idx, result in enumerate(results, start=1)
         )
+
+    @staticmethod
+    def _result_text(result: dict) -> str:
+        """Return the page text of one result.
+
+        Keenable returns both `snippet` and `description`: `snippet` carries the
+        page text and `description` is the page's meta description, which is empty
+        for most pages. It also returns whole pages rather than an excerpt, so the
+        text is collapsed and capped to the length the other search tools return.
+        """
+        text = " ".join(str(result.get("snippet") or result.get("description") or "").split())
+        return text[:500]
 
 
 class WebSearchTool(Tool):

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -20,6 +20,7 @@ import pytest
 from smolagents.agent_types import _AGENT_TYPE_MAPPING
 from smolagents.default_tools import (
     DuckDuckGoSearchTool,
+    KeenableSearchTool,
     PythonInterpreterTool,
     SpeechToTextTool,
     VisitWebpageTool,
@@ -252,3 +253,52 @@ def test_wikipedia_search(language, content_type, extract_format, query):
         assert len(result.split()) < 1000, "Summary mode should return a shorter text"
     if content_type == "text":
         assert len(result.split()) > 1000, "Full text mode should return a longer text"
+
+
+class TestKeenableSearchTool:
+    """Tests for the keyless-by-default KeenableSearchTool."""
+
+    def test_keyless_uses_public_endpoint(self):
+        mock_response_data = {
+            "results": [
+                {"title": "Keenable", "url": "https://keenable.ai", "description": "Search for AI agents."},
+                {"title": "Hugging Face", "url": "https://huggingface.co", "description": "The AI community."},
+            ]
+        }
+        tool = KeenableSearchTool(max_results=2)
+        with patch.dict("os.environ", {}, clear=True):
+            tool.api_key = None
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.json.return_value = mock_response_data
+                mock_post.return_value.raise_for_status = lambda: None
+                result = tool("test query")
+
+        assert "## Search Results" in result
+        assert "[Keenable](https://keenable.ai)" in result
+        assert "[Hugging Face](https://huggingface.co)" in result
+        # Keyless -> public endpoint, no API-key header
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.keenable.ai/v1/search/public"
+        assert "X-API-Key" not in call.kwargs["headers"]
+        assert call.kwargs["json"]["query"] == "test query"
+
+    def test_api_key_uses_keyed_endpoint(self):
+        tool = KeenableSearchTool(api_key="keen_test")
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.json.return_value = {
+                "results": [{"title": "T", "url": "https://x.test", "description": "d"}]
+            }
+            mock_post.return_value.raise_for_status = lambda: None
+            tool("q")
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.keenable.ai/v1/search"
+        assert call.kwargs["headers"]["X-API-Key"] == "keen_test"
+
+    def test_no_results_raises(self):
+        tool = KeenableSearchTool()
+        tool.api_key = None
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.json.return_value = {"results": []}
+            mock_post.return_value.raise_for_status = lambda: None
+            with pytest.raises(Exception, match="No results found"):
+                tool("obscure query")

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -261,8 +261,18 @@ class TestKeenableSearchTool:
     def test_keyless_uses_public_endpoint(self):
         mock_response_data = {
             "results": [
-                {"title": "Keenable", "url": "https://keenable.ai", "description": "Search for AI agents."},
-                {"title": "Hugging Face", "url": "https://huggingface.co", "description": "The AI community."},
+                {
+                    "title": "Keenable",
+                    "url": "https://keenable.ai",
+                    "description": "",
+                    "snippet": "Search for AI agents.",
+                },
+                {
+                    "title": "Hugging Face",
+                    "url": "https://huggingface.co",
+                    "description": "",
+                    "snippet": "The AI community.",
+                },
             ]
         }
         tool = KeenableSearchTool(max_results=2)
@@ -293,6 +303,41 @@ class TestKeenableSearchTool:
         call = mock_post.call_args
         assert call.args[0] == "https://api.keenable.ai/v1/search"
         assert call.kwargs["headers"]["X-API-Key"] == "keen_test"
+
+    def test_reads_page_text_from_snippet(self):
+        """`description` is the page's meta description and is empty for most pages."""
+        tool = KeenableSearchTool(max_results=1)
+        tool.api_key = None
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.json.return_value = {
+                "results": [
+                    {
+                        "title": "T",
+                        "url": "https://x.test",
+                        "description": "",
+                        "snippet": "line one\n\nline two",
+                    }
+                ]
+            }
+            mock_post.return_value.raise_for_status = lambda: None
+            result = tool("q")
+        assert "line one line two" in result
+
+    def test_falls_back_to_description_and_caps_page_text(self):
+        tool = KeenableSearchTool(max_results=2)
+        tool.api_key = None
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.json.return_value = {
+                "results": [
+                    {"title": "Long", "url": "https://long.test", "snippet": "word " * 400},
+                    {"title": "Meta", "url": "https://meta.test", "description": "only a meta description"},
+                ]
+            }
+            mock_post.return_value.raise_for_status = lambda: None
+            result = tool("q")
+        assert "only a meta description" in result
+        long_block = result.split("[Long](https://long.test)\n")[1].split("\n\n")[0]
+        assert len(long_block) == 500
 
     def test_no_results_raises(self):
         tool = KeenableSearchTool()


### PR DESCRIPTION
Adds a `KeenableSearchTool` backed by the [Keenable](https://keenable.ai) Search API.

Unlike the key-gated backends (`GoogleSearchTool`, `ApiWebSearchTool`) it is **keyless by default** — the public endpoint needs no account or API key (rate-limited to 1,000 req/hour). An optional `KEENABLE_API_KEY` only lifts the rate limit; it is never required. It uses the shared `web_search` tool name and mirrors `ApiWebSearchTool`'s shape (per-second rate limit + markdown output), so agents select it like any other search backend:

```python
from smolagents import CodeAgent, KeenableSearchTool, InferenceClientModel

agent = CodeAgent(tools=[KeenableSearchTool()], model=InferenceClientModel())  # keyless
agent.run("What are the latest developments in retrieval-augmented generation?")
```

Context: the maintainer of [txtai](https://github.com/neuml/txtai) suggested smolagents as the right home for this (neuml/txtai#1127) — txtai already adapts smolagents tools, so this unblocks that ecosystem too.

Changes:
- `default_tools.py` — `KeenableSearchTool` + `__all__` export (not added to `TOOL_MAPPING` since it shares the `web_search` name, same as `ApiWebSearchTool`/`GoogleSearchTool`)
- `docs/source/en/reference/default_tools.md` — reference entry
- `tests/test_default_tools.py` — keyless vs keyed endpoint selection + no-results handling

Verified: 3 new tests pass, ruff clean, and the keyless endpoint was self-tested live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)