### PR TITLE
Fix max_steps=0 being silently ignored in run()

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -465,7 +465,7 @@ class MultiStepAgent(ABC):
         agent.run("What is the result of 2 power 3.7384?")
         ```
         """
-        max_steps = max_steps or self.max_steps
+        max_steps = max_steps if max_steps is not None else self.max_steps
         self.task = task
         self.interrupt_switch = False
         if additional_args:


### PR DESCRIPTION
Closes #2458

  `max_steps = max_steps or self.max_steps` treats `max_steps=0` as
  falsy, so passing max_steps=0 silently falls back to the agent's
  default instead of actually running zero steps. Changed to an
  explicit None check so 0 is respected.