### PR TITLE
fix: block os.system via the nt module on Windows

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -148,8 +148,9 @@ DANGEROUS_FUNCTIONS = [
     "builtins.locals",
     "builtins.__import__",
     "os.popen",
-    "os.system",
+    "os.system",  # os.system resolves to the `posix` module on Linux/macOS
     "posix.system",
+    "nt.system",  # ...and to the `nt` module on Windows, where __module__ == "nt" (GH-2232)
 ]
 
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -33,6 +33,7 @@ from smolagents.local_python_executor import (
     LocalPythonExecutor,
     PrintContainer,
     check_import_authorized,
+    check_safer_result,
     evaluate_boolop,
     evaluate_condition,
     evaluate_delete,
@@ -2329,6 +2330,19 @@ result = "completed"
 )
 def test_check_import_authorized(module: str, authorized_imports: list[str], expected: bool):
     assert check_import_authorized(module, authorized_imports) == expected
+
+
+def test_check_safer_result_blocks_nt_system():
+    """os.system is implemented in the `nt` module on Windows, so os.system.__module__
+    reports "nt" rather than "os" there. check_safer_result must still block it (GH-2232)."""
+
+    def nt_system():
+        pass
+
+    nt_system.__module__ = "nt"
+    nt_system.__name__ = "system"
+    with pytest.raises(InterpreterError, match="Forbidden access to function: system"):
+        check_safer_result(nt_system)
 
 
 class TestLocalPythonExecutor:


### PR DESCRIPTION
## What does this PR do?

Closes #2232.

`check_safer_result` blocks dangerous functions by matching `result.__module__` + `"."` + `result.__name__` against `DANGEROUS_FUNCTIONS`. On Windows, `os.system` is implemented in the `nt` module, so `os.system.__module__` is `"nt"` — not `"os"`. Since `DANGEROUS_FUNCTIONS` listed `os.system` and `posix.system` but not `nt.system`, the check silently let `os.system` through on Windows when a user authorized `os` via `additional_authorized_imports=["os"]`.

The default sandbox blocks `os` entirely, so this only affects users who explicitly authorize it — but for them it is a sandbox escape on Windows.

## How

Add `nt.system` to `DANGEROUS_FUNCTIONS`, mirroring the existing `posix.system` entry that covers Linux/macOS.

## Test

- The existing parametrized `test_vulnerability_for_all_dangerous_functions` now covers `nt.system` on Windows. It uses `pytest.importorskip`, so `nt.system` is skipped on Linux/macOS — exactly symmetric to how `posix.system` is skipped on Windows.
- Added `test_check_safer_result_blocks_nt_system`, which is platform-independent: it passes `check_safer_result` a function with `__module__ == "nt"` / `__name__ == "system"` and asserts it is blocked. This keeps the regression covered on the Linux CI runners where `nt` is unavailable. Fails on `main`, passes with this change.
