### PR TITLE
fix(agents): handle GeneratorExit gracefully during stream cancellation (#2703)

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -594,20 +594,20 @@ You have been provided with these additional arguments, that you can access dire
             except AgentGenerationError as e:
                 # Agent generation errors are not caused by a Model error but an implementation error: so we should raise them and exit.
                 raise e
-            except AgentError as e:
-                # Other AgentError types are caused by the Model, so we should log them and iterate.
-                action_step.error = e
             except GeneratorExit:
                 # When the generator is closed early (e.g. gen.close(), loop break),
                 # finalize the step and update memory without yielding inside unwinding.
                 self._finalize_step(action_step)
                 self.memory.steps.append(action_step)
                 raise
-            else:
-                self._finalize_step(action_step)
-                self.memory.steps.append(action_step)
-                yield action_step
-                self.step_number += 1
+            except AgentError as e:
+                # Other AgentError types are caused by the Model, so we should log them and iterate.
+                action_step.error = e
+
+            self._finalize_step(action_step)
+            self.memory.steps.append(action_step)
+            yield action_step
+            self.step_number += 1
 
         if not returned_final_answer and self.step_number == max_steps + 1:
             final_answer = self._handle_max_steps_reached(task)

--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -597,7 +597,13 @@ You have been provided with these additional arguments, that you can access dire
             except AgentError as e:
                 # Other AgentError types are caused by the Model, so we should log them and iterate.
                 action_step.error = e
-            finally:
+            except GeneratorExit:
+                # When the generator is closed early (e.g. gen.close(), loop break),
+                # finalize the step and update memory without yielding inside unwinding.
+                self._finalize_step(action_step)
+                self.memory.steps.append(action_step)
+                raise
+            else:
                 self._finalize_step(action_step)
                 self.memory.steps.append(action_step)
                 yield action_step

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2626,3 +2626,15 @@ def test_tool_calling_agents_raises_agent_execution_error_when_tool_raises():
     agent = ToolCallingAgent(model=FakeToolCallModel(), tools=[_sample_tool])
     with pytest.raises(AgentExecutionError):
         agent.execute_tool_call(_sample_tool.name, "sample")
+
+
+def test_stream_run_handles_generator_exit_and_agent_error():
+    agent = CodeAgent(tools=[], model=FakeCodeModel())
+    # Test GeneratorExit handling
+    gen = agent.run("Dummy test task", stream=True)
+    first_step = next(gen)
+    assert first_step is not None
+    assert len(agent.memory.steps) >= 1
+    gen.close()
+    assert len(agent.memory.steps) >= 1
+


### PR DESCRIPTION
## Summary

Fixes #2703

### Problem
`MultiStepAgent._run_stream` yielded from inside a `finally` block. When a consumer stops consuming early (via `gen.close()`, breaking out of a loop, or garbage collection), Python raises `GeneratorExit`. Yielding inside a generator unwinding sequence triggers `RuntimeError: generator ignored GeneratorExit`.

### Solution
- Added explicit `except GeneratorExit:` handling to finalize the current step, append it to `self.memory.steps`, and re-raise without attempting to yield.
- Changed normal step yielding to execute inside an `else:` block, ensuring clean cleanup when streaming is aborted.
