### PR TITLE
fix(tool_validation): tuple literals wrongly rejected as complex

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -196,7 +196,10 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
                     self.class_attributes.add(target.id)
 
             # Check if the assignment is more complex than simple literals
-            if not all(isinstance(val, (ast.Constant, ast.Dict, ast.List, ast.Set)) for val in ast.walk(node.value)):
+            if not all(
+                isinstance(val, (ast.Constant, ast.Dict, ast.List, ast.Set, ast.Tuple, ast.Load))
+                for val in ast.walk(node.value)
+            ):
                 for target in node.targets:
                     if isinstance(target, ast.Name):
                         self.complex_attributes.add(target.id)
@@ -220,7 +223,7 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
                 if default is None:
                     if arg.arg != "self":
                         self.non_defaults.add(arg.arg)
-                elif not isinstance(default, (ast.Constant, ast.Dict, ast.List, ast.Set)):
+                elif not isinstance(default, (ast.Constant, ast.Dict, ast.List, ast.Set, ast.Tuple)):
                     self.non_literal_defaults.add(arg.arg)
 
     class_level_checker = ClassLevelChecker()

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -31,10 +31,13 @@ class ValidTool(Tool):
     output_type = "string"
     simple_attr = "string"
     dict_attr = {"key": "value"}
+    tuple_attr = (".png", ".jpg")
+    list_attr = [".png", ".jpg"]
 
-    def __init__(self, optional_param="default"):
+    def __init__(self, optional_param="default", tuple_default=(1, 2, 3)):
         super().__init__()
         self.param = optional_param
+        self.tuple_default = tuple_default
 
     def forward(self, input: str) -> str:
         return input.upper()


### PR DESCRIPTION
## What

`validate_tool_attributes()`'s "is this attribute a simple literal" check whitelisted `(ast.Constant, ast.Dict, ast.List, ast.Set)` but not `ast.Tuple`, so any `Tool` subclass using an ordinary tuple class attribute (e.g. `allowed_exts = (".png", ".jpg")`) failed validation with `"Complex attributes should be defined in __init__, not as class attributes"` — blocking `Tool.save()`/`push_to_hub()` for a completely standard pattern.

Adding `ast.Tuple` alone wasn't sufficient: the check uses `ast.walk()` over the whole assignment value, and for `Tuple`/`List` nodes that also yields their `ast.Load()` context node (a Tuple's `ctx` field, always `Load` for a value expression) — previously unnoticed because `Dict`/`Set` don't have a `ctx` field. This meant **list** literal attributes had the identical latent bug (untested until now), just never reported since tuples were the more common case people hit:

```python
>>> ast.dump(ast.parse('x = (".png", ".jpg")').body[0].value)
"Tuple(elts=[...], ctx=Load())"   # ast.walk() yields the Load() node too
```

The non-literal-default-value check (`__init__` parameter defaults) only needed `ast.Tuple` added — it inspects the top-level default node directly, not via `ast.walk()`, so it doesn't have the `ctx`-node issue.

## Fix

Add `ast.Tuple` (both checks) and `ast.Load` (the `ast.walk()`-based check only) to the whitelists.

## Testing

Extended `ValidTool` in `tests/test_tool_validation.py` with `tuple_attr`, `list_attr` class attributes and a `tuple_default` `__init__` parameter default, covered by the existing `test_validate_tool_attributes_valid` parametrized test. Confirmed via `git stash` that all three new cases fail against the pre-fix code and pass after; `InvalidToolComplexAttrs`'s genuinely-complex list-comprehension case is still correctly rejected (no false negative introduced).

- `pytest tests/test_tool_validation.py` — 16 passed.
- `pytest tests/test_utils.py` — 44 passed, no regressions.
- `ruff check` and `ruff format --check` both clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the bug via a targeted search for AST-node-type whitelists that looked incomplete. I reviewed the diff, independently reproduced the crash and the fix by executing both against the actual function (including diagnosing the secondary `ast.Load` issue after the first fix attempt was incomplete), and ran the tests/linters myself before opening this PR.