### PR TITLE
fix(executor): support dict unpacking in dict literals (#2552)

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1493,10 +1493,18 @@ def evaluate_ast(
     elif isinstance(expression, ast.FunctionDef):
         return evaluate_function_def(expression, *common_params)
     elif isinstance(expression, ast.Dict):
-        # Dict -> evaluate all keys and values
-        keys = (evaluate_ast(k, *common_params) for k in expression.keys)
-        values = (evaluate_ast(v, *common_params) for v in expression.values)
-        return dict(zip(keys, values))
+        # Dict -> evaluate all keys and values, supporting dict unpacking ({**d, 'k': v})
+        res = {}
+        for k, v in zip(expression.keys, expression.values):
+            val = evaluate_ast(v, *common_params)
+            if k is None:
+                if not isinstance(val, Mapping):
+                    raise TypeError(f"'{type(val).__name__}' object is not a mapping")
+                res.update(val)
+            else:
+                key = evaluate_ast(k, *common_params)
+                res[key] = val
+        return res
     elif isinstance(expression, ast.Expr):
         # Expression -> evaluate the content
         return evaluate_ast(expression.value, *common_params)

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -444,6 +444,19 @@ recur_fibo(6)"""
         result, _ = evaluate_python_code(code, {}, state={})
         assert result == "t-h-e-s-e-a-g-u-l-l"
 
+    def test_dict_unpacking(self):
+        code = '{**{"a": 1}, "b": 2}'
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == {"a": 1, "b": 2}
+
+        code_override = '{**{"a": 1, "b": 2}, **{"b": 99}}'
+        result_override, _ = evaluate_python_code(code_override, {}, state={})
+        assert result_override == {"a": 1, "b": 99}
+
+        code_non_mapping = '{**[1, 2]}'
+        with pytest.raises(InterpreterError, match="is not a mapping"):
+            evaluate_python_code(code_non_mapping, {}, state={})
+
     def test_string_indexing(self):
         code = """text_block = [
     "THESE",


### PR DESCRIPTION
Fixes #2552

### Problem
Evaluating dict literals with unpacking syntax like `{**{"a": 1}, "b": 2}` previously failed with:
```
InterpreterError: NoneType is not supported.
```
because `expression.keys` contains `None` for `**mapping` entries in Python's AST (`ast.Dict`).

### Solution
- Check for `k is None` in `expression.keys`.
- Ensure unpacked value implements `collections.abc.Mapping`, raising `TypeError` if non-mapping is unpacked.
- Call `res.update(val)` in order, preserving standard CPython dictionary unpacking semantics and overrides.
- Added regression unit tests covering valid unpacking, key overrides, and invalid mapping errors.