### PR TITLE
docs: document `relative_path` parameter in `MultiStepAgent.save()`

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -903,6 +903,7 @@ You have been provided with these additional arguments, that you can access dire
 
         Args:
             output_dir (`str` or `Path`): The folder in which you want to save your agent.
+            relative_path (`str`, *optional*): Dotted module path prefix locating this agent within a hierarchy of managed agents. Used internally when recursively saving managed agents so that the import paths in the generated files reflect the agent hierarchy; leave as `None` for the top-level agent.
         """
         make_init_file(output_dir)
 


### PR DESCRIPTION
## What does this PR do?

`MultiStepAgent.save()` accepts a `relative_path` argument, but its docstring's `Args` section only documented `output_dir`, leaving `relative_path` undocumented.

This PR adds an `Args` entry for `relative_path`, explaining that it sets the dotted module-path prefix used when recursively saving managed agents, so the import paths in the generated files (e.g. `app.py`) reflect the agent hierarchy. Top-level callers leave it as `None`.

Documentation-only change — no functional or behavioral impact.

### Before / After

Before:
```
Args:
    output_dir (`str` or `Path`): The folder in which you want to save your agent.
```

After:
```
Args:
    output_dir (`str` or `Path`): The folder in which you want to save your agent.
    relative_path (`str`, *optional*): Dotted module path prefix locating this agent within a hierarchy of managed agents. ...
```

## Before submitting
- [x] Documentation-only improvement.
- [x] Followed the docstring style used elsewhere in the file (`` `type` ``, `*optional*`).
- [x] Read the contributor guidelines.