### PR TITLE
fix(memory): serialize task images in step dict

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -188,6 +188,12 @@ class TaskStep(MemoryStep):
     task: str
     task_images: list["PIL.Image.Image"] | None = None
 
+    def dict(self):
+        return {
+            "task": self.task,
+            "task_images": [image.tobytes() for image in self.task_images] if self.task_images is not None else None,
+        }
+
     def to_messages(self, summary_mode: bool = False) -> list[ChatMessage]:
         content = [{"type": "text", "text": f"New task:\n{self.task}"}]
         if self.task_images:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -217,6 +217,15 @@ def test_task_step_to_messages():
             assert "image" in image_content
 
 
+def test_task_step_dict_converts_images_to_bytes():
+    image = Image.new("RGB", (2, 2), "red")
+
+    assert TaskStep(task="Describe the image", task_images=[image]).dict() == {
+        "task": "Describe the image",
+        "task_images": [image.tobytes()],
+    }
+
+
 def test_system_prompt_step_to_messages():
     system_prompt_step = SystemPromptStep(system_prompt="This is a system prompt.")
     messages = system_prompt_step.to_messages(summary_mode=False)


### PR DESCRIPTION
## Summary

- convert `TaskStep.task_images` to bytes when exporting a step dictionary, matching `ActionStep.observations_images`
- add a regression test covering image conversion

## Why

`TaskStep` inherited `MemoryStep.dict()`, which uses `dataclasses.asdict()` and leaves raw PIL image objects in exported full memory steps. Other image-bearing memory steps already convert images to bytes before export.

## Validation

- regression test failed before the implementation and passes after it
- `pytest tests/test_memory.py tests/test_agents.py::TestRunResult` (20 passed)
- `make quality`
- `make test` (952 passed, 68 skipped, 3 unrelated failures): the Transformers tool-calling failure reproduces unchanged on `upstream/main`; the two MCP integration failures cannot bind port 8000 because an unrelated existing service owns it

Existing open PRs touching `memory.py` were checked; none changes `TaskStep.dict()` or task-image conversion. PR #971 touches the `TaskStep` structure but not this export path.

AI assistance disclosure: Claude Opus 4.8 assisted with implementation and test drafting; the contributor reviewed and validated the change.
