### PR TITLE
fix: make_json_serializable must not reinterpret JSON-looking strings

### DIFF
--- a/src/smolagents/utils.py
+++ b/src/smolagents/utils.py
@@ -142,14 +142,6 @@ def make_json_serializable(obj: Any) -> Any:
     if obj is None:
         return None
     elif isinstance(obj, (str, int, float, bool)):
-        # Try to parse string as JSON if it looks like a JSON object/array
-        if isinstance(obj, str):
-            try:
-                if (obj.startswith("{") and obj.endswith("}")) or (obj.startswith("[") and obj.endswith("]")):
-                    parsed = json.loads(obj)
-                    return make_json_serializable(parsed)
-            except json.JSONDecodeError:
-                pass
         return obj
     elif isinstance(obj, (list, tuple)):
         return [make_json_serializable(item) for item in obj]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from smolagents.utils import (
     get_source,
     instance_to_source,
     is_valid_name,
+    make_json_serializable,
     parse_code_blobs,
     parse_json_blob,
 )
@@ -469,6 +470,19 @@ def test_parse_json_blob_with_valid_json(raw_json, expected_data, expected_blob)
 
     assert data == expected_data
     assert blob == expected_blob
+
+
+def test_make_json_serializable_preserves_json_looking_strings():
+    """A string value that happens to look like a JSON object/array (e.g. a tool
+    argument that is itself JSON text) must not be silently reinterpreted as a
+    dict/list - make_json_serializable should preserve the original type."""
+    obj = {"content": '{"key": "value"}', "path": "out.json", "items": "[1, 2, 3]"}
+
+    result = make_json_serializable(obj)
+
+    assert result == obj
+    assert isinstance(result["content"], str)
+    assert isinstance(result["items"], str)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`make_json_serializable()` opportunistically ran `json.loads()` on any string starting with `{`/`[` and ending with `}`/`]`, silently replacing the original string with the parsed dict/list. This changes the Python type of a value based on its *content*, which breaks the "make this object JSON-serializable" contract — a string is already JSON-serializable and should never need reinterpreting.

```python
>>> make_json_serializable({"content": '{"key": "value"}', "path": "out.json"})
{"content": {"key": "value"}, "path": "out.json"}   # before this fix - "content" silently became a dict
```

This is reachable through `ToolCall.dict()` (`memory.py`), which feeds both the documented `RunResult.steps` API and, more importantly, `ActionStep.to_messages()`'s `"Calling tools:\n" + str([tc.dict() for tc in self.tool_calls])` — the actual conversation history replayed back to the model. Any tool whose argument is a plain string that happens to look like JSON (e.g. a file-writing tool given literal JSON text to write) has that argument silently mutated from `str` to `dict` in what the model sees of its own prior tool calls.

## Fix

Removed the JSON-sniffing block so strings pass through unchanged.

## Testing

Added `test_make_json_serializable_preserves_json_looking_strings` to `tests/test_utils.py`. Confirmed via `git stash` that it fails against the pre-fix code (string values get silently turned into dict/list) and passes after.

- `pytest tests/test_utils.py tests/test_memory.py` — 45 + 12 passed, no regressions.
- `ruff check` and `ruff format --check` both clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the bug via a targeted search for functions with no test coverage and traced how `ToolCall.dict()`'s output reaches both the public `RunResult.steps` API and the model-facing conversation history. I reviewed the diff, independently reproduced the type-mutation bug and confirmed the fix by executing both against the actual function, and ran the tests/linters myself before opening this PR.