### PR TITLE
fix: max_steps=0 falsy fallback and planning remaining_steps override

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -465,7 +465,7 @@ class MultiStepAgent(ABC):
         agent.run("What is the result of 2 power 3.7384?")
         ```
         """
-        max_steps = max_steps or self.max_steps
+        max_steps = max_steps if max_steps is not None else self.max_steps
         self.task = task
         self.interrupt_switch = False
         if additional_args:
@@ -542,6 +542,10 @@ You have been provided with these additional arguments, that you can access dire
     ) -> Generator[ActionStep | PlanningStep | FinalAnswerStep | ChatMessageStreamDelta]:
         self.step_number = 1
         returned_final_answer = False
+        # max_steps=0 means the loop body never runs, so this stays None; guarded
+        # before the final `yield action_step` below instead of assuming a step
+        # was always taken.
+        action_step: ActionStep | None = None
         while not returned_final_answer and self.step_number <= max_steps:
             if self.interrupt_switch:
                 raise AgentError("Agent interrupted.", self.logger)
@@ -553,7 +557,7 @@ You have been provided with these additional arguments, that you can access dire
                 planning_start_time = time.time()
                 planning_step = None
                 for element in self._generate_planning_step(
-                    task, is_first_step=len(self.memory.steps) == 1, step=self.step_number
+                    task, is_first_step=len(self.memory.steps) == 1, step=self.step_number, max_steps=max_steps
                 ):  # Don't use the attribute step_number here, because there can be steps from previous runs
                     yield element
                     planning_step = element
@@ -605,7 +609,9 @@ You have been provided with these additional arguments, that you can access dire
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)
-            yield action_step
+            # No action step was ever taken when max_steps=0, nothing to yield here.
+            if action_step is not None:
+                yield action_step
         final_answer_step = FinalAnswerStep(handle_agent_output_types(final_answer))
         self._finalize_step(final_answer_step)
         yield final_answer_step
@@ -637,7 +643,7 @@ You have been provided with these additional arguments, that you can access dire
         return final_answer.content
 
     def _generate_planning_step(
-        self, task, is_first_step: bool, step: int
+        self, task, is_first_step: bool, step: int, max_steps: int
     ) -> Generator[ChatMessageStreamDelta | PlanningStep]:
         start_time = time.time()
         if is_first_step:
@@ -704,7 +710,7 @@ You have been provided with these additional arguments, that you can access dire
                                 "task": task,
                                 "tools": self.tools,
                                 "managed_agents": self.managed_agents,
-                                "remaining_steps": (self.max_steps - step),
+                                "remaining_steps": (max_steps - step),
                             },
                         ),
                     }

--- a/src/smolagents/prompts/code_agent.yaml
+++ b/src/smolagents/prompts/code_agent.yaml
@@ -255,7 +255,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/src/smolagents/prompts/structured_code_agent.yaml
+++ b/src/smolagents/prompts/structured_code_agent.yaml
@@ -199,7 +199,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/src/smolagents/prompts/toolcalling_agent.yaml
+++ b/src/smolagents/prompts/toolcalling_agent.yaml
@@ -192,7 +192,7 @@ planning:
     ### 2. 1. ...
     Etc.
     This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
-    Beware that you have {remaining_steps} steps remaining.
+    Beware that you have {{ remaining_steps }} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -519,6 +519,24 @@ class TestAgent:
         assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
         assert isinstance(answer, str)
 
+    def test_run_max_steps_zero_is_respected(self):
+        """Regression test for #2458.
+
+        `max_steps=0` is an explicit, distinct value from "not provided" (the
+        parameter defaults to `None`), and must actually mean zero action
+        steps, not silently fall back to the agent's configured default via
+        `max_steps or self.max_steps` (0 is falsy).
+        """
+        agent = CodeAgent(
+            tools=[PythonInterpreterTool()],
+            model=FakeCodeModelNoReturn(),  # use this callable because it never ends
+            max_steps=20,
+        )
+        answer = agent.run("What is 2 multiplied by 3.6452?", max_steps=0)
+        assert len(agent.memory.steps) == 2  # Task step + Final answer, no action steps taken
+        assert type(agent.memory.steps[-1].error) is AgentMaxStepsError
+        assert isinstance(answer, str)
+
     def test_tool_descriptions_get_baked_in_system_prompt(self):
         tool = PythonInterpreterTool()
         tool.name = "fake_tool_name"
@@ -1297,7 +1315,9 @@ class TestMultiStepAgent:
         )
         task = "Test task"
 
-        planning_step = list(agent._generate_planning_step(task, is_first_step=(step == 1), step=step))[-1]
+        planning_step = list(
+            agent._generate_planning_step(task, is_first_step=(step == 1), step=step, max_steps=agent.max_steps)
+        )[-1]
         expected_message_texts = {
             "INITIAL_PLAN_USER_PROMPT": populate_template(
                 agent.prompt_templates["planning"]["initial_plan"],
@@ -1351,6 +1371,32 @@ class TestMultiStepAgent:
                 assert isinstance(message.content, list)
                 for content, expected_content in zip(message.content, expected_message.content):
                     assert content == expected_content
+
+    def test_planning_step_remaining_steps_uses_per_run_max_steps_override(self):
+        """Regression test for #2510.
+
+        `run(..., max_steps=N)` overrides the agent's constructor `max_steps`, and
+        planning's `remaining_steps` value must reflect that override, not the
+        constructor default. Also verifies the `{{ remaining_steps }}` Jinja
+        placeholder is actually interpolated (single-brace `{remaining_steps}`
+        is never substituted and reaches the model as literal text).
+        """
+        fake_model = MagicMock()
+        agent = CodeAgent(tools=[], model=fake_model, max_steps=20)
+        task = "Test task"
+        step = 2
+        override_max_steps = 3
+
+        planning_step = list(
+            agent._generate_planning_step(
+                task, is_first_step=False, step=step, max_steps=override_max_steps
+            )
+        )[-1]
+        rendered_text = planning_step.model_input_messages[1].content[0]["text"]
+
+        assert "{remaining_steps}" not in rendered_text, "Jinja placeholder was not interpolated"
+        assert f"you have {override_max_steps - step} steps remaining" in rendered_text
+        assert f"you have {agent.max_steps - step} steps remaining" not in rendered_text
 
     @pytest.mark.parametrize(
         "expected_messages_list",


### PR DESCRIPTION
## Summary

Fixes #2458 and #2510, two related bugs in how `max_steps` propagates through a run.

### #2458: `max_steps=0` silently ignored

`run()` does `max_steps = max_steps or self.max_steps`. Since `max_steps: int | None = None` and `0` is falsy, `run(task, max_steps=0)` silently falls back to the agent's constructor default instead of running zero steps.

Fixing this exposed a pre-existing edge case: when the loop body never executes (zero steps), `action_step` was never assigned, but the max-steps-reached branch unconditionally did `yield action_step`, raising `UnboundLocalError`. Initialized `action_step = None` before the loop and guarded the yield.

### #2510: planning `remaining_steps` placeholder never interpolated, and uses the wrong budget

Two stacked issues on the same value:

1. The three built-in planning templates (`code_agent.yaml`, `structured_code_agent.yaml`, `toolcalling_agent.yaml`) use `{remaining_steps}` (single brace). `populate_template` renders with Jinja2 (`Template(..., undefined=StrictUndefined)`), which requires `{{ }}` for interpolation, single braces are literal text. So the model receives the literal string `{remaining_steps}` instead of a number.
2. Even fixed, the value was computed from `self.max_steps` (the constructor default) inside `_generate_planning_step`, not the effective per-run budget. When `run(task, max_steps=N)` overrides the default, the execution loop correctly uses `N`, but planning was still reading the constructor value. Threaded `max_steps` through `_run_stream` → `_generate_planning_step` so both agree.

## Testing

- `test_run_max_steps_zero_is_respected`: `run(..., max_steps=0)` takes zero action steps and returns cleanly (no `UnboundLocalError`).
- `test_planning_step_remaining_steps_uses_per_run_max_steps_override`: planning text contains the per-run override's remaining-steps number, not the constructor default's, and never contains the literal `{remaining_steps}` placeholder.
- Updated `test_planning_step`'s call site for the new `_generate_planning_step(..., max_steps=...)` signature.

Ran the full `tests/test_agents.py` suite before and after against unfixed code to isolate what's actually caused by this change: the same ~15 failures are present identically on unfixed `main` (missing `numpy`/`transformers` extras, `from_folder` version-compat fixtures, one `ImportError`, one flaky timing assertion, all unrelated to `max_steps`), confirming this diff doesn't introduce any new failures.
