### PR TITLE
fix: stop forwarding from_dict kwargs into managed agents

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1040,7 +1040,11 @@ You have been provided with these additional arguments, that you can access dire
                     f"Unknown agent class '{managed_agent_dict['class']}'. "
                     f"Supported agents: {', '.join(sorted(AGENT_REGISTRY.keys()))}"
                 )
-            managed_agent = agent_class.from_dict(managed_agent_dict, **kwargs)
+            # kwargs are overrides meant for the agent currently being deserialized
+            # only, so don't forward them to managed agents. Doing so would let the
+            # parent's configuration (e.g. additional_authorized_imports) clobber
+            # each child's own settings. See GH-1849.
+            managed_agent = agent_class.from_dict(managed_agent_dict)
             managed_agents.append(managed_agent)
         # Extract base agent parameters
         agent_args = {

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1594,6 +1594,40 @@ class TestMultiStepAgent:
         assert recreated_managed_agent.description == "A managed agent for testing"
         assert recreated_managed_agent.max_steps == 5
 
+    def test_from_dict_does_not_leak_kwargs_into_managed_agents(self):
+        """from_dict kwargs target the deserialized agent only and must not cascade into
+        managed agents, otherwise the parent's additional_authorized_imports overrides
+        each child's own imports (issue #1849)."""
+        managed_agent = CodeAgent(
+            tools=[],
+            model=MagicMock(),
+            name="child_agent",
+            description="A managed agent",
+            max_steps=3,
+            additional_authorized_imports=["rich"],
+        )
+        main_agent = CodeAgent(
+            tools=[],
+            model=MagicMock(),
+            managed_agents=[managed_agent],
+            name="main_agent",
+            description="Main agent",
+            max_steps=2,
+            additional_authorized_imports=["requests"],
+        )
+        agent_dict = main_agent.to_dict()
+
+        mock_model_class = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_model_class.from_dict.return_value = mock_model_instance
+        with patch.dict("smolagents.models.MODEL_REGISTRY", {"MagicMock": mock_model_class}):
+            recreated_agent = CodeAgent.from_dict(agent_dict)
+
+        recreated_managed_agent = list(recreated_agent.managed_agents.values())[0]
+        assert recreated_managed_agent.authorized_imports == managed_agent.authorized_imports
+        assert "rich" in recreated_managed_agent.authorized_imports
+        assert "requests" not in recreated_managed_agent.authorized_imports
+
     def test_from_dict_invalid_model_class(self):
         """Test that from_dict raises ValueError with helpful message for invalid model class."""
         agent_dict = {


### PR DESCRIPTION
## What does this PR do?

Closes #1849.

`MultiStepAgent.from_dict` forwarded the caller's `**kwargs` to each managed agent while deserializing it. Because `CodeAgent.from_dict` packs `additional_authorized_imports` (and a couple of other fields) into those kwargs, the parent's imports replaced every child's own imports after a `to_dict` / `from_dict` round-trip — the child ended up with the parent's imports instead of the ones it was serialized with, which then breaks code that relied on those imports at runtime.

## How

Managed agents are now rebuilt from their own serialized dict, without the parent's kwargs. The kwargs still apply to the top-level agent being deserialized, which matches the existing docstring ("Additional keyword arguments that will override agent_dict values").

## Test

Added `test_from_dict_does_not_leak_kwargs_into_managed_agents`: a parent `CodeAgent` (imports `["requests"]`) with a managed `CodeAgent` (imports `["rich"]`) is serialized and rebuilt, then the child is asserted to keep `rich` and not gain `requests`. It fails on `main` and passes with this change.
