### PR TITLE
docs(models): add PZERO OpenAIModel api_base example (#2701)

### DIFF
--- a/docs/source/en/examples/using_different_models.md
+++ b/docs/source/en/examples/using_different_models.md
@@ -78,6 +78,22 @@ model = OpenAIModel(
 )
 ```
 
+## Using PZERO Models
+
+PZERO provides access to models like DeepSeek via a prepaid OpenAI-compatible API endpoint.
+You can use [`OpenAIModel`] directly by configuring its `api_base`:
+
+```python
+import os
+from smolagents import OpenAIModel
+
+model = OpenAIModel(
+    model_id="deepseek-v4-flash",
+    api_base="https://api.pzero.studio/v1",
+    api_key=os.environ["PZERO_API_KEY"],
+)
+```
+
 ## Using xAI's Grok Models
 
 xAI's Grok models can be accessed through [`LiteLLMModel`].


### PR DESCRIPTION
## Summary

Closes #2701

Adds an example of using PZERO's OpenAI-compatible inference endpoint with `OpenAIModel` in `docs/source/en/examples/using_different_models.md`.
