### PR TITLE
fix(agents): keep successful parallel tool results when one call fails

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1415,6 +1415,7 @@ class ToolCallingAgent(MultiStepAgent):
 
         # Process tool calls in parallel
         outputs = {}
+        parallel_errors: list[BaseException] = []
         if len(parallel_calls) == 1:
             # If there's only one call, process it directly
             tool_call = list(parallel_calls.values())[0]
@@ -1422,14 +1423,20 @@ class ToolCallingAgent(MultiStepAgent):
             outputs[tool_output.id] = tool_output
             yield tool_output
         else:
-            # If multiple tool calls, process them in parallel
+            # If multiple tool calls, process them in parallel.
+            # Collect successes even when some futures fail so partial results
+            # are written to memory before re-raising (#2457).
             with ThreadPoolExecutor(self.max_tool_threads) as executor:
                 futures = []
                 for tool_call in parallel_calls.values():
                     ctx = copy_context()
                     futures.append(executor.submit(ctx.run, process_single_tool_call, tool_call))
                 for future in as_completed(futures):
-                    tool_output = future.result()
+                    try:
+                        tool_output = future.result()
+                    except BaseException as e:  # noqa: BLE001 — re-raise after partial write
+                        parallel_errors.append(e)
+                        continue
                     outputs[tool_output.id] = tool_output
                     yield tool_output
 
@@ -1440,6 +1447,10 @@ class ToolCallingAgent(MultiStepAgent):
         memory_step.observations = (
             memory_step.observations.rstrip("\n") if memory_step.observations else memory_step.observations
         )
+
+        # Re-raise after partial successes are recorded so the agent keeps context.
+        if parallel_errors:
+            raise parallel_errors[0]
 
     def _substitute_state_variables(self, arguments: dict[str, str] | str) -> dict[str, Any] | str:
         """Replace string values in arguments with their corresponding state values if they exist."""


### PR DESCRIPTION
## Summary

In `ToolCallingAgent.process_tool_calls`, parallel tool execution used:

```python
for future in as_completed(futures):
    tool_output = future.result()  # first failure aborts the loop
```

If one tool raised, successes from other tools were discarded and `memory_step.observations` was never updated. The agent then retries the whole step without context of what already worked.

## Change

- Catch per-future exceptions while collecting successful `ToolOutput`s
- Always write partial successes into `memory_step.tool_calls` / `observations`
- Re-raise the first failure after the partial write

## Linked issue

Fixes #2457

## Test plan

- [ ] Manual: three parallel tools (2 ok, 1 raise) → observations contain the two successes, exception still surfaces
- [ ] CI unit suite

I used AI tooling for drafting; I reviewed the control flow against the issue report and the local source path around `as_completed`.
