### PR TITLE
fix(executor): evaluate augmented assignment targets once

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -645,13 +645,6 @@ def evaluate_augassign(
     def get_current_value(target: ast.AST) -> Any:
         if isinstance(target, ast.Name):
             return state.get(target.id, 0)
-        elif isinstance(target, ast.Subscript):
-            obj = evaluate_ast(target.value, state, static_tools, custom_tools, authorized_imports)
-            key = evaluate_ast(target.slice, state, static_tools, custom_tools, authorized_imports)
-            return obj[key]
-        elif isinstance(target, ast.Attribute):
-            obj = evaluate_ast(target.value, state, static_tools, custom_tools, authorized_imports)
-            return getattr(obj, target.attr)
         elif isinstance(target, ast.Tuple):
             return tuple(get_current_value(elt) for elt in target.elts)
         elif isinstance(target, ast.List):
@@ -659,7 +652,18 @@ def evaluate_augassign(
         else:
             raise InterpreterError("AugAssign not supported for {type(target)} targets.")
 
-    current_value = get_current_value(expression.target)
+    target = expression.target
+    target_object = None
+    target_key = None
+    if isinstance(target, ast.Subscript):
+        target_object = evaluate_ast(target.value, state, static_tools, custom_tools, authorized_imports)
+        target_key = evaluate_ast(target.slice, state, static_tools, custom_tools, authorized_imports)
+        current_value = target_object[target_key]
+    elif isinstance(target, ast.Attribute):
+        target_object = evaluate_ast(target.value, state, static_tools, custom_tools, authorized_imports)
+        current_value = getattr(target_object, target.attr)
+    else:
+        current_value = get_current_value(target)
     value_to_add = evaluate_ast(expression.value, state, static_tools, custom_tools, authorized_imports)
 
     if isinstance(expression.op, ast.Add):
@@ -694,15 +698,12 @@ def evaluate_augassign(
     else:
         raise InterpreterError(f"Operation {type(expression.op).__name__} is not supported.")
 
-    # Update the state: current_value has been updated in-place
-    set_value(
-        expression.target,
-        current_value,
-        state,
-        static_tools,
-        custom_tools,
-        authorized_imports,
-    )
+    if isinstance(target, ast.Subscript):
+        target_object[target_key] = current_value
+    elif isinstance(target, ast.Attribute):
+        setattr(target_object, target.attr, current_value)
+    else:
+        set_value(target, current_value, state, static_tools, custom_tools, authorized_imports)
 
     return current_value
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1664,6 +1664,45 @@ exec(compile('{unsafe_code}', 'no filename', 'exec'))
         assert result == expected_result
 
     @pytest.mark.parametrize(
+        "code, expected_result",
+        [
+            (
+                dedent("""\
+                    values = [1, 2]
+                    calls = [0]
+                    def next_index():
+                        index = calls[0]
+                        calls[0] += 1
+                        return index
+                    values[next_index()] += 10
+                    (values, calls[0])
+                """),
+                ([11, 2], 1),
+            ),
+            (
+                dedent("""\
+                    class Box:
+                        def __init__(self, value):
+                            self.value = value
+                    boxes = [Box(1), Box(2)]
+                    calls = [0]
+                    def next_box():
+                        box = boxes[calls[0]]
+                        calls[0] += 1
+                        return box
+                    next_box().value += 10
+                    ([box.value for box in boxes], calls[0])
+                """),
+                ([11, 2], 1),
+            ),
+        ],
+    )
+    def test_evaluate_augassign_target_evaluated_once(self, code, expected_result):
+        result, _ = evaluate_python_code(code, {})
+
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
         "operator, expected_result",
         [
             ("+=", 7),


### PR DESCRIPTION
## What

`evaluate_augassign()` currently evaluates subscript and attribute target expressions twice: once in `get_current_value()` to read the old value, and again in `set_value()` to store the result. Python evaluates the target object and subscript key only once for augmented assignment.

A side-effecting target can therefore read from one location and write the result to another:

```python
values = [1, 2]
calls = [0]

def next_index():
    index = calls[0]
    calls[0] += 1
    return index

values[next_index()] += 10
```

Native Python produces `values == [11, 2]` with one call. The local executor produced `values == [1, 11]` with two calls: it read `values[0]`, then re-ran `next_index()` and stored that result into `values[1]`.

Attribute targets had the same problem. `next_box().value += 10` read from the first returned object, then called `next_box()` again and wrote the result onto the second object.

## Fix

Resolve subscript objects/keys and attribute objects once before evaluating the right-hand side, then reuse those exact references for the final store. Name targets and the operation dispatch are unchanged; the general-purpose `set_value()` helper is also unchanged.

This also preserves Python's evaluation order: target object, subscript key (if any), right-hand side, operation, then store.

## Testing

Added two parametrized regression cases covering side-effecting subscript and attribute targets.

- Before the fix: both new cases failed with `([1, 11], 2)` instead of `([11, 2], 1)`.
- After the fix: both new cases pass.
- Full `tests/test_local_python_executor.py`: **399 passed, 2 skipped**.
  - The first full run had one unrelated timing failure in `TestTimeout.test_timeout_decorator_raises_error_when_exceeded`; it passed immediately in isolation, and the complete file then passed on rerun.
- `ruff check` and `ruff format --check`: clean.
- `git diff --check`: clean.

## Duplicate-work check

Checked every currently open PR page (roughly 500 PRs), including changed file paths. Many open PRs touch this hot executor file, but none of their diffs touches `evaluate_augassign` or claims this evaluation-order bug. Also inspected the merged historical augassign PRs #285 and #313; they implemented/refactored operator dispatch and do not address repeated target evaluation.

## AI disclosure

Developed with AI assistance (Codex), which surfaced the candidate during a targeted executor review. I independently reproduced both wrong-write cases against the real evaluator, audited all open PR file overlaps and the historical augassign changes, reviewed the implementation, and ran the focused and full tests before submitting.
