### PR TITLE
fix(cli): support OpenAIServerModel in load_model (#2726)

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -192,7 +192,7 @@ def load_model(
     api_key: str | None = None,
     provider: str | None = None,
 ) -> Model:
-    if model_type == "OpenAIModel":
+    if model_type in ("OpenAIModel", "OpenAIServerModel"):
         return OpenAIModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
             api_base=api_base or "https://api.fireworks.ai/inference/v1",


### PR DESCRIPTION
## Summary
- Fixes #2726
- Allows `OpenAIServerModel` in `load_model()` dispatch.
- In interactive mode (`interactive_mode`), `OpenAIServerModel` is explicitly listed in the model type choices, but previously `load_model()` only matched `OpenAIModel`, causing an immediate `ValueError: Unsupported model type: OpenAIServerModel` at the end of setup.
- Both `OpenAIModel` and its alias `OpenAIServerModel` are now supported.