### PR TITLE
fix: remove duplicate colon in cleanup error log message

### DIFF
--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -1057,7 +1057,7 @@ class BlaxelExecutor(RemotePythonExecutor):
             self._delete_sandbox()
         except Exception as e:
             # Log cleanup errors but don't raise - cleanup should be best-effort
-            self.logger.log(f"Error during cleanup: : {e}", level=LogLevel.INFO)
+            self.logger.log(f"Error during cleanup: {e}", level=LogLevel.INFO)
         finally:
             # Always clean up local references
             if hasattr(self, "sandbox"):


### PR DESCRIPTION
This PR addresses: remove duplicate colon in cleanup error log message