### PR TITLE
docs: replace broken tool Space link

### DIFF
--- a/docs/source/en/tutorials/tools.md
+++ b/docs/source/en/tutorials/tools.md
@@ -72,9 +72,7 @@ For the push to Hub to work, your tool will need to respect some rules:
 - If you subclass the `__init__` method, you can give it no other argument than `self`. This is because arguments set during a specific tool instance's initialization are hard to track, which prevents from sharing them properly to the hub. And anyway, the idea of making a specific class is that you can already set class attributes for anything you need to hard-code (just set `your_variable=(...)` directly under the `class YourTool(Tool):` line). And of course you can still create a class attribute anywhere in your code by assigning stuff to `self.your_variable`.
 
 
-Once your tool is pushed to Hub, you can visualize it. [Here](https://huggingface.co/spaces/m-ric/hf-model-downloads) is the `model_downloads_tool` that I've pushed. It has a nice gradio interface.
-
-When diving into the tool files, you can find that all the tool's logic is under [tool.py](https://huggingface.co/spaces/m-ric/hf-model-downloads/blob/main/tool.py). That is where you can inspect a tool shared by someone else.
+Once your tool is pushed to Hub, you can inspect it. The [`model_downloads_tool` source](https://huggingface.co/spaces/m-ric/hf-model-downloads/blob/main/tool.py) contains all of the tool's logic and shows how to inspect a tool shared by someone else.
 
 Then you can load the tool with [`load_tool`] or create it with [`~Tool.from_hub`] and pass it to the `tools` parameter in your agent.
 Since running tools means running custom code, you need to make sure you trust the repository, thus we require to pass `trust_remote_code=True` to load a tool from the Hub.
@@ -409,4 +407,3 @@ agent.run("Please draw me a picture of rivers and lakes.")
 ```
 
 To speed up the start, tools are loaded only if called by the agent.
-


### PR DESCRIPTION
## Summary

- Replace the runtime-broken m-ric/hf-model-downloads Space link in docs/source/en/tutorials/tools.md with its stable tool.py source link.
- Keep the tutorial focused on inspecting shared tool source code.

## Why

The linked Space currently reports a Python 3.13 runtime error caused by the missing pyaudioop module, while the source file remains accessible. Sending readers to the source avoids a dead demo and preserves the tutorial's inspection example.

## Validation

- git diff --check
- Confirmed the Space API reports RUNTIME_ERROR with the documented pyaudioop failure.
- Confirmed the replacement tool.py URL returns HTTP 200.

Fixes #2349