### PR TITLE
fix(cli): support OpenAIServerModel in load_model

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -192,7 +192,7 @@ def load_model(
     api_key: str | None = None,
     provider: str | None = None,
 ) -> Model:
-    if model_type == "OpenAIModel":
+    if model_type in ("OpenAIModel", "OpenAIServerModel"):
         return OpenAIModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
             api_base=api_base or "https://api.fireworks.ai/inference/v1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,12 @@ def test_load_model_openai_model(set_env_vars):
     assert MockOpenAI.call_args.kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
     assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
 
+    with patch("openai.OpenAI") as MockOpenAI:
+        model_server = load_model("OpenAIServerModel", "test_model_id")
+    assert isinstance(model_server, OpenAIModel)
+    assert model_server.model_id == "test_model_id"
+    assert MockOpenAI.call_count == 1
+
 
 def test_load_model_litellm_model():
     model = load_model("LiteLLMModel", "test_model_id", api_key="test_api_key", api_base="https://api.test.com")


### PR DESCRIPTION
### What does this PR do?

Resolves #2726.

The CLI interactive mode (`interactive_mode`) offers `OpenAIServerModel` as one of the 4 model choices. However, `load_model()` previously only checked for `"OpenAIModel"`, raising an unsupported model type error when `OpenAIServerModel` was selected.

This PR:
- Adds `OpenAIServerModel` to `load_model()` check alongside `OpenAIModel`.
- Adds a unit test in `tests/test_cli.py` asserting that `load_model("OpenAIServerModel", ...)` instantiates properly.

### Testing
- Ran `pytest tests/test_cli.py -k test_load_model_openai_model` - PASSED.