### PR TITLE
fix: correct f-string escaping in serialization error message

### DIFF
--- a/src/smolagents/serialization.py
+++ b/src/smolagents/serialization.py
@@ -426,7 +426,7 @@ class SafeSerializer:
                 try:
                     return "pickle:" + base64.b64encode(pickle.dumps(obj)).decode()
                 except (pickle.PicklingError, TypeError, AttributeError) as e:
-                    raise SerializationError(f"Cannot serialize object: {{e}}") from e
+                    raise SerializationError(f"Cannot serialize object: {e}") from e
 
     @staticmethod
     def loads(data, allow_pickle=False):


### PR DESCRIPTION
This PR addresses: correct f-string escaping in serialization error message