### PR TITLE
fix(mcp): support root module imports for mcpadapt package layout (#2576)

### DIFF
--- a/src/smolagents/mcp_client.py
+++ b/src/smolagents/mcp_client.py
@@ -103,8 +103,11 @@ class MCPClient:
         try:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Please install 'mcp' extra to use MCPClient: `pip install 'smolagents[mcp]'`")
+        except ImportError:
+            try:
+                from mcpadapt import MCPAdapt, SmolAgentsAdapter
+            except ImportError:
+                raise ModuleNotFoundError("Please install 'mcp' extra to use MCPClient: `pip install 'smolagents[mcp]'`")
         if isinstance(server_parameters, dict):
             transport = server_parameters.get("transport")
             if transport is None:

--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -1037,9 +1037,13 @@ class ToolCollection:
             from mcpadapt.core import MCPAdapt
             from mcpadapt.smolagents_adapter import SmolAgentsAdapter
         except ImportError:
-            raise ImportError(
-                """Please install 'mcp' extra to use ToolCollection.from_mcp: `pip install 'smolagents[mcp]'`."""
-            )
+            try:
+                # Fallback for mcpadapt >= 2.0 structure
+                from mcpadapt import MCPAdapt, SmolAgentsAdapter
+            except ImportError:
+                raise ImportError(
+                    """Please install 'mcp' extra to use ToolCollection.from_mcp: `pip install 'smolagents[mcp]'`."""
+                )
         if isinstance(server_parameters, dict):
             transport = server_parameters.get("transport")
             if transport is None:


### PR DESCRIPTION
## Summary
- Fixes #2576 by adding fallback import handling for `mcpadapt` when `MCPAdapt` and `SmolAgentsAdapter` are exported at the root module level.
- Ensures compatibility across different package layouts of `mcpadapt`.

## Test Plan
- Verified safe fallback resolution in both `MCPClient` and `ToolCollection.from_mcp`.