### PR TITLE
fix(memory): make ActionStep.dict() JSON-serialize observations_images

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Type
 
 from smolagents.models import ChatMessage, MessageRole, get_dict_from_nested_dataclasses
 from smolagents.monitoring import AgentLogger, LogLevel, Timing, TokenUsage
-from smolagents.utils import AgentError, make_json_serializable
+from smolagents.utils import AgentError, encode_image_base64, make_json_serializable
 
 
 if TYPE_CHECKING:
@@ -81,7 +81,10 @@ class ActionStep(MemoryStep):
             "model_output": self.model_output,
             "code_action": self.code_action,
             "observations": self.observations,
-            "observations_images": [image.tobytes() for image in self.observations_images]
+            "observations_images": [
+                {"mode": image.mode, "size": image.size, "data": encode_image_base64(image)}
+                for image in self.observations_images
+            ]
             if self.observations_images
             else None,
             "action_output": make_json_serializable(self.action_output),

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,3 +1,5 @@
+import base64
+import io
 import json
 
 import pytest
@@ -111,6 +113,18 @@ def test_action_step_dict():
     assert action_step_dict["observations"] == "This is a nice observation"
 
     assert "observations_images" in action_step_dict
+    # The whole dict must be JSON-serializable, which used to fail because observations_images
+    # held raw bytes from PIL.Image.tobytes().
+    serialized = json.dumps(action_step_dict)
+    reloaded = json.loads(serialized)
+    assert len(reloaded["observations_images"]) == 1
+    image_entry = reloaded["observations_images"][0]
+    assert image_entry["mode"] == "RGB"
+    assert image_entry["size"] == [100, 100]
+    # The base64 payload must decode back to PNG bytes that PIL can reopen as the original image.
+    decoded = Image.open(io.BytesIO(base64.b64decode(image_entry["data"])))
+    assert decoded.mode == "RGB"
+    assert decoded.size == (100, 100)
 
     assert "action_output" in action_step_dict
     assert action_step_dict["action_output"] == "Output"


### PR DESCRIPTION
## What changed

`ActionStep.dict()` in `src/smolagents/memory.py` no longer puts raw `bytes` into `observations_images`. Each `PIL.Image.Image` in the list is now encoded as `{"mode": image.mode, "size": image.size, "data": <base64 PNG>}`, using the existing `encode_image_base64()` helper from `smolagents/utils.py`.

## Why

`ActionStep.dict()` is meant to produce a fully JSON-serializable representation of a step (every other field already goes through `make_json_serializable()` or an explicit conversion). `observations_images` was the one exception:

```python
"observations_images": [image.tobytes() for image in self.observations_images]
```

`image.tobytes()` returns raw Python `bytes`, which `json.dumps()` cannot serialize:

```python
>>> import json
>>> from PIL import Image
>>> json.dumps(Image.new("RGB", (2, 2)).tobytes())
TypeError: Object of type bytes is not JSON serializable
```

`ActionStep.dict()` backs `AgentMemory.get_full_steps()` / `get_succinct_steps()`, which `agent.run(..., return_full_result=True)` returns via `RunResult.steps`. Any step with `observations_images` set (e.g. from `vision_web_browser.py`) breaks the moment a caller does `json.dumps(steps)` or writes it to a JSON log/replay file, even though that is the method's whole purpose.

Separately, `tobytes()` also drops the image's size and mode, so even a caller that base64-encodes the raw bytes itself has no way to reconstruct the image. The fix stores `mode` and `size` alongside the base64 PNG data so the image round-trips.

This matches the pattern `SafeSerializer.to_json_safe()` already uses for PIL images elsewhere in the codebase (`src/smolagents/serialization.py`), and reuses `encode_image_base64()`, which is already used for encoding images sent to model APIs (`src/smolagents/utils.py`).

## How to test

```python
from PIL import Image
from smolagents.memory import ActionStep
from smolagents.monitoring import Timing
import json

step = ActionStep(step_number=1, timing=Timing(start_time=0.0, end_time=1.0), observations_images=[Image.new("RGB", (10, 10))])
json.dumps(step.dict())  # no longer raises TypeError
```

Added a regression check to `tests/test_memory.py::test_action_step_dict`: it JSON-round-trips the full `action_step.dict()` output, checks the `mode`/`size` fields, and reopens the base64 payload with PIL to confirm it decodes back to an image with the original mode and size. This fails on the current `tobytes()` code (`TypeError: Object of type bytes is not JSON serializable`) and passes with the fix.

Fixes #2725
