### PR TITLE
Raise informative error when serializing MCP tools

### DIFF
--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -174,6 +174,9 @@ with MCPClient([server_params1, server_params2]) as tools:
 > - **Stdio-based MCP servers** will always execute code on your machine (that's their intended functionality).
 > - **Streamable HTTP-based MCP servers:** While remote MCP servers will not execute code on your machine, still proceed with caution.
 
+> [!NOTE]
+> MCP tools cannot be serialized: they wrap a live MCP server session, so `Tool.to_dict`, `save` and `push_to_hub` raise an error for them, as do `to_dict` and `save` on an agent that holds them. Remove MCP tools from your agent before serializing it, and recreate them with [`MCPClient`] or [`ToolCollection.from_mcp`] when loading.
+
 #### Structured Output and Output Schema Support
 
 The latest [MCP specifications (2025-06-18+)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) include support for `outputSchema`, which enables tools to return structured data with defined schemas. `smolagents` takes advantage of these structured output capabilities, allowing agents to work with tools that return complex data structures, JSON objects, and other structured formats. With this feature, the agent's LLMs can "see" the structure of the tool output before calling a tool, enabling more intelligent and context-aware interactions.

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -349,6 +349,12 @@ class Tool(BaseTool):
                 raise ValueError(
                     "Cannot save objects created with from_space, from_langchain or from_gradio, as this would create errors."
                 )
+            if type(self).__name__ == "MCPAdaptTool":
+                raise ValueError(
+                    f"Cannot serialize MCP tool '{self.name}': it wraps a live MCP server session, which cannot be "
+                    "saved as standalone code. Remove MCP tools from your agent before calling to_dict, save or "
+                    "push_to_hub, and recreate them with MCPClient or ToolCollection.from_mcp when loading the agent."
+                )
 
             validate_tool_attributes(self.__class__)
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,9 +1,11 @@
 import json
 from textwrap import dedent
+from unittest.mock import MagicMock
 
 import pytest
 from mcp import StdioServerParameters
 
+from smolagents import CodeAgent
 from smolagents.mcp_client import MCPClient
 
 
@@ -129,3 +131,24 @@ def test_multiple_servers(echo_server_script: str):
         assert tools[1].name == "echo_tool"
         assert tools[0].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
         assert tools[1].forward(**{"text": "Hello, world!"}) == "Echo: Hello, world!"
+
+
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
+def test_mcp_tool_to_dict_raises_informative_error(echo_server_script: str):
+    """Test that serializing an MCP tool raises a clear error instead of a validation failure (#1108)."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
+    with MCPClient(server_parameters) as tools:
+        with pytest.raises(ValueError, match="Cannot serialize MCP tool 'echo_tool'"):
+            tools[0].to_dict()
+
+
+# Ignore FutureWarning about structured_output default value change: this test intentionally uses default behavior
+@pytest.mark.filterwarnings("ignore:.*structured_output:FutureWarning")
+def test_agent_to_dict_with_mcp_tool_raises_informative_error(echo_server_script: str):
+    """Test that CodeAgent.to_dict() with an MCP tool raises a clear error instead of a validation failure (#1108)."""
+    server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
+    with MCPClient(server_parameters) as tools:
+        agent = CodeAgent(tools=tools, model=MagicMock())
+        with pytest.raises(ValueError, match="Cannot serialize MCP tool 'echo_tool'"):
+            agent.to_dict()


### PR DESCRIPTION
Fixes #1108

## Problem

Calling `to_dict()` (and therefore `save()` or `push_to_hub()`) on an agent that holds MCP tools crashes with a confusing internal error:

```
ValueError: Tool validation failed for MCPAdaptTool:
Parameters in __init__ must have default values, found required parameters: name, description, inputs, output_type
- forward: Name 'func' is undefined.
- forward: Name 'mcp' is undefined.
...
```

Reproduction (stdio MCP server, same shape as the tests in `tests/test_mcp_client.py`):

```python
from mcp import StdioServerParameters
from smolagents import CodeAgent, InferenceClientModel
from smolagents.mcp_client import MCPClient

server_parameters = StdioServerParameters(command="python", args=["-c", echo_server_script])
with MCPClient(server_parameters) as tools:
    agent = CodeAgent(model=InferenceClientModel(), tools=list(tools))
    agent.to_dict()  # ValueError: Tool validation failed for MCPAdaptTool: ...
```

## Root cause

`Tool.to_dict` serializes a tool by reconstructing standalone source code for its class: it calls `validate_tool_attributes(self.__class__)` and `instance_to_source(...)` so that `Tool.from_code` can later rebuild the tool from that source alone.

That contract cannot hold for MCP tools. `MCPAdaptTool` is generated at runtime by `mcpadapt`, its `__init__` takes required parameters and its `forward` is a closure over the live MCP client session (`func`, `mcp`, `logger`, ...). The tool's behavior lives on the MCP server, not in Python source, and the underlying connection is not serializable, so source reconstruction fails validation with the cryptic error above.

`Tool.to_dict` already fails fast with a clear message for the other three runtime generated wrapper classes (`SpaceToolWrapper`, `LangChainToolWrapper`, `GradioToolWrapper`). MCP tools were missing from that guard.

## Fix

Extend the existing guard in `Tool.to_dict` to detect MCP tools and raise an actionable error:

```
ValueError: Cannot serialize MCP tool 'echo_tool': it wraps a live MCP server session, which cannot be
saved as standalone code. Remove MCP tools from your agent before calling to_dict, save or push_to_hub,
and recreate them with MCPClient or ToolCollection.from_mcp when loading the agent.
```

Detection matches the runtime class name, following the existing convention in the same block, since `mcpadapt` is an optional dependency. The `from_dict` direction needs no change: serialization now fails fast with a clear message, and recreating a live MCP session is a user decision (server lifecycle, credentials, trust) that `Tool.from_code` could never perform safely.

A note documenting the limitation is added to the MCP section of the tools tutorial.

## Tests

Two tests in `tests/test_mcp_client.py`, using the existing `echo_server_script` stdio fixture:

- `test_mcp_tool_to_dict_raises_informative_error`: `tool.to_dict()` raises the clear error.
- `test_agent_to_dict_with_mcp_tool_raises_informative_error`: `CodeAgent.to_dict()` raises the clear error (the exact scenario from the issue).

Both fail on `main` with the old `Tool validation failed for MCPAdaptTool` error and pass with this change. `make quality` passes. `tests/test_mcp_client.py` (7 passed), `tests/test_tools.py` and the agent serialization tests in `tests/test_agents.py` pass locally; the two pre-existing failures in `test_integration_from_mcp_with_streamable_http` and `test_integration_from_mcp_with_sse` also fail on a clean `main` checkout (local port binding) and are unrelated.
