### PR TITLE
fix(cli): accept OpenAIServerModel in load_model()'s dispatch

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -192,7 +192,7 @@ def load_model(
     api_key: str | None = None,
     provider: str | None = None,
 ) -> Model:
-    if model_type == "OpenAIModel":
+    if model_type in ("OpenAIModel", "OpenAIServerModel"):
         return OpenAIModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
             api_base=api_base or "https://api.fireworks.ai/inference/v1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,19 @@ def test_load_model_openai_model(set_env_vars):
     assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
 
 
+def test_load_model_openai_server_model_alias(set_env_vars):
+    # interactive_mode() offers "OpenAIServerModel" as a model type choice, and
+    # OpenAIServerModel is a real exported alias for OpenAIModel (models.py), so
+    # load_model() must accept it too instead of raising "Unsupported model type".
+    with patch("openai.OpenAI") as MockOpenAI:
+        model = load_model("OpenAIServerModel", "test_model_id")
+    assert isinstance(model, OpenAIModel)
+    assert model.model_id == "test_model_id"
+    assert MockOpenAI.call_count == 1
+    assert MockOpenAI.call_args.kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
+    assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
+
+
 def test_load_model_litellm_model():
     model = load_model("LiteLLMModel", "test_model_id", api_key="test_api_key", api_base="https://api.test.com")
     assert isinstance(model, LiteLLMModel)


### PR DESCRIPTION
## What changed

`load_model()` in `src/smolagents/cli.py` now accepts `model_type == "OpenAIServerModel"` alongside `"OpenAIModel"`, both routing to `OpenAIModel(...)`.

## Why

`interactive_mode()` restricts its model type prompt to exactly 4 choices:

```python
model_type = Prompt.ask(
    "[bold]Model type[/]",
    default="InferenceClientModel",
    choices=["InferenceClientModel", "OpenAIServerModel", "LiteLLMModel", "TransformersModel"],
)
```

but `load_model()`, which every path (interactive and `--model-type`) funnels through, only matched `"OpenAIModel"`:

```python
if model_type == "OpenAIModel":
    return OpenAIModel(...)
...
else:
    raise ValueError(f"Unsupported model type: {model_type}")
```

Selecting `"OpenAIServerModel"`, one of only 4 options offered by the tool's own interactive prompt, always fell into the `else` branch and raised `ValueError: Unsupported model type: OpenAIServerModel`, after the user had already answered every other interactive prompt (action type, tools, model id, and optionally provider/api-base/api-key/imports/task). The same happens non-interactively with `--model-type OpenAIServerModel`, since `argparse` places no `choices=` restriction on that flag.

`OpenAIServerModel` is not a typo: it's a real, exported alias (`src/smolagents/models.py:1796`, `OpenAIServerModel = OpenAIModel`, listed in `__all__`). `load_model()` simply never learned the alias name that `interactive_mode()` advertises.

## How to test

```
smolagent
# action type: code
# tools: web_search
# model type: OpenAIServerModel   <- offered as a valid choice
# ... answer remaining prompts ...
```
Before the fix this crashed with `ValueError: Unsupported model type: OpenAIServerModel` at the very end. After the fix it loads an `OpenAIModel` instance normally, same as choosing `OpenAIModel` would.

Added `test_load_model_openai_server_model_alias` to `tests/test_cli.py`, mirroring the existing `test_load_model_openai_model` test but calling `load_model("OpenAIServerModel", ...)`. It fails on the current code (`ValueError: Unsupported model type: OpenAIServerModel`) and passes with the fix.

Fixes #2726
