### PR TITLE
fix(local_python_executor): SSRF egress guard (CVE-2026-2654)

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 import ast
 import builtins
+import contextlib
 import difflib
 import inspect
 import logging
@@ -32,6 +33,7 @@ from importlib.util import find_spec
 from types import BuiltinFunctionType, FunctionType, ModuleType
 from typing import Any
 
+from .network_guard import authorized_imports_reach_network, ssrf_guard
 from .tools import Tool
 from .utils import BASE_BUILTIN_MODULES, truncate_content
 
@@ -1703,6 +1705,15 @@ class LocalPythonExecutor(PythonExecutor):
             Additional Python functions to be added to the executor.
         timeout_seconds (`int`, *optional*, defaults to `MAX_EXECUTION_TIME_SECONDS`):
             Maximum time in seconds allowed for code execution. Set to `None` to disable timeout.
+        block_ssrf (`bool`, defaults to `True`):
+            Defense-in-depth SSRF guard (CVE-2026-2654): when a network-capable module is
+            authorized, block outbound connections to private / reserved / loopback /
+            link-local destinations (incl. the 169.254.169.254 cloud-metadata address).
+            This is not a sandbox boundary — for untrusted code use a remote executor.
+        network_allowlist (`list[str]`, *optional*):
+            Hostnames explicitly permitted to resolve to otherwise-blocked addresses
+            (e.g. an internal service intentionally exposed to the agent). Only meaningful
+            when ``block_ssrf`` is enabled.
     """
 
     def __init__(
@@ -1711,6 +1722,8 @@ class LocalPythonExecutor(PythonExecutor):
         max_print_outputs_length: int | None = None,
         additional_functions: dict[str, Callable] | None = None,
         timeout_seconds: int | None = MAX_EXECUTION_TIME_SECONDS,
+        block_ssrf: bool = True,
+        network_allowlist: list[str] | None = None,
     ):
         self.custom_tools = {}
         self.state = {"__name__": "__main__"}
@@ -1723,6 +1736,8 @@ class LocalPythonExecutor(PythonExecutor):
         self.static_tools = None
         self.additional_functions = additional_functions or {}
         self.timeout_seconds = timeout_seconds
+        self.block_ssrf = block_ssrf
+        self.network_allowlist = set(network_allowlist or [])
 
     def _check_authorized_imports_are_installed(self):
         """
@@ -1745,15 +1760,24 @@ class LocalPythonExecutor(PythonExecutor):
             )
 
     def __call__(self, code_action: str) -> CodeOutput:
-        output, is_final_answer = evaluate_python_code(
-            code_action,
-            static_tools=self.static_tools,
-            custom_tools=self.custom_tools,
-            state=self.state,
-            authorized_imports=self.authorized_imports,
-            max_print_outputs_length=self.max_print_outputs_length,
-            timeout_seconds=self.timeout_seconds,
+        # Defense-in-depth SSRF guard (CVE-2026-2654): only armed when a
+        # network-capable module is authorized, so the common no-network case
+        # pays nothing and behaviour is unchanged.
+        guard = (
+            ssrf_guard(self.network_allowlist)
+            if self.block_ssrf and authorized_imports_reach_network(self.authorized_imports)
+            else contextlib.nullcontext()
         )
+        with guard:
+            output, is_final_answer = evaluate_python_code(
+                code_action,
+                static_tools=self.static_tools,
+                custom_tools=self.custom_tools,
+                state=self.state,
+                authorized_imports=self.authorized_imports,
+                max_print_outputs_length=self.max_print_outputs_length,
+                timeout_seconds=self.timeout_seconds,
+            )
         logs = str(self.state["_print_outputs"])
         return CodeOutput(output=output, logs=logs, is_final_answer=is_final_answer)
 

--- a/src/smolagents/network_guard.py
+++ b/src/smolagents/network_guard.py
@@ -1,0 +1,142 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defense-in-depth SSRF guard for the local Python executor.
+
+Rationale (CVE-2026-2654 / GHSA-jxgv-6j54-wwc7): when a developer allow-lists a
+network-capable module (``requests``, ``urllib``, ``httpx``, ``http.client``,
+``socket`` …) via ``additional_authorized_imports``, the local executor performs
+no egress filtering. Model-generated (or prompt-injected) code can then reach
+internal-only endpoints — cloud metadata (169.254.169.254), RFC1918 hosts,
+loopback services — i.e. Server-Side Request Forgery (CWE-918).
+
+This module blocks outbound connections to private / reserved / loopback /
+link-local destinations at the single DNS choke point every stdlib and
+third-party HTTP client funnels through: ``socket.getaddrinfo``. Filtering on the
+**resolved IP** (not the hostname) defeats DNS-rebinding. Numeric-IP targets are
+covered too, since ``getaddrinfo`` is invoked to build the sockaddr even when the
+host is already an IP literal.
+
+This is defense-in-depth, not a security boundary: ``LocalPythonExecutor`` is
+explicitly not a sandbox. For untrusted code, use a remote executor
+(Docker / E2B / Wasm).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ipaddress
+import socket
+from collections.abc import Iterator
+
+
+class SSRFBlockedError(OSError):
+    """Raised when the SSRF guard blocks a connection to a non-public address."""
+
+
+def is_blocked_address(host: str) -> bool:
+    """Return True if ``host`` (an IP literal) resolves to a non-public range.
+
+    Blocks loopback, private (RFC1918 / ULA), link-local (incl. the
+    169.254.169.254 cloud-metadata address), reserved, multicast and the
+    unspecified address, for both IPv4 and IPv6. A host that is not a valid IP
+    literal is treated as non-blocked here (the caller resolves it first).
+    """
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    # ``is_global`` is the authoritative "publicly routable" flag; the explicit
+    # checks below make the intent auditable and catch a few ranges that some
+    # Python versions classify inconsistently.
+    return (
+        not ip.is_global
+        or ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+@contextlib.contextmanager
+def ssrf_guard(allowlist_hosts: set[str] | None = None) -> Iterator[None]:
+    """Patch ``socket.getaddrinfo`` to reject non-public destinations.
+
+    Args:
+        allowlist_hosts: hostnames (exact match, case-insensitive) explicitly
+            permitted to resolve to otherwise-blocked addresses (e.g. an internal
+            service the developer intentionally exposes to the agent).
+
+    The patch is process-global for the duration of the ``with`` block and is
+    restored on exit. It targets the local (single-run) executor's execution
+    window; concurrent unrelated network calls in the same process are also
+    subject to it while active.
+    """
+    allow = {h.lower() for h in (allowlist_hosts or set())}
+    real_getaddrinfo = socket.getaddrinfo
+
+    def guarded_getaddrinfo(host, *args, **kwargs):
+        results = real_getaddrinfo(host, *args, **kwargs)
+        if host is not None and str(host).lower() in allow:
+            return results
+        for family, type_, proto, canonname, sockaddr in results:
+            ip = sockaddr[0]
+            if is_blocked_address(ip):
+                raise SSRFBlockedError(
+                    f"SSRF guard: blocked connection to non-public address "
+                    f"{ip} (host={host!r}). Add the host to the executor's "
+                    f"network_allowlist to permit it explicitly."
+                )
+        return results
+
+    socket.getaddrinfo = guarded_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = real_getaddrinfo
+
+
+# Network-capable stdlib / common third-party modules whose presence in the
+# authorized imports means outbound requests are reachable from agent code.
+NETWORK_CAPABLE_MODULES = frozenset(
+    {
+        "socket",
+        "ssl",
+        "http",
+        "urllib",
+        "urllib3",
+        "ftplib",
+        "telnetlib",
+        "smtplib",
+        "poplib",
+        "imaplib",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "websocket",
+        "websockets",
+        "asyncio",
+    }
+)
+
+
+def authorized_imports_reach_network(authorized_imports: list[str]) -> bool:
+    """True if any authorized import can perform network egress (incl. wildcard)."""
+    for imp in authorized_imports:
+        if imp == "*":
+            return True
+        if imp.split(".")[0] in NETWORK_CAPABLE_MODULES:
+            return True
+    return False

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -1,0 +1,156 @@
+# coding=utf-8
+# Copyright 2024 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the SSRF guard (CVE-2026-2654 / GHSA-jxgv-6j54-wwc7)."""
+
+import socket
+
+import pytest
+
+from smolagents.local_python_executor import LocalPythonExecutor
+from smolagents.network_guard import (
+    SSRFBlockedError,
+    authorized_imports_reach_network,
+    is_blocked_address,
+    ssrf_guard,
+)
+
+
+@pytest.mark.parametrize(
+    "ip, blocked",
+    [
+        ("169.254.169.254", True),  # cloud metadata
+        ("127.0.0.1", True),  # loopback
+        ("10.0.0.5", True),  # RFC1918
+        ("192.168.1.1", True),  # RFC1918
+        ("172.16.0.1", True),  # RFC1918
+        ("::1", True),  # IPv6 loopback
+        ("fe80::1", True),  # IPv6 link-local
+        ("fc00::1", True),  # IPv6 ULA
+        ("8.8.8.8", False),  # public
+        ("1.1.1.1", False),  # public
+    ],
+)
+def test_is_blocked_address(ip, blocked):
+    assert is_blocked_address(ip) is blocked
+
+
+def test_is_blocked_address_non_ip_is_not_blocked():
+    # Hostnames are resolved by the caller; the classifier only judges IP literals.
+    assert is_blocked_address("example.com") is False
+
+
+def test_ssrf_guard_blocks_metadata_and_private():
+    with ssrf_guard():
+        for host in ("169.254.169.254", "127.0.0.1", "10.0.0.1"):
+            with pytest.raises(SSRFBlockedError):
+                socket.getaddrinfo(host, 80)
+
+
+def test_ssrf_guard_allows_public():
+    with ssrf_guard():
+        # Public literal resolves without raising (no connection is made).
+        assert socket.getaddrinfo("8.8.8.8", 53)
+
+
+def test_ssrf_guard_allowlist_overrides():
+    with ssrf_guard(allowlist_hosts={"127.0.0.1"}):
+        assert socket.getaddrinfo("127.0.0.1", 80)
+
+
+def test_ssrf_guard_restores_getaddrinfo():
+    before = socket.getaddrinfo
+    with ssrf_guard():
+        pass
+    assert socket.getaddrinfo is before
+
+
+@pytest.mark.parametrize(
+    "imports, reaches",
+    [
+        (["math", "requests"], True),
+        (["urllib.request"], True),
+        (["math", "pandas"], False),
+        (["*"], True),
+    ],
+)
+def test_authorized_imports_reach_network(imports, reaches):
+    assert authorized_imports_reach_network(imports) is reaches
+
+
+# --- Integration through LocalPythonExecutor -------------------------------
+
+
+def _run(executor: LocalPythonExecutor, code: str):
+    executor.send_tools({"final_answer": (lambda x: x)})
+    return executor(code).output
+
+
+_CONNECT = (
+    "import socket\n"
+    "try:\n"
+    "    s = socket.create_connection(('127.0.0.1', {port}), timeout=3)\n"
+    "    s.close()\n"
+    "    outcome = 'REACHED'\n"
+    "except Exception as e:\n"
+    "    outcome = 'BLOCKED ' + str(e)[:120]\n"
+    "final_answer(outcome)\n"
+)
+
+
+def _serve() -> tuple[socket.socket, int]:
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    return srv, srv.getsockname()[1]
+
+
+def test_executor_blocks_ssrf_to_reachable_internal_target():
+    """The guard blocks a genuinely reachable loopback service (fail-closed)."""
+    srv, port = _serve()
+    try:
+        ex = LocalPythonExecutor(additional_authorized_imports=["socket"])
+        out = _run(ex, _CONNECT.format(port=port))
+        assert out.startswith("BLOCKED")
+        assert "127.0.0.1" in out
+    finally:
+        srv.close()
+
+
+def test_executor_reaches_target_when_guard_disabled():
+    """block_ssrf=False restores the historical (unguarded) behaviour."""
+    srv, port = _serve()
+    try:
+        ex = LocalPythonExecutor(additional_authorized_imports=["socket"], block_ssrf=False)
+        assert _run(ex, _CONNECT.format(port=port)) == "REACHED"
+    finally:
+        srv.close()
+
+
+def test_executor_allowlist_permits_internal_host():
+    srv, port = _serve()
+    try:
+        ex = LocalPythonExecutor(additional_authorized_imports=["socket"], network_allowlist=["127.0.0.1"])
+        assert _run(ex, _CONNECT.format(port=port)) == "REACHED"
+    finally:
+        srv.close()
+
+
+def test_executor_guard_not_armed_without_network_module():
+    """No network module authorized → getaddrinfo is never patched (zero overhead)."""
+    before = socket.getaddrinfo
+    ex = LocalPythonExecutor(additional_authorized_imports=["math"])
+    assert _run(ex, "import math\nfinal_answer(math.factorial(6))") == 720
+    assert socket.getaddrinfo is before


### PR DESCRIPTION
## What
Adds a defense-in-depth SSRF guard to `LocalPythonExecutor`, addressing **CVE-2026-2654 / GHSA-jxgv-6j54-wwc7** (CWE-918).

## Why
`LocalPythonExecutor` performs no network egress filtering. Once a developer allow-lists a network-capable module (`requests`, `urllib`, `httpx`, `socket`, …) via `additional_authorized_imports` — common for web agents — model-generated or prompt-injected code can reach internal-only endpoints: cloud metadata (`169.254.169.254`), RFC1918 hosts, loopback services. `DANGEROUS_MODULES` blocks `socket`/`os`/`subprocess` but not `requests`/`urllib`/`http.client`.

This is **complementary** to the tool-level SSRF work (#2081 / #2082 / #2370), which guards `AgentAudio` / `VisitWebpageTool` URL fetching. This PR guards the **executor egress layer** — arbitrary agent code using any authorized network module — which those PRs do not cover.

## How
A guard armed **only when a network module is authorized** (the no-network case pays nothing) patches `socket.getaddrinfo` — the single DNS choke point every HTTP client funnels through — and blocks resolution to private / reserved / loopback / link-local ranges. Filtering on the **resolved IP** defeats DNS-rebinding; numeric-IP targets are covered too. Opt-out via `block_ssrf=False`; per-host opt-in via `network_allowlist`.

**Framing**: this is defense-in-depth, not a sandbox boundary — the docstring's guidance to use a remote executor for untrusted code still stands.

## Tests
`tests/test_network_guard.py` (23 tests): IP classification (IPv4/IPv6), metadata / RFC1918 / loopback blocking, allowlist override, `getaddrinfo` restoration, network-module detection, and end-to-end through `LocalPythonExecutor` (blocks a genuinely reachable loopback service; with `block_ssrf=False` the same target is reached — proving the guard, not the network). `make quality` passes; no regression in `tests/test_local_python_executor.py` (395 passed, the 2 failures are missing optional `scipy`/`sklearn`).
