### PR TITLE
fix(memory): make ActionStep.dict() JSON-serializable when observations_images is present

### DIFF
--- a/src/smolagents/memory.py
+++ b/src/smolagents/memory.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Type
 
 from smolagents.models import ChatMessage, MessageRole, get_dict_from_nested_dataclasses
 from smolagents.monitoring import AgentLogger, LogLevel, Timing, TokenUsage
-from smolagents.utils import AgentError, make_json_serializable
+from smolagents.utils import AgentError, encode_image_base64, make_json_serializable
 
 
 if TYPE_CHECKING:
@@ -81,7 +81,7 @@ class ActionStep(MemoryStep):
             "model_output": self.model_output,
             "code_action": self.code_action,
             "observations": self.observations,
-            "observations_images": [image.tobytes() for image in self.observations_images]
+            "observations_images": [encode_image_base64(image) for image in self.observations_images]
             if self.observations_images
             else None,
             "action_output": make_json_serializable(self.action_output),

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -111,6 +111,9 @@ def test_action_step_dict():
     assert action_step_dict["observations"] == "This is a nice observation"
 
     assert "observations_images" in action_step_dict
+    assert isinstance(action_step_dict["observations_images"], list)
+    import json
+    json.dumps(action_step_dict)
 
     assert "action_output" in action_step_dict
     assert action_step_dict["action_output"] == "Output"


### PR DESCRIPTION
### What does this PR do?

Resolves #2725.

Currently, `ActionStep.dict()` converts `self.observations_images` using `image.tobytes()`, returning raw Python `bytes` objects. This causes `json.dumps(step.dict())` to raise `TypeError: Object of type bytes is not JSON serializable`.

This PR:
- Uses `encode_image_base64(image)` so `observations_images` is serialized to base64 strings, matching the serialization format elsewhere in the library.
- Updates `test_action_step_dict` in `tests/test_memory.py` to verify that `json.dumps(action_step_dict)` succeeds.

### Testing
- Ran `pytest tests/test_memory.py` - 12 passed.