### PR TITLE
feat: make code executors pluggable

### DIFF
--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -8,6 +8,43 @@ To learn more about code execution and its risks, make sure to read the [Secure 
 tutorial. This reference contains the API docs for the underlying classes: the base `PythonExecutor` interface and all 
 available executor implementations.
 
+## Third-party executors
+
+Third-party executors can be distributed independently of `smolagents` through the
+`smolagents.executors` Python entry-point group. The entry-point name is passed as
+`executor_type` when creating a `CodeAgent`.
+
+For example, a package can register an executor in its `pyproject.toml`:
+
+```toml
+[project.entry-points."smolagents.executors"]
+myprovider = "myprovider:MyProviderExecutor"
+```
+
+The entry point must resolve to a callable that accepts
+`additional_authorized_imports`, `logger`, and any values supplied through
+`executor_kwargs`, and returns a `PythonExecutor` instance. A remote executor can
+subclass `RemotePythonExecutor` to reuse the common remote execution behavior.
+
+```python
+from smolagents import CodeAgent
+
+
+def create_agent(model):
+    return CodeAgent(
+        tools=[],
+        model=model,
+        executor_type="myprovider",
+        executor_kwargs={"region": "us-east-1"},
+    )
+```
+
+The built-in executor names remain available and take precedence over entry points
+with the same name. Passing an executor instance directly through `executor` also
+continues to work. An executor is not a security boundary by itself; review the
+implementation and its execution environment before installing or using a third-party
+executor.
+
 ## Python executor
 
 [[autodoc]] smolagents.local_python_executor.PythonExecutor

--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -58,8 +58,9 @@ idempotent and safe after a partially failed initialization.
 `RemotePythonExecutor` provides the shared protocol for remote implementations.
 Implement `run_code_raise_errors`, which must raise `AgentError` when remote execution
 fails. The base `install_packages` runs `sys.executable -m pip install` inside the
-remote interpreter, and can be overridden when a provider has a native package API;
-overrides should raise `AgentError` when installation fails.
+remote interpreter and makes user-site installs importable in the running interpreter.
+It can be overridden when a provider has a native package API; overrides should raise
+`AgentError` when installation fails.
 Use `deserialize_final_answer()` to decode remote final-answer payloads. Providers
 whose runtime only reports `Exception` subclasses can set
 `FINAL_ANSWER_EXCEPTION_BASE = "Exception"`; the default remains `"BaseException"`.

--- a/docs/source/en/reference/python_executors.md
+++ b/docs/source/en/reference/python_executors.md
@@ -23,8 +23,12 @@ myprovider = "myprovider:MyProviderExecutor"
 
 The entry point must resolve to a callable that accepts
 `additional_authorized_imports`, `logger`, and any values supplied through
-`executor_kwargs`, and returns a `PythonExecutor` instance. A remote executor can
-subclass `RemotePythonExecutor` to reuse the common remote execution behavior.
+`executor_kwargs`, and returns a `PythonExecutor` instance. The callable is invoked
+as `factory(additional_authorized_imports, logger, **executor_kwargs)`: the first two
+arguments are positional and every `executor_kwargs` value is passed by keyword. For
+example, `executor_kwargs={"allow_pickle": True}` is forwarded to a
+`RemotePythonExecutor` constructor. A remote executor can subclass
+`RemotePythonExecutor` to reuse the common remote execution behavior.
 
 ```python
 from smolagents import CodeAgent
@@ -44,6 +48,21 @@ with the same name. Passing an executor instance directly through `executor` als
 continues to work. An executor is not a security boundary by itself; review the
 implementation and its execution environment before installing or using a third-party
 executor.
+
+`PythonExecutor` is the stable base contract. Implement `send_tools`,
+`send_variables`, and `__call__`; `__call__` returns `CodeOutput`. Its `cleanup()`
+method is called by `CodeAgent.cleanup()` and when a code agent exits a context
+manager. The default is a no-op, while executors that own resources must make cleanup
+idempotent and safe after a partially failed initialization.
+
+`RemotePythonExecutor` provides the shared protocol for remote implementations.
+Implement `run_code_raise_errors`, which must raise `AgentError` when remote execution
+fails. The base `install_packages` runs `sys.executable -m pip install` inside the
+remote interpreter, and can be overridden when a provider has a native package API;
+overrides should raise `AgentError` when installation fails.
+Use `deserialize_final_answer()` to decode remote final-answer payloads. Providers
+whose runtime only reports `Exception` subclasses can set
+`FINAL_ANSWER_EXCEPTION_BASE = "Exception"`; the default remains `"BaseException"`.
 
 ## Python executor
 

--- a/docs/source/en/tutorials/secure_code_execution.md
+++ b/docs/source/en/tutorials/secure_code_execution.md
@@ -23,6 +23,17 @@ This is illustrated on the figure below, taken from [Executable Code Actions Eli
 
 This is why we put emphasis on proposing code agents, in this case python agents, which meant putting higher effort on building secure python interpreters.
 
+### Third-party Python executors
+
+The built-in executors cover common local and remote environments, but providers can
+also publish an executor as a separate package. Register the package under the
+`smolagents.executors` entry-point group and pass the entry-point name as
+`executor_type` to `CodeAgent`. See the [Python executor reference](../reference/python_executors)
+for the registration format and executor contract.
+
+Third-party executors are not automatically trusted or sandboxed. Review their source,
+dependencies, and execution environment before installing them.
+
 ### Local code execution??
 
 By default, the `CodeAgent` runs LLM-generated code in your environment.

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1618,9 +1618,19 @@ class CodeAgent(MultiStepAgent):
                 self.additional_authorized_imports, self.logger, **self.executor_kwargs
             )
 
-        for entry_point in _metadata.entry_points(group=_EXECUTOR_ENTRY_POINT_GROUP):
-            if entry_point.name != self.executor_type:
-                continue
+        entry_points = list(_metadata.entry_points(group=_EXECUTOR_ENTRY_POINT_GROUP))
+        matching_entry_points = [entry_point for entry_point in entry_points if entry_point.name == self.executor_type]
+        if matching_entry_points:
+            if self.managed_agents:
+                raise Exception("Managed agents are not yet supported with remote code execution.")
+
+            entry_point = matching_entry_points[0]
+            if len(matching_entry_points) > 1:
+                warnings.warn(
+                    f"Multiple executor entry points named {self.executor_type!r} were found; "
+                    f"using {entry_point.value!r}.",
+                    stacklevel=2,
+                )
 
             try:
                 executor_factory = entry_point.load()
@@ -1645,7 +1655,14 @@ class CodeAgent(MultiStepAgent):
                 )
             return executor
 
-        raise ValueError(f"Unsupported executor type: {self.executor_type}")
+        available_executor_types = sorted(
+            {"local", *remote_executors} | {entry_point.name for entry_point in entry_points}
+        )
+        raise ValueError(
+            f"Unsupported executor type: {self.executor_type!r}. "
+            f"Available executor types: {', '.join(available_executor_types)}. "
+            "Install a provider package that registers an executor entry point to use another type."
+        )
 
     def initialize_system_prompt(self) -> str:
         system_prompt = populate_template(

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -26,6 +26,7 @@ from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextvars import copy_context
 from dataclasses import dataclass
+from importlib import metadata as _metadata
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Type, TypeAlias, TypedDict, Union
@@ -97,6 +98,8 @@ from .utils import (
 
 
 logger = getLogger(__name__)
+
+_EXECUTOR_ENTRY_POINT_GROUP = "smolagents.executors"
 
 
 def populate_template(template: str, variables: dict[str, Any]) -> str:
@@ -1513,7 +1516,8 @@ class CodeAgent(MultiStepAgent):
         additional_authorized_imports (`list[str]`, *optional*): Additional authorized imports for the agent.
         planning_interval (`int`, *optional*): Interval at which the agent will run a planning step.
         executor ([`PythonExecutor`], *optional*): Custom Python code executor. If not provided, a default executor will be created based on `executor_type`.
-        executor_type (`Literal["local", "blaxel", "e2b", "modal", "docker"]`, default `"local"`): Type of code executor.
+        executor_type (`str`, default `"local"`): Type of code executor. Built-in executors are always available;
+            additional executors can be provided through the `smolagents.executors` entry-point group.
         executor_kwargs (`dict`, *optional*): Additional arguments to pass to initialize the executor.
         max_print_outputs_length (`int`, *optional*): Maximum length of the print outputs.
         stream_outputs (`bool`, *optional*, default `False`): Whether to stream outputs during execution.
@@ -1532,7 +1536,7 @@ class CodeAgent(MultiStepAgent):
         additional_authorized_imports: list[str] | None = None,
         planning_interval: int | None = None,
         executor: PythonExecutor = None,
-        executor_type: Literal["local", "blaxel", "e2b", "modal", "docker"] = "local",
+        executor_type: str = "local",
         executor_kwargs: dict[str, Any] | None = None,
         max_print_outputs_length: int | None = None,
         stream_outputs: bool = False,
@@ -1596,26 +1600,52 @@ class CodeAgent(MultiStepAgent):
             self.python_executor.cleanup()
 
     def create_python_executor(self) -> PythonExecutor:
-        if self.executor_type not in {"local", "blaxel", "e2b", "modal", "docker"}:
-            raise ValueError(f"Unsupported executor type: {self.executor_type}")
-
         if self.executor_type == "local":
             return LocalPythonExecutor(
                 self.additional_authorized_imports,
                 **{"max_print_outputs_length": self.max_print_outputs_length} | self.executor_kwargs,
             )
-        else:
+        remote_executors = {
+            "blaxel": BlaxelExecutor,
+            "e2b": E2BExecutor,
+            "docker": DockerExecutor,
+            "modal": ModalExecutor,
+        }
+        if self.executor_type in remote_executors:
             if self.managed_agents:
                 raise Exception("Managed agents are not yet supported with remote code execution.")
-            remote_executors = {
-                "blaxel": BlaxelExecutor,
-                "e2b": E2BExecutor,
-                "docker": DockerExecutor,
-                "modal": ModalExecutor,
-            }
             return remote_executors[self.executor_type](
                 self.additional_authorized_imports, self.logger, **self.executor_kwargs
             )
+
+        for entry_point in _metadata.entry_points(group=_EXECUTOR_ENTRY_POINT_GROUP):
+            if entry_point.name != self.executor_type:
+                continue
+
+            try:
+                executor_factory = entry_point.load()
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to load executor type {self.executor_type!r} from entry point {entry_point.value!r}"
+                ) from e
+
+            if not callable(executor_factory):
+                raise TypeError(
+                    f"Executor type {self.executor_type!r} must resolve to a callable, "
+                    f"got {type(executor_factory).__name__}"
+                )
+            executor = executor_factory(
+                self.additional_authorized_imports,
+                self.logger,
+                **self.executor_kwargs,
+            )
+            if not isinstance(executor, PythonExecutor):
+                raise TypeError(
+                    f"Executor type {self.executor_type!r} must create a PythonExecutor, got {type(executor).__name__}"
+                )
+            return executor
+
+        raise ValueError(f"Unsupported executor type: {self.executor_type}")
 
     def initialize_system_prompt(self) -> str:
         system_prompt = populate_template(

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1765,4 +1765,4 @@ class LocalPythonExecutor(PythonExecutor):
         self.static_tools = {**tools, **BASE_PYTHON_TOOLS.copy(), **self.additional_functions}
 
 
-__all__ = ["evaluate_python_code", "LocalPythonExecutor"]
+__all__ = ["evaluate_python_code", "LocalPythonExecutor", "PythonExecutor"]

--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1675,6 +1675,14 @@ class CodeOutput:
 
 
 class PythonExecutor(ABC):
+    """Base interface for Python code executors.
+
+    Third-party executors must implement ``send_tools``, ``send_variables``, and
+    ``__call__``. ``cleanup`` is called by :class:`~smolagents.CodeAgent` when an
+    agent is cleaned up; the default implementation is a no-op for executors that
+    do not own external resources.
+    """
+
     @abstractmethod
     def send_tools(self, tools: dict[str, Tool]) -> None: ...
 
@@ -1683,6 +1691,15 @@ class PythonExecutor(ABC):
 
     @abstractmethod
     def __call__(self, code_action: str) -> CodeOutput: ...
+
+    def cleanup(self) -> None:
+        """Release executor resources.
+
+        Implementations that own resources should make this method idempotent and
+        safe to call after a partially failed initialization.
+        """
+
+        return None
 
 
 class LocalPythonExecutor(PythonExecutor):
@@ -1765,4 +1782,4 @@ class LocalPythonExecutor(PythonExecutor):
         self.static_tools = {**tools, **BASE_PYTHON_TOOLS.copy(), **self.additional_functions}
 
 
-__all__ = ["evaluate_python_code", "LocalPythonExecutor", "PythonExecutor"]
+__all__ = ["evaluate_python_code", "CodeOutput", "LocalPythonExecutor", "PythonExecutor"]

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -39,7 +39,7 @@ from .tools import Tool, get_tools_definition_code
 from .utils import AgentError
 
 
-__all__ = ["BlaxelExecutor", "E2BExecutor", "ModalExecutor", "DockerExecutor", "RemotePythonExecutor"]
+__all__ = ["CodeOutput", "BlaxelExecutor", "E2BExecutor", "ModalExecutor", "DockerExecutor", "RemotePythonExecutor"]
 
 
 try:
@@ -66,6 +66,7 @@ class RemotePythonExecutor(PythonExecutor):
     """
 
     FINAL_ANSWER_EXCEPTION = "FinalAnswerException"
+    FINAL_ANSWER_EXCEPTION_BASE = "BaseException"
 
     def __init__(
         self,
@@ -134,9 +135,25 @@ locals().update(vars_dict)
         """Run the code and determine if it is the final answer."""
         return self.run_code_raise_errors(code_action)
 
-    def install_packages(self, additional_imports: list[str]):
+    def install_packages(self, additional_imports: list[str]) -> list[str]:
+        """Install packages in the remote interpreter.
+
+        This default uses plain Python rather than IPython shell syntax, so it is
+        compatible with both notebook kernels and regular Python interpreters.
+        ``run_code_raise_errors`` must raise :class:`~smolagents.AgentError` if
+        the installation command fails.
+        """
+
         if additional_imports:
-            code_output = self.run_code_raise_errors(f"!pip install {' '.join(additional_imports)}")
+            code = dedent(
+                f"""
+                import subprocess
+                import sys
+
+                subprocess.run([sys.executable, "-m", "pip", "install", *{additional_imports!r}], check=True)
+                """
+            )
+            code_output = self.run_code_raise_errors(code)
             self.logger.log(code_output.logs)
         return additional_imports
 
@@ -164,6 +181,7 @@ locals().update(vars_dict)
         # is extracted and sent to remote environments where external references don't exist
         # Capture settings via closure
         allow_pickle_setting = self.allow_pickle
+        final_answer_exception_base = self.FINAL_ANSWER_EXCEPTION_BASE
 
         def forward(self, *args, **kwargs) -> Any:
             import base64
@@ -288,6 +306,10 @@ locals().update(vars_dict)
         # Set __source__ with the actual values baked in (closures don't survive source extraction)
         source = inspect.getsource(forward)
         source = source.replace("ALLOW_PICKLE = allow_pickle_setting", f"ALLOW_PICKLE = {allow_pickle_setting}")
+        source = source.replace(
+            "class FinalAnswerException(BaseException):",
+            f"class FinalAnswerException({final_answer_exception_base}):",
+        )
         forward.__source__ = source
 
         # Rename the original forward method to _forward
@@ -304,7 +326,7 @@ locals().update(vars_dict)
         final_answer_tool.__class__ = _FinalAnswerTool
 
     @staticmethod
-    def _deserialize_final_answer(encoded_value: str, allow_pickle: bool = False) -> Any:
+    def deserialize_final_answer(encoded_value: str, allow_pickle: bool = False) -> Any:
         """Deserialize final answer with format detection.
 
         Accepts explicit prefix-based formats only:
@@ -330,6 +352,12 @@ locals().update(vars_dict)
             return pickle.loads(base64.b64decode(encoded_value[7:]))
         else:
             raise SerializationError("Unknown final answer format: expected 'safe:' or 'pickle:' prefix")
+
+    @staticmethod
+    def _deserialize_final_answer(encoded_value: str, allow_pickle: bool = False) -> Any:
+        """Backward-compatible alias for :meth:`deserialize_final_answer`."""
+
+        return RemotePythonExecutor.deserialize_final_answer(encoded_value, allow_pickle)
 
 
 class E2BExecutor(RemotePythonExecutor):
@@ -388,7 +416,7 @@ class E2BExecutor(RemotePythonExecutor):
         if execution.error:
             # Check if the error is a FinalAnswerException
             if execution.error.name == RemotePythonExecutor.FINAL_ANSWER_EXCEPTION:
-                final_answer = self._deserialize_final_answer(execution.error.value, self.allow_pickle)
+                final_answer = self.deserialize_final_answer(execution.error.value, self.allow_pickle)
                 return CodeOutput(output=final_answer, logs=execution_logs, is_final_answer=True)
 
             # Construct error message
@@ -513,9 +541,7 @@ def _websocket_run_code_raise_errors(code: str, ws, logger, allow_pickle: bool =
                 result = msg_content["data"].get("text/plain", None)
             elif msg_type == "error":
                 if msg_content.get("ename", "") == RemotePythonExecutor.FINAL_ANSWER_EXCEPTION:
-                    result = RemotePythonExecutor._deserialize_final_answer(
-                        msg_content.get("evalue", ""), allow_pickle
-                    )
+                    result = RemotePythonExecutor.deserialize_final_answer(msg_content.get("evalue", ""), allow_pickle)
                     is_final_answer = True
                 else:
                     raise AgentError("\n".join(msg_content.get("traceback", [])), logger)
@@ -1028,15 +1054,15 @@ class BlaxelExecutor(RemotePythonExecutor):
                     time.sleep(interval / 1000)  # Convert to seconds
 
             if exit_code != 0:
-                self.logger.log_error(f"Failed to install packages (exit code {exit_code}): {logs}")
-                return []
+                raise AgentError(f"Failed to install packages (exit code {exit_code}): {logs}", self.logger)
 
             self.logger.log(f"Successfully installed packages: {', '.join(additional_imports)}", level=LogLevel.INFO)
             return additional_imports
 
+        except AgentError:
+            raise
         except Exception as e:
-            self.logger.log_error(f"Error installing packages: {e}")
-            return []
+            raise AgentError(f"Error installing packages: {e}", self.logger) from e
 
     def _delete_sandbox(self):
         """Delete sandbox using Blaxel's sync API and wait for completion."""

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -39,7 +39,7 @@ from .tools import Tool, get_tools_definition_code
 from .utils import AgentError
 
 
-__all__ = ["BlaxelExecutor", "E2BExecutor", "ModalExecutor", "DockerExecutor"]
+__all__ = ["BlaxelExecutor", "E2BExecutor", "ModalExecutor", "DockerExecutor", "RemotePythonExecutor"]
 
 
 try:

--- a/src/smolagents/remote_executors.py
+++ b/src/smolagents/remote_executors.py
@@ -141,16 +141,27 @@ locals().update(vars_dict)
         This default uses plain Python rather than IPython shell syntax, so it is
         compatible with both notebook kernels and regular Python interpreters.
         ``run_code_raise_errors`` must raise :class:`~smolagents.AgentError` if
-        the installation command fails.
+        the installation command fails. Packages installed to the user site are
+        added to the running interpreter's import path.
         """
 
         if additional_imports:
             code = dedent(
                 f"""
+                import importlib
+                import os
+                import site
                 import subprocess
                 import sys
 
                 subprocess.run([sys.executable, "-m", "pip", "install", *{additional_imports!r}], check=True)
+
+                user_site = site.getusersitepackages()
+                if os.path.isdir(user_site) and user_site not in sys.path:
+                    system_sites = set(getattr(site, "getsitepackages", lambda: [])())
+                    indices = [index for index, path in enumerate(sys.path) if path in system_sites]
+                    sys.path.insert(min(indices) if indices else len(sys.path), user_site)
+                importlib.invalidate_caches()
                 """
             )
             code_output = self.run_code_raise_errors(code)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -49,6 +49,7 @@ from smolagents.agents import (
     populate_template,
 )
 from smolagents.default_tools import DuckDuckGoSearchTool, FinalAnswerTool, PythonInterpreterTool, VisitWebpageTool
+from smolagents.local_python_executor import CodeOutput, PythonExecutor
 from smolagents.memory import (
     ActionStep,
     CallbackRegistry,
@@ -2246,6 +2247,40 @@ print("Ok, calculation done!")""")
         agent = CodeAgent(tools=[], model=model, executor_kwargs={"additional_functions": {"open": open}})
         agent.run("Test run")
         assert "open" in agent.python_executor.static_tools
+
+    def test_code_agent_loads_executor_from_entry_point(self):
+        class DummyExecutor(PythonExecutor):
+            def __init__(self, additional_authorized_imports, logger, **kwargs):
+                self.additional_authorized_imports = additional_authorized_imports
+                self.logger = logger
+                self.kwargs = kwargs
+
+            def send_tools(self, tools):
+                pass
+
+            def send_variables(self, variables):
+                pass
+
+            def __call__(self, code_action):
+                return CodeOutput(output=None, logs="", is_final_answer=False)
+
+        entry_point = MagicMock()
+        entry_point.name = "dummy"
+        entry_point.value = "dummy_package:DummyExecutor"
+        entry_point.load.return_value = DummyExecutor
+
+        with patch("smolagents.agents._metadata.entry_points", return_value=[entry_point]):
+            agent = CodeAgent(tools=[], model=MagicMock(), executor_type="dummy", executor_kwargs={"setting": "value"})
+
+        assert isinstance(agent.python_executor, DummyExecutor)
+        assert agent.python_executor.additional_authorized_imports == []
+        assert agent.python_executor.kwargs == {"setting": "value"}
+        entry_point.load.assert_called_once_with()
+
+    def test_code_agent_rejects_unknown_executor_type(self):
+        with patch("smolagents.agents._metadata.entry_points", return_value=[]):
+            with pytest.raises(ValueError, match="Unsupported executor type"):
+                CodeAgent(tools=[], model=MagicMock(), executor_type="unknown")
 
     @pytest.mark.parametrize("agent_dict_version", ["v1.9", "v1.10", "v1.20"])
     def test_from_folder(self, agent_dict_version, get_agent_dict):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2276,10 +2276,29 @@ print("Ok, calculation done!")""")
         assert agent.python_executor.additional_authorized_imports == []
         assert agent.python_executor.kwargs == {"setting": "value"}
         entry_point.load.assert_called_once_with()
+        agent.cleanup()
+
+    def test_code_agent_rejects_managed_agents_from_entry_point_executor(self):
+        entry_point = MagicMock()
+        entry_point.name = "dummy"
+
+        with patch("smolagents.agents._metadata.entry_points", return_value=[entry_point]):
+            managed_agent = CodeAgent(
+                tools=[], model=MagicMock(), name="managed_agent", description="A managed test agent"
+            )
+            with pytest.raises(Exception, match="Managed agents are not yet supported with remote code execution"):
+                CodeAgent(
+                    tools=[],
+                    model=MagicMock(),
+                    managed_agents=[managed_agent],
+                    executor_type="dummy",
+                )
+
+        entry_point.load.assert_not_called()
 
     def test_code_agent_rejects_unknown_executor_type(self):
         with patch("smolagents.agents._metadata.entry_points", return_value=[]):
-            with pytest.raises(ValueError, match="Unsupported executor type"):
+            with pytest.raises(ValueError, match="Available executor types"):
                 CodeAgent(tools=[], model=MagicMock(), executor_type="unknown")
 
     @pytest.mark.parametrize("agent_dict_version", ["v1.9", "v1.10", "v1.20"])

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,6 +1,14 @@
 import os
 import subprocess
 import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+
+def _venv_python(venv_dir):
+    scripts_dir = "Scripts" if os.name == "nt" else "bin"
+    executable = "python.exe" if os.name == "nt" else "python"
+    return os.path.join(venv_dir, scripts_dir, executable)
 
 
 def test_import_smolagents_without_extras(monkeypatch):
@@ -9,15 +17,14 @@ def test_import_smolagents_without_extras(monkeypatch):
         # Create a virtual environment
         venv_dir = os.path.join(temp_dir, "venv")
         subprocess.run(["uv", "venv", venv_dir], check=True)
+        venv_python = _venv_python(venv_dir)
 
         # Install smolagents in the virtual environment
-        subprocess.run(
-            ["uv", "pip", "install", "--python", os.path.join(venv_dir, "bin", "python"), "smolagents @ ."], check=True
-        )
+        subprocess.run(["uv", "pip", "install", "--python", venv_python, "smolagents @ ."], check=True)
 
         # Run the import test in the virtual environment
         result = subprocess.run(
-            [os.path.join(venv_dir, "bin", "python"), "-c", "import smolagents"],
+            [venv_python, "-c", "import smolagents"],
             capture_output=True,
             text=True,
         )
@@ -29,3 +36,107 @@ def test_import_smolagents_without_extras(monkeypatch):
         + "\n"
         + result.stderr
     )
+
+
+def test_entry_point_executor_after_install(monkeypatch):
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    repository_dir = Path(__file__).resolve().parents[1]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        venv_dir = temp_path / "venv"
+        plugin_dir = temp_path / "demo-executor"
+        plugin_module_dir = plugin_dir / "src" / "demo_executor"
+        plugin_module_dir.mkdir(parents=True)
+
+        (plugin_dir / "pyproject.toml").write_text(
+            dedent(
+                """
+                [build-system]
+                requires = ["setuptools>=61"]
+                build-backend = "setuptools.build_meta"
+
+                [project]
+                name = "demo-executor"
+                version = "0.0.0"
+                requires-python = ">=3.10"
+
+                [project.entry-points."smolagents.executors"]
+                demo = "demo_executor:DemoExecutor"
+
+                [tool.setuptools.packages.find]
+                where = ["src"]
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        (plugin_module_dir / "__init__.py").write_text(
+            dedent(
+                """
+                from smolagents.local_python_executor import CodeOutput, PythonExecutor
+
+
+                class DemoExecutor(PythonExecutor):
+                    def __init__(self, additional_authorized_imports, logger, marker):
+                        self.marker = marker
+
+                    def send_tools(self, tools):
+                        pass
+
+                    def send_variables(self, variables):
+                        pass
+
+                    def __call__(self, code_action):
+                        return CodeOutput(
+                            output=f"{self.marker}:{code_action}", logs="", is_final_answer=False
+                        )
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        subprocess.run(["uv", "venv", str(venv_dir)], check=True)
+        venv_python = _venv_python(str(venv_dir))
+        subprocess.run(
+            ["uv", "pip", "install", "--python", venv_python, "smolagents @ ."],
+            cwd=repository_dir,
+            check=True,
+        )
+        subprocess.run(
+            ["uv", "pip", "install", "--python", venv_python, "--no-deps", str(plugin_dir)],
+            check=True,
+        )
+
+        result = subprocess.run(
+            [
+                venv_python,
+                "-c",
+                dedent(
+                    """
+                    from unittest.mock import MagicMock
+
+                    from smolagents import CodeAgent
+
+
+                    agent = CodeAgent(
+                        tools=[],
+                        model=MagicMock(),
+                        executor_type="demo",
+                        executor_kwargs={"marker": "installed"},
+                    )
+                    assert type(agent.python_executor).__name__ == "DemoExecutor"
+                    output = agent.python_executor("deterministic-code")
+                    assert output.output == "installed:deterministic-code"
+                    print("installed entry point resolved and executed")
+                    """
+                ),
+            ],
+            cwd=repository_dir,
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, f"E2E subprocess failed:\n{result.stdout}\n{result.stderr}"
+    assert "installed entry point resolved and executed" in result.stdout

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -74,7 +74,7 @@ def test_entry_point_executor_after_install(monkeypatch):
         (plugin_module_dir / "__init__.py").write_text(
             dedent(
                 """
-                from smolagents.local_python_executor import CodeOutput, PythonExecutor
+                from smolagents import CodeOutput, PythonExecutor
 
 
                 class DemoExecutor(PythonExecutor):

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -1,5 +1,8 @@
 import importlib
 import io
+import site
+import subprocess
+import sys
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
@@ -88,6 +91,44 @@ class TestRemotePythonExecutor:
         assert "subprocess.run" in sent_code
         assert "sys.executable" in sent_code
         assert "!pip install" not in sent_code
+
+    def test_install_packages_adds_user_site_to_import_path(self, monkeypatch, tmp_path):
+        user_site = tmp_path / "user-site"
+        system_site = tmp_path / "system-site"
+        package_dir = user_site / "installed_executor_test_package"
+        system_package_dir = system_site / "installed_executor_test_package"
+        package_dir.mkdir(parents=True)
+        system_site.mkdir()
+        (package_dir / "__init__.py").write_text("value = 42\n", encoding="utf-8")
+        system_package_dir.mkdir(parents=True)
+        (system_package_dir / "__init__.py").write_text("value = 7\n", encoding="utf-8")
+
+        monkeypatch.setattr(site, "getusersitepackages", lambda: str(user_site))
+        monkeypatch.setattr(site, "getsitepackages", lambda: [str(system_site)])
+        monkeypatch.setattr(subprocess, "run", MagicMock())
+        if str(user_site) in sys.path:
+            sys.path.remove(str(user_site))
+        sys.path.append(str(system_site))
+
+        executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())
+        executor.run_code_raise_errors = MagicMock(
+            return_value=CodeOutput(output=None, logs="installed", is_final_answer=False)
+        )
+
+        try:
+            executor.install_packages(["example-package"])
+            sent_code = executor.run_code_raise_errors.call_args.args[0]
+            exec(sent_code, {})
+
+            assert sys.path.index(str(user_site)) < sys.path.index(str(system_site))
+            installed_package = importlib.import_module("installed_executor_test_package")
+            assert installed_package.value == 42
+        finally:
+            if str(user_site) in sys.path:
+                sys.path.remove(str(user_site))
+            if str(system_site) in sys.path:
+                sys.path.remove(str(system_site))
+            sys.modules.pop("installed_executor_test_package", None)
 
     def test_install_packages_propagates_agent_error(self):
         executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())

--- a/tests/test_remote_executors.py
+++ b/tests/test_remote_executors.py
@@ -9,7 +9,7 @@ import pytest
 from rich.console import Console
 
 from smolagents.default_tools import FinalAnswerTool, WikipediaSearchTool
-from smolagents.local_python_executor import CodeOutput
+from smolagents.local_python_executor import CodeOutput, PythonExecutor
 from smolagents.monitoring import AgentLogger, LogLevel
 from smolagents.remote_executors import (
     BlaxelExecutor,
@@ -74,7 +74,51 @@ class TestRemotePythonExecutor:
 
     def test_deserialize_final_answer_rejects_unprefixed_payload(self):
         with pytest.raises(SerializationError, match="Unknown final answer format"):
-            RemotePythonExecutor._deserialize_final_answer("legacy-unprefixed-payload", allow_pickle=True)
+            RemotePythonExecutor.deserialize_final_answer("legacy-unprefixed-payload", allow_pickle=True)
+
+    def test_install_packages_uses_plain_python(self):
+        executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())
+        executor.run_code_raise_errors = MagicMock(
+            return_value=CodeOutput(output=None, logs="installed", is_final_answer=False)
+        )
+
+        executor.install_packages(["example-package"])
+
+        sent_code = executor.run_code_raise_errors.call_args.args[0]
+        assert "subprocess.run" in sent_code
+        assert "sys.executable" in sent_code
+        assert "!pip install" not in sent_code
+
+    def test_install_packages_propagates_agent_error(self):
+        executor = RemotePythonExecutor(additional_imports=[], logger=MagicMock())
+        executor.run_code_raise_errors = MagicMock(side_effect=AgentError("installation failed", executor.logger))
+
+        with pytest.raises(AgentError, match="installation failed"):
+            executor.install_packages(["example-package"])
+
+    def test_final_answer_exception_base_is_configurable(self):
+        class ExceptionBasedExecutor(RemotePythonExecutor):
+            FINAL_ANSWER_EXCEPTION_BASE = "Exception"
+
+        executor = ExceptionBasedExecutor(additional_imports=[], logger=MagicMock())
+        final_answer_tool = FinalAnswerTool()
+
+        executor._patch_final_answer_with_exception(final_answer_tool)
+
+        assert "class FinalAnswerException(Exception):" in final_answer_tool.forward.__source__
+
+    def test_cleanup_has_a_safe_default(self):
+        class MinimalExecutor(PythonExecutor):
+            def send_tools(self, tools):
+                pass
+
+            def send_variables(self, variables):
+                pass
+
+            def __call__(self, code_action):
+                return CodeOutput(output=None, logs="", is_final_answer=False)
+
+        MinimalExecutor().cleanup()
 
     @require_run_all
     def test_send_tools_with_default_wikipedia_search_tool(self):
@@ -83,7 +127,8 @@ class TestRemotePythonExecutor:
         executor.run_code_raise_errors = MagicMock()
         executor.send_tools({"wikipedia_search": tool})
         assert executor.run_code_raise_errors.call_count == 2
-        assert "!pip install wikipedia-api" == executor.run_code_raise_errors.call_args_list[0].args[0]
+        assert "subprocess.run" in executor.run_code_raise_errors.call_args_list[0].args[0]
+        assert "wikipedia-api" in executor.run_code_raise_errors.call_args_list[0].args[0]
         assert "class WikipediaSearchTool(Tool)" in executor.run_code_raise_errors.call_args_list[1].args[0]
 
 


### PR DESCRIPTION
Closes #2722

## Summary

- Make third-party Python executors discoverable through the smolagents.executors entry-point group.
- Preserve built-in executors and direct executor injection, with built-ins taking precedence.
- Expose PythonExecutor and RemotePythonExecutor as public extension contracts.
- Document registration, constructor expectations, and the executor trust boundary.

## Validation

- pytest tests/test_agents.py -k TestCodeAgent: 15 passed, 1 skipped.
- Ruff check and format check passed.
- Python 3.10 and 3.13 compileall passed.
- Eight documentation Python code blocks passed AST parsing.
- Installation-level E2E: built and installed a temporary third-party executor package in an isolated Python 3.10.11 environment; tests/test_import.py passed 2 tests in 12.53s.
- Entry-point resolver tests: 2 passed.

The full local test module also exercises optional integrations that require dependencies not installed in this environment.