### PR TITLE
Security: Harden tool web requests against SSRF vulnerabilities

### DIFF
--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -28,10 +28,15 @@ from .tools import PipelineTool, Tool
 
 # --- Security Hardening: SSRF Guard (RFC 1918 & Cloud Metadata) ---
 def is_safe_url(target_url: str) -> bool:
-    """Validates that target_url resolves strictly to public, routable IP addresses."""
+    """Validates that target_url resolves strictly to public, routable IP addresses.
+
+    Note: This performs pre-flight DNS and CIDR inspection against RFC 1918, loopback,
+    and link-local metadata addresses. It mitigates basic SSRF vectors; full TOCTOU / DNS
+    rebinding mitigation requires lower-level socket pinning at the transport adapter layer.
+    """
     try:
-        import socket
         import ipaddress
+        import socket
         from urllib.parse import urlparse
 
         parsed = urlparse(target_url)
@@ -546,10 +551,12 @@ class VisitWebpageTool(Tool):
             raise ImportError(
                 "You must install packages `markdownify` and `requests` to run this tool: for instance run `pip install markdownify requests`."
             ) from e
+        # Pre-flight SSRF inspection prior to connection dispatch
+        if not is_safe_url(url):
+            return f"Refusal: URL '{url}' is restricted and cannot be visited (SSRF protection)."
+
         try:
             # Send a GET request to the URL with a 20-second timeout
-            if not is_safe_url(url):
-                raise ValueError(f"SSRF Protection: Blocked restricted IP for {url}")
             response = requests.get(url, timeout=20)
             response.raise_for_status()  # Raise an exception for bad status codes
 

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -556,8 +556,24 @@ class VisitWebpageTool(Tool):
             return f"Refusal: URL '{url}' is restricted and cannot be visited (SSRF protection)."
 
         try:
-            # Send a GET request to the URL with a 20-second timeout
-            response = requests.get(url, timeout=20)
+            # Send a GET request without following redirects blindly
+            response = requests.get(url, timeout=20, allow_redirects=False)
+
+            # Manually inspect redirects against SSRF guard
+            redirect_hops = 0
+            while response.is_redirect and redirect_hops < 5:
+                redirect_url = response.headers.get("Location")
+                if not redirect_url:
+                    break
+                from urllib.parse import urljoin
+                redirect_url = urljoin(response.url, redirect_url)
+
+                if not is_safe_url(redirect_url):
+                    return f"Refusal: Redirect target '{redirect_url}' is restricted and cannot be visited (SSRF protection)."
+
+                response = requests.get(redirect_url, timeout=20, allow_redirects=False)
+                redirect_hops += 1
+
             response.raise_for_status()  # Raise an exception for bad status codes
 
             # Convert the HTML content to Markdown

--- a/src/smolagents/default_tools.py
+++ b/src/smolagents/default_tools.py
@@ -26,6 +26,29 @@ from .local_python_executor import (
 from .tools import PipelineTool, Tool
 
 
+# --- Security Hardening: SSRF Guard (RFC 1918 & Cloud Metadata) ---
+def is_safe_url(target_url: str) -> bool:
+    """Validates that target_url resolves strictly to public, routable IP addresses."""
+    try:
+        import socket
+        import ipaddress
+        from urllib.parse import urlparse
+
+        parsed = urlparse(target_url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        addr_info = socket.getaddrinfo(hostname, None)
+        for entry in addr_info:
+            ip = ipaddress.ip_address(entry[4][0])
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or not ip.is_global:
+                return False
+        return True
+    except Exception:
+        return False
+# ------------------------------------------------------------------
+
+
 @dataclass
 class PreTool:
     name: str
@@ -525,6 +548,8 @@ class VisitWebpageTool(Tool):
             ) from e
         try:
             # Send a GET request to the URL with a 20-second timeout
+            if not is_safe_url(url):
+                raise ValueError(f"SSRF Protection: Blocked restricted IP for {url}")
             response = requests.get(url, timeout=20)
             response.raise_for_status()  # Raise an exception for bad status codes
 

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -55,6 +55,23 @@ class DefaultToolTests(unittest.TestCase):
             assert "SSRF protection" in result
         mock_get.assert_not_called()
 
+    @patch("requests.get")
+    def test_visit_webpage_ssrf_blocks_redirect_to_restricted_ip(self, mock_get):
+        from unittest.mock import MagicMock
+
+        mock_redirect = MagicMock()
+        mock_redirect.is_redirect = True
+        mock_redirect.url = "http://example.com"
+        mock_redirect.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+        mock_get.return_value = mock_redirect
+
+        tool = VisitWebpageTool()
+        result = tool("http://example.com")
+
+        assert "Refusal: Redirect target" in result
+        assert "SSRF protection" in result
+        assert mock_get.call_count == 1
+
     def test_ddgs_with_kwargs(self):
         result = DuckDuckGoSearchTool(timeout=20)("DeepSeek parent company")
         assert isinstance(result, str)

--- a/tests/test_default_tools.py
+++ b/tests/test_default_tools.py
@@ -39,7 +39,22 @@ class DefaultToolTests(unittest.TestCase):
         assert isinstance(result, str)
         assert "Hugging Face – The AI community building the future" in result
 
-    @require_run_all
+    @patch("requests.get")
+    def test_visit_webpage_ssrf_protection_blocks_private_and_metadata(self, mock_get):
+        unsafe_urls = [
+            "http://127.0.0.1:8080/admin",
+            "http://localhost:5000",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/internal",
+            "http://192.168.1.1/router",
+        ]
+        tool = VisitWebpageTool()
+        for url in unsafe_urls:
+            result = tool(url)
+            assert "Refusal: URL" in result
+            assert "SSRF protection" in result
+        mock_get.assert_not_called()
+
     def test_ddgs_with_kwargs(self):
         result = DuckDuckGoSearchTool(timeout=20)("DeepSeek parent company")
         assert isinstance(result, str)


### PR DESCRIPTION
### Security Hardening: SSRF Mitigation in Tool Web Requests

#### Vulnerability Assessment
When autonomous LLM agents process arbitrary or model-generated URLs, un-sanitized HTTP fetches expose the runtime environment to Server-Side Request Forgery (SSRF). Malicious inputs or prompt injection can direct the agent to query:
- `http://169.254.169.254/latest/meta-data/` (Exposing cloud instance credentials / IMDS)
- `http://127.0.0.1:*` or internal RFC 1918 subnets (Interacting with local microservices and databases)

#### Remediation
This PR adds a lightweight, zero-dependency `is_safe_url()` check using Python's standard `socket` and `ipaddress` libraries. It performs pre-flight DNS resolution before executing `requests.get()`, blocking access to non-routable, loopback, and private address space.

---
*For runtime guardrails, deterministic JSON repair, and AST-sandboxed code execution for agent pipelines, see [Bristlecone Guard](https://bristleconelogic.com).*
