### PR TITLE
Fix and unskip test_change_tools_after_init tests

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1913,10 +1913,6 @@ class TestToolCallingAgent:
         assert "Error while parsing" in capture.get()
         assert len(agent.memory.steps) == 4
 
-    @pytest.mark.skip(
-        reason="Test is not properly implemented (GH-1255) because fake_tools should have the same name. "
-        "Additionally, it uses CodeAgent instead of ToolCallingAgent (GH-1409)"
-    )
     def test_change_tools_after_init(self):
         from smolagents import tool
 
@@ -1930,11 +1926,34 @@ class TestToolCallingAgent:
             """Fake tool"""
             return "2"
 
-        class FakeCodeModel(Model):
-            def generate(self, messages, stop_sequences=None):
-                return ChatMessage(role=MessageRole.ASSISTANT, content="<code>\nfinal_answer(fake_tool_1())\n</code>")
+        class FakeToolCallModel(Model):
+            def generate(self, messages, tools_to_call_from=None, stop_sequences=None):
+                if len(messages) < 3:
+                    return ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="I will call fake_tool_1.",
+                        tool_calls=[
+                            ChatMessageToolCall(
+                                id="call_0",
+                                type="function",
+                                function=ChatMessageToolCallFunction(name="fake_tool_1", arguments={}),
+                            )
+                        ],
+                    )
+                else:
+                    return ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="I will return the final answer.",
+                        tool_calls=[
+                            ChatMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=ChatMessageToolCallFunction(name="final_answer", arguments={"answer": "2"}),
+                            )
+                        ],
+                    )
 
-        agent = CodeAgent(tools=[fake_tool_1], model=FakeCodeModel())
+        agent = ToolCallingAgent(tools=[fake_tool_1], model=FakeToolCallModel())
 
         agent.tools["final_answer"] = CustomFinalAnswerTool()
         agent.tools["fake_tool_1"] = fake_tool_2
@@ -2206,9 +2225,6 @@ print("Ok, calculation done!")""")
         assert messages
         assert all(m.content.endswith("</code>") for m in messages)
 
-    @pytest.mark.skip(
-        reason="Test is not properly implemented (GH-1255) because fake_tools should have the same name. "
-    )
     def test_change_tools_after_init(self):
         from smolagents import tool
 


### PR DESCRIPTION
## Summary
Both `test_change_tools_after_init` tests in `tests/test_agents.py` were marked `@pytest.mark.skip`, citing GH-1255 and GH-1409 as reasons they were broken/not properly implemented.

- The copy in `TestCodeAgent` already passes as-is against the current codebase (the fake-tool-name concern from GH-1255 no longer applies — tool lookup during execution is by the `agent.tools` dict key, not the tool's own `.name`), so it's simply unskipped.
- The copy in `TestToolCallingAgent` was a verbatim copy-paste that used `CodeAgent` instead of `ToolCallingAgent` (GH-1409), so it never actually exercised `ToolCallingAgent`'s tool-execution path. It's rewritten with a fake tool-calling model (following the existing `FakeToolCallModel` pattern used elsewhere in the file) so it now genuinely tests that swapping an entry in `agent.tools` after init affects execution for `ToolCallingAgent` too.

## Test plan
- [x] `pytest tests/test_agents.py -k test_change_tools_after_init -v` — both pass
- [x] Full `pytest tests/test_agents.py` — 97 passed
- [x] `ruff check` / `ruff format --check` on the changed file — clean