### PR TITLE
fix(tools): replace assertions with explicit exceptions in validate_arguments (#2736)

### DIFF
--- a/src/smolagents/tools.py
+++ b/src/smolagents/tools.py
@@ -170,10 +170,12 @@ class Tool(BaseTool):
             )
         # Validate inputs
         for input_name, input_content in self.inputs.items():
-            assert isinstance(input_content, dict), f"Input '{input_name}' should be a dictionary."
-            assert "type" in input_content and "description" in input_content, (
-                f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
-            )
+            if not isinstance(input_content, dict):
+                raise TypeError(f"Input '{input_name}' should be a dictionary.")
+            if "type" not in input_content or "description" not in input_content:
+                raise ValueError(
+                    f"Input '{input_name}' should have keys 'type' and 'description', has only {list(input_content.keys())}."
+                )
             # Get input_types as a list, whether from a string or list
             if isinstance(input_content["type"], str):
                 input_types = [input_content["type"]]
@@ -193,7 +195,8 @@ class Tool(BaseTool):
             if invalid_types:
                 raise ValueError(f"Input '{input_name}': types {invalid_types} must be one of {AUTHORIZED_TYPES}")
         # Validate output type
-        assert getattr(self, "output_type", None) in AUTHORIZED_TYPES
+        if getattr(self, "output_type", None) not in AUTHORIZED_TYPES:
+            raise ValueError(f"Tool '{self.name}': output_type '{getattr(self, 'output_type', None)}' must be one of {AUTHORIZED_TYPES}")
 
         # Validate forward function signature, except for Tools that use a "generic" signature (PipelineTool, SpaceToolWrapper, LangChainToolWrapper)
         if not (
@@ -213,17 +216,20 @@ class Tool(BaseTool):
                 "properties"
             ]  # This function will not raise an error on missing docstrings, contrary to get_json_schema
             for key, value in self.inputs.items():
-                assert key in json_schema, (
-                    f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
-                )
+                if key not in json_schema:
+                    raise ValueError(
+                        f"Input '{key}' should be present in function signature, found only {json_schema.keys()}"
+                    )
                 if "nullable" in value:
-                    assert "nullable" in json_schema[key], (
-                        f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
-                    )
+                    if "nullable" not in json_schema[key]:
+                        raise ValueError(
+                            f"Nullable argument '{key}' in inputs should have key 'nullable' set to True in function signature."
+                        )
                 if key in json_schema and "nullable" in json_schema[key]:
-                    assert "nullable" in value, (
-                        f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
-                    )
+                    if "nullable" not in value:
+                        raise ValueError(
+                            f"Nullable argument '{key}' in function signature should have key 'nullable' set to True in inputs."
+                        )
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError("Write this method in your subclass of `Tool`.")


### PR DESCRIPTION
## Summary

Fixes #2736

### Problem
`Tool.validate_arguments()` relied on Python `assert` statements for schema, type, and signature compatibility validation. In optimized execution mode (`python -O` or `python -OO`), assertions are stripped, allowing malformed tools with invalid schemas to bypass validation silently.

### Solution
- Replaced assertion checks with explicit `TypeError` and `ValueError` exceptions preserving the original validation semantics and error formatting.
- Ensures robust tool schema and parameter validation in all Python runtime environments.
