### PR TITLE
fix(tools): validate keyword-only and positional-only __init__ parameters (#2668)

### DIFF
--- a/src/smolagents/tool_validation.py
+++ b/src/smolagents/tool_validation.py
@@ -216,10 +216,17 @@ def validate_tool_attributes(cls, check_imports: bool = True) -> None:
 
         def _check_init_function_parameters(self, node):
             # Check defaults in parameters
-            for arg, default in reversed(list(zip_longest(reversed(node.args.args), reversed(node.args.defaults)))):
+            positional = node.args.posonlyargs + node.args.args
+            for arg, default in reversed(list(zip_longest(reversed(positional), reversed(node.args.defaults)))):
                 if default is None:
                     if arg.arg != "self":
                         self.non_defaults.add(arg.arg)
+                elif not isinstance(default, (ast.Constant, ast.Dict, ast.List, ast.Set)):
+                    self.non_literal_defaults.add(arg.arg)
+
+            for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+                if default is None:
+                    self.non_defaults.add(arg.arg)
                 elif not isinstance(default, (ast.Constant, ast.Dict, ast.List, ast.Set)):
                     self.non_literal_defaults.add(arg.arg)
 


### PR DESCRIPTION
## Summary

Fixes #2668

### Problem
`ClassLevelChecker._check_init_function_parameters` in `src/smolagents/tool_validation.py` only checked `node.args.args`. It completely ignored positional-only parameters (`node.args.posonlyargs`) and keyword-only parameters (`node.args.kwonlyargs`), allowing custom tools with un-defaulted required keyword-only parameters (`def __init__(self, *, api_key):`) or positional-only parameters to bypass serialization validation silently.

### Solution
- Extended positional argument check to walk `node.args.posonlyargs + node.args.args` against `node.args.defaults`.
- Added check for `node.args.kwonlyargs` against `node.args.kw_defaults`.
