### PR TITLE
Fix nested Any types in tool JSON schemas

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -285,15 +285,52 @@ tool_role_conversions = {
 }
 
 
-def _sanitize_tool_json_schema(schema: Any) -> None:
-    if isinstance(schema, dict):
-        if schema.get("type") == "any":
-            schema["type"] = "string"
-        for value in schema.values():
-            _sanitize_tool_json_schema(value)
-    elif isinstance(schema, list):
-        for value in schema:
-            _sanitize_tool_json_schema(value)
+def _sanitize_tool_json_schema(schema: dict[str, Any]) -> None:
+    """Replace internal ``"any"`` types without traversing annotation payloads."""
+    schema_type = schema.get("type")
+    if schema_type == "any":
+        schema["type"] = "string"
+    elif isinstance(schema_type, list):
+        schema["type"] = ["string" if value == "any" else value for value in schema_type]
+
+    # Values under keywords such as ``default``, ``examples``, and ``enum`` are
+    # arbitrary JSON data, not schemas. Descend only through JSON Schema
+    # keywords whose values contain subschemas so payloads remain untouched.
+    for keyword in (
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    ):
+        nested_schema = schema.get(keyword)
+        if isinstance(nested_schema, dict):
+            _sanitize_tool_json_schema(nested_schema)
+        elif keyword == "items" and isinstance(nested_schema, list):
+            for item in nested_schema:
+                if isinstance(item, dict):
+                    _sanitize_tool_json_schema(item)
+
+    for keyword in ("allOf", "anyOf", "oneOf", "prefixItems"):
+        nested_schemas = schema.get(keyword)
+        if isinstance(nested_schemas, list):
+            for nested_schema in nested_schemas:
+                if isinstance(nested_schema, dict):
+                    _sanitize_tool_json_schema(nested_schema)
+
+    for keyword in ("$defs", "definitions", "dependencies", "dependentSchemas", "patternProperties", "properties"):
+        nested_schemas = schema.get(keyword)
+        if isinstance(nested_schemas, dict):
+            for nested_schema in nested_schemas.values():
+                if isinstance(nested_schema, dict):
+                    _sanitize_tool_json_schema(nested_schema)
 
 
 def get_tool_json_schema(tool: Tool) -> dict:

--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -285,12 +285,21 @@ tool_role_conversions = {
 }
 
 
+def _sanitize_tool_json_schema(schema: Any) -> None:
+    if isinstance(schema, dict):
+        if schema.get("type") == "any":
+            schema["type"] = "string"
+        for value in schema.values():
+            _sanitize_tool_json_schema(value)
+    elif isinstance(schema, list):
+        for value in schema:
+            _sanitize_tool_json_schema(value)
+
+
 def get_tool_json_schema(tool: Tool) -> dict:
     properties = deepcopy(tool.inputs)
     required = []
     for key, value in properties.items():
-        if value["type"] == "any":
-            value["type"] = "string"
         if not ("nullable" in value and value["nullable"]):
             required.append(key)
 
@@ -314,6 +323,8 @@ def get_tool_json_schema(tool: Tool) -> dict:
                 value["enum"] = enum
 
             value.pop("anyOf")
+
+        _sanitize_tool_json_schema(value)
 
     return {
         "type": "function",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -230,6 +230,8 @@ class TestModel:
             mapping: dict[str, Any],
             pairs: tuple[Any, str],
             nested: list[dict[str, Any]],
+            choice: Any | int,
+            optional_mapping: dict[str, Any] | None = None,
         ) -> str:
             """Process nested values.
 
@@ -238,6 +240,8 @@ class TestModel:
                 mapping: Values keyed by name.
                 pairs: A pair of values.
                 nested: Nested mappings to process.
+                choice: An unconstrained value or an integer.
+                optional_mapping: An optional mapping keyed by name.
             """
             return "processed"
 
@@ -248,7 +252,32 @@ class TestModel:
         assert properties["mapping"]["additionalProperties"]["type"] == "string"
         assert properties["pairs"]["prefixItems"][0]["type"] == "string"
         assert properties["nested"]["items"]["additionalProperties"]["type"] == "string"
+        assert set(properties["choice"]["type"]) == {"integer", "string"}
+        assert properties["optional_mapping"]["additionalProperties"]["type"] == "string"
+        assert properties["optional_mapping"]["nullable"] is True
+        assert "optional_mapping" not in schema["function"]["parameters"]["required"]
         assert '"any"' not in json.dumps(schema)
+
+    def test_get_tool_json_schema_preserves_data_payloads(self):
+        tool = MagicMock()
+        tool.name = "process_payload"
+        tool.description = "Process an object with schema-like payload data."
+        tool.inputs = {
+            "payload": {
+                "type": "object",
+                "properties": {"value": {"type": "any"}},
+                "default": {"type": "any"},
+                "examples": [{"type": "any"}],
+                "enum": [{"type": "any"}],
+            }
+        }
+
+        payload_schema = get_tool_json_schema(tool)["function"]["parameters"]["properties"]["payload"]
+
+        assert payload_schema["properties"]["value"]["type"] == "string"
+        assert payload_schema["default"] == {"type": "any"}
+        assert payload_schema["examples"] == [{"type": "any"}]
+        assert payload_schema["enum"] == [{"type": "any"}]
 
     def test_chatmessage_has_model_dumps_json(self):
         message = ChatMessage("user", [{"type": "text", "text": "Hello!"}])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@
 import json
 import sys
 from contextlib import ExitStack
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -221,6 +222,33 @@ class TestModel:
             return "The weather is UNGODLY with torrential rains and temperatures below -10°C"
 
         assert "nullable" in get_tool_json_schema(get_weather)["function"]["parameters"]["properties"]["celsius"]
+
+    def test_get_tool_json_schema_sanitizes_nested_any_types(self):
+        @tool
+        def process_nested_values(
+            values: list[Any],
+            mapping: dict[str, Any],
+            pairs: tuple[Any, str],
+            nested: list[dict[str, Any]],
+        ) -> str:
+            """Process nested values.
+
+            Args:
+                values: Values to process.
+                mapping: Values keyed by name.
+                pairs: A pair of values.
+                nested: Nested mappings to process.
+            """
+            return "processed"
+
+        schema = get_tool_json_schema(process_nested_values)
+        properties = schema["function"]["parameters"]["properties"]
+
+        assert properties["values"]["items"]["type"] == "string"
+        assert properties["mapping"]["additionalProperties"]["type"] == "string"
+        assert properties["pairs"]["prefixItems"][0]["type"] == "string"
+        assert properties["nested"]["items"]["additionalProperties"]["type"] == "string"
+        assert '"any"' not in json.dumps(schema)
 
     def test_chatmessage_has_model_dumps_json(self):
         message = ChatMessage("user", [{"type": "text", "text": "Hello!"}])


### PR DESCRIPTION
## What does this PR do?

- sanitizes smolagents' internal `"any"` marker at every schema depth before tool definitions reach model providers
- follows only JSON Schema keywords that contain subschemas, preserving arbitrary data under `default`, `examples`, and `enum`
- covers arrays, mappings, tuple prefix items, unions represented as type arrays, optional mappings, and deeper nested containers
- adds regression coverage for both nested sanitization and payload preservation

Fixes #2608

## Why

`get_tool_json_schema` previously converted only a top-level `{"type": "any"}`. Nested `Any` annotations such as `list[Any]` and `dict[str, Any]` could therefore emit an invalid JSON Schema type.

A generic recursive dictionary walk fixes that leak but can corrupt user data that happens to look like a schema, for example `default={"type": "any"}`. This implementation descends only through schema-bearing keywords, so schema nodes are sanitized without modifying annotation payloads.

## Testing

- `uv run --with pytest pytest tests/test_models.py -k 'get_tool_json_schema_sanitizes_nested_any_types or get_tool_json_schema_preserves_data_payloads or get_json_schema_has_nullable_args'` — 3 passed
- `uv run --with pytest --with pytest-datadir pytest tests/test_function_type_hints_utils.py` — 25 passed
- `uv run --with ruff ruff check src/smolagents/models.py tests/test_models.py` — passed
- `uv run --with ruff ruff format --check src/smolagents/models.py tests/test_models.py` — passed
- `uv run --with ruff ruff check examples src tests` — passed

The repository-wide format check still reports the unchanged `examples/plan_customization/README.md` formatting issue that is also present on `main`; both files changed by this PR pass the format check.