### PR TITLE
fix: correct AgentImage tensor and array conversion

### DIFF
--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -83,10 +83,13 @@ class AgentImage(AgentType, PIL.Image.Image):
         self._path = None
         self._raw = None
         self._tensor = None
-        self._numpy = None
+        self._array = None
 
         if isinstance(value, AgentImage):
-            self._raw, self._path, self._tensor = value._raw, value._path, value._tensor
+            self._raw = value._raw
+            self._path = value._path
+            self._tensor = value._tensor
+            self._array = value._array
         elif isinstance(value, PIL.Image.Image):
             self._raw = value
         elif isinstance(value, bytes):
@@ -95,31 +98,33 @@ class AgentImage(AgentType, PIL.Image.Image):
             self._path = value
         else:
             try:
+                import numpy as np
+
+                if isinstance(value, np.ndarray):
+                    self._array = value
+            except ModuleNotFoundError:
+                pass
+
+            try:
                 import torch
 
                 if isinstance(value, torch.Tensor):
                     self._tensor = value
-                import numpy as np
-
-                if isinstance(value, np.ndarray):
-                    self._tensor = torch.from_numpy(value)
             except ModuleNotFoundError:
-                # numpy or torch unavailable: keep numpy arrays usable without torch
-                try:
-                    import numpy as np
+                pass
 
-                    if isinstance(value, np.ndarray):
-                        self._numpy = value
-                except ModuleNotFoundError:
-                    pass
-
-        if (
-            self._path is None
-            and self._raw is None
-            and self._tensor is None
-            and self._numpy is None
-        ):
+        if self._path is None and self._raw is None and self._tensor is None and self._array is None:
             raise TypeError(f"Unsupported type for {self.__class__.__name__}: {type(value)}")
+
+    @staticmethod
+    def _to_pil_image(array):
+        import numpy as np
+
+        if np.issubdtype(array.dtype, np.floating):
+            array = np.clip(array, 0.0, 1.0) * 255
+        else:
+            array = np.clip(array, 0, 255)
+        return PIL.Image.fromarray(array.astype(np.uint8))
 
     def _ipython_display_(self, include=None, exclude=None):
         """
@@ -140,11 +145,11 @@ class AgentImage(AgentType, PIL.Image.Image):
             self._raw = PIL.Image.open(self._path)
             return self._raw
 
-        if self._tensor is not None or self._numpy is not None:
-            import numpy as np
+        if self._tensor is not None:
+            return self._to_pil_image(self._tensor.cpu().detach().numpy())
 
-            array = self._tensor.cpu().detach().numpy() if self._tensor is not None else self._numpy
-            return PIL.Image.fromarray((array * 255).astype(np.uint8))
+        if self._array is not None:
+            return self._to_pil_image(self._array)
 
     def to_string(self):
         """
@@ -160,13 +165,9 @@ class AgentImage(AgentType, PIL.Image.Image):
             self._raw.save(self._path, format="png")
             return self._path
 
-        if self._tensor is not None or self._numpy is not None:
-            import numpy as np
-
-            array = self._tensor.cpu().detach().numpy() if self._tensor is not None else self._numpy
-
-            # There is likely simpler than load into image into save
-            img = PIL.Image.fromarray((array * 255).astype(np.uint8))
+        if self._tensor is not None or self._array is not None:
+            array = self._tensor.cpu().detach().numpy() if self._tensor is not None else self._array
+            img = self._to_pil_image(array)
 
             directory = tempfile.mkdtemp()
             self._path = os.path.join(directory, str(uuid.uuid4()) + ".png")

--- a/src/smolagents/agent_types.py
+++ b/src/smolagents/agent_types.py
@@ -83,6 +83,7 @@ class AgentImage(AgentType, PIL.Image.Image):
         self._path = None
         self._raw = None
         self._tensor = None
+        self._numpy = None
 
         if isinstance(value, AgentImage):
             self._raw, self._path, self._tensor = value._raw, value._path, value._tensor
@@ -103,9 +104,21 @@ class AgentImage(AgentType, PIL.Image.Image):
                 if isinstance(value, np.ndarray):
                     self._tensor = torch.from_numpy(value)
             except ModuleNotFoundError:
-                pass
+                # numpy or torch unavailable: keep numpy arrays usable without torch
+                try:
+                    import numpy as np
 
-        if self._path is None and self._raw is None and self._tensor is None:
+                    if isinstance(value, np.ndarray):
+                        self._numpy = value
+                except ModuleNotFoundError:
+                    pass
+
+        if (
+            self._path is None
+            and self._raw is None
+            and self._tensor is None
+            and self._numpy is None
+        ):
             raise TypeError(f"Unsupported type for {self.__class__.__name__}: {type(value)}")
 
     def _ipython_display_(self, include=None, exclude=None):
@@ -127,11 +140,11 @@ class AgentImage(AgentType, PIL.Image.Image):
             self._raw = PIL.Image.open(self._path)
             return self._raw
 
-        if self._tensor is not None:
+        if self._tensor is not None or self._numpy is not None:
             import numpy as np
 
-            array = self._tensor.cpu().detach().numpy()
-            return PIL.Image.fromarray((255 - array * 255).astype(np.uint8))
+            array = self._tensor.cpu().detach().numpy() if self._tensor is not None else self._numpy
+            return PIL.Image.fromarray((array * 255).astype(np.uint8))
 
     def to_string(self):
         """
@@ -147,13 +160,13 @@ class AgentImage(AgentType, PIL.Image.Image):
             self._raw.save(self._path, format="png")
             return self._path
 
-        if self._tensor is not None:
+        if self._tensor is not None or self._numpy is not None:
             import numpy as np
 
-            array = self._tensor.cpu().detach().numpy()
+            array = self._tensor.cpu().detach().numpy() if self._tensor is not None else self._numpy
 
             # There is likely simpler than load into image into save
-            img = PIL.Image.fromarray((255 - array * 255).astype(np.uint8))
+            img = PIL.Image.fromarray((array * 255).astype(np.uint8))
 
             directory = tempfile.mkdtemp()
             self._path = os.path.join(directory, str(uuid.uuid4()) + ".png")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -108,6 +108,58 @@ class TestAgentImage:
         del agent_type
         assert os.path.exists(path)
 
+    def test_from_tensor_is_not_inverted(self):
+        import numpy as np
+        import torch
+
+        tensor = torch.tensor(
+            [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
+            dtype=torch.float32,
+        )
+        agent_type = AgentImage(tensor)
+        array = np.asarray(agent_type.to_raw())
+
+        assert array[0, 0].tolist() == [0, 0, 0]
+        assert array[0, 1].tolist() == [255, 255, 255]
+
+    def test_from_numpy_array(self):
+        import numpy as np
+
+        array = np.array(
+            [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
+            dtype=np.float32,
+        )
+        agent_type = AgentImage(array)
+        raw = np.asarray(agent_type.to_raw())
+
+        assert raw[0, 0].tolist() == [0, 0, 0]
+        assert raw[0, 1].tolist() == [255, 255, 255]
+
+    def test_from_numpy_array_without_torch(self):
+        import builtins
+        from unittest import mock
+
+        import numpy as np
+
+        real_import = builtins.__import__
+
+        def import_without_torch(name, *args, **kwargs):
+            if name == "torch":
+                raise ModuleNotFoundError("No module named 'torch'")
+            return real_import(name, *args, **kwargs)
+
+        array = np.array(
+            [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
+            dtype=np.float32,
+        )
+        with mock.patch("builtins.__import__", side_effect=import_without_torch):
+            agent_type = AgentImage(array)
+
+        assert agent_type._numpy is array
+        raw = np.asarray(agent_type.to_raw())
+        assert raw[0, 0].tolist() == [0, 0, 0]
+        assert raw[0, 1].tolist() == [255, 255, 255]
+
 
 class AgentTextTests(unittest.TestCase):
     def test_from_string(self):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -122,17 +122,32 @@ class TestAgentImage:
         assert array[0, 0].tolist() == [0, 0, 0]
         assert array[0, 1].tolist() == [255, 255, 255]
 
-    def test_from_numpy_array(self):
+    def test_from_tensor_to_string_is_not_inverted(self):
+        import numpy as np
+        import torch
+
+        tensor = torch.tensor(
+            [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
+            dtype=torch.float32,
+        )
+        agent_type = AgentImage(tensor)
+        path = agent_type.to_string()
+        array = np.asarray(PIL.Image.open(path))
+
+        assert array[0, 0].tolist() == [0, 0, 0]
+        assert array[0, 1].tolist() == [255, 255, 255]
+
+    def test_from_numpy_array_preserves_uint8_values(self):
         import numpy as np
 
         array = np.array(
-            [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
-            dtype=np.float32,
+            [[[0, 64, 128], [255, 255, 255]]],
+            dtype=np.uint8,
         )
         agent_type = AgentImage(array)
         raw = np.asarray(agent_type.to_raw())
 
-        assert raw[0, 0].tolist() == [0, 0, 0]
+        assert raw[0, 0].tolist() == [0, 64, 128]
         assert raw[0, 1].tolist() == [255, 255, 255]
 
     def test_from_numpy_array_without_torch(self):
@@ -155,7 +170,7 @@ class TestAgentImage:
         with mock.patch("builtins.__import__", side_effect=import_without_torch):
             agent_type = AgentImage(array)
 
-        assert agent_type._numpy is array
+        assert agent_type._array is array
         raw = np.asarray(agent_type.to_raw())
         assert raw[0, 0].tolist() == [0, 0, 0]
         assert raw[0, 1].tolist() == [255, 255, 255]


### PR DESCRIPTION
Fixes #2656 and #2657.

This PR fixes two related `AgentImage` conversion issues:

1. Tensor-backed images were written as photographic negatives because both `to_raw()` and `to_string()` used `255 - array * 255` when converting normalized float tensors to byte pixels. The conversion now scales with `array * 255` instead.
2. NumPy image arrays were rejected when `torch` was not installed because the constructor imported `torch` before checking `np.ndarray`. NumPy arrays are now handled independently and no longer round-trip through torch.

While touching this path, I also centralized tensor/array-to-PIL conversion so `to_raw()` and `to_string()` share the same behavior. Float arrays are clipped to `[0, 1]` before scaling, while integer arrays are clipped to `[0, 255]` without being multiplied again.

Added regression tests for:

- normalized float tensor conversion through `to_raw()`
- normalized float tensor conversion through `to_string()`
- uint8 NumPy arrays preserving their original values
- NumPy array input still working when `torch` import fails

Tested with:

```bash
PYTHONPATH=src python -m pytest \
  tests/test_types.py::TestAgentImage::test_from_tensor_is_not_inverted \
  tests/test_types.py::TestAgentImage::test_from_tensor_to_string_is_not_inverted \
  tests/test_types.py::TestAgentImage::test_from_numpy_array_preserves_uint8_values \
  tests/test_types.py::TestAgentImage::test_from_numpy_array_without_torch \
  -q

git diff --check
```

Result: `4 passed` for the targeted regression tests. Running the full `TestAgentImage` class locally also executes these tests, but two pre-existing tests require the `pytest-datadir` fixture, which is not installed in my local environment.

`python -m ruff check src/smolagents/agent_types.py tests/test_types.py` could not be run locally because `ruff` is not installed in this Python environment.