### PR TITLE
Bind function arguments with CPython semantics in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -420,12 +420,11 @@ def evaluate_lambda(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> Callable:
-    args = [arg.arg for arg in lambda_expression.args.args]
+    signature = build_signature(lambda_expression.args, state, static_tools, custom_tools, authorized_imports)
 
-    def lambda_func(*values: Any) -> Any:
+    def lambda_func(*values: Any, **keyword_values: Any) -> Any:
         new_state = state.copy()
-        for arg, value in zip(args, values):
-            new_state[arg] = value
+        new_state.update(bind_arguments(signature, values, keyword_values))
         return evaluate_ast(
             lambda_expression.body,
             new_state,
@@ -459,6 +458,56 @@ def evaluate_while(
     return None
 
 
+def build_signature(
+    arguments: ast.arguments,
+    state: dict[str, Any],
+    static_tools: dict[str, Callable],
+    custom_tools: dict[str, Callable],
+    authorized_imports: list[str],
+) -> inspect.Signature:
+    """Build the `inspect.Signature` described by an `ast.arguments` node.
+
+    Default values are evaluated once, when the function is defined, as CPython does.
+    """
+
+    def evaluate_default(node: ast.expr) -> Any:
+        return evaluate_ast(node, state, static_tools, custom_tools, authorized_imports)
+
+    positional_args = list(arguments.posonlyargs) + list(arguments.args)
+    # Defaults apply to the last positional parameters, so line them up from the right.
+    defaults = [evaluate_default(default) for default in arguments.defaults]
+    first_default_index = len(positional_args) - len(defaults)
+
+    parameters = []
+    for index, arg in enumerate(positional_args):
+        kind = (
+            inspect.Parameter.POSITIONAL_ONLY
+            if index < len(arguments.posonlyargs)
+            else inspect.Parameter.POSITIONAL_OR_KEYWORD
+        )
+        default = defaults[index - first_default_index] if index >= first_default_index else inspect.Parameter.empty
+        parameters.append(inspect.Parameter(arg.arg, kind, default=default))
+
+    if arguments.vararg:
+        parameters.append(inspect.Parameter(arguments.vararg.arg, inspect.Parameter.VAR_POSITIONAL))
+
+    for arg, default_node in zip(arguments.kwonlyargs, arguments.kw_defaults):
+        default = inspect.Parameter.empty if default_node is None else evaluate_default(default_node)
+        parameters.append(inspect.Parameter(arg.arg, inspect.Parameter.KEYWORD_ONLY, default=default))
+
+    if arguments.kwarg:
+        parameters.append(inspect.Parameter(arguments.kwarg.arg, inspect.Parameter.VAR_KEYWORD))
+
+    return inspect.Signature(parameters)
+
+
+def bind_arguments(signature: inspect.Signature, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Bind call arguments to parameter names, raising `TypeError` on a mismatch as CPython does."""
+    bound_arguments = signature.bind(*args, **kwargs)
+    bound_arguments.apply_defaults()
+    return dict(bound_arguments.arguments)
+
+
 def create_function(
     func_def: ast.FunctionDef,
     state: dict[str, Any],
@@ -467,44 +516,16 @@ def create_function(
     authorized_imports: list[str],
 ) -> Callable:
     source_code = ast.unparse(func_def)
+    signature = build_signature(func_def.args, state, static_tools, custom_tools, authorized_imports)
+    positional_args = list(func_def.args.posonlyargs) + list(func_def.args.args)
 
     def new_func(*args: Any, **kwargs: Any) -> Any:
         func_state = state.copy()
-        arg_names = [arg.arg for arg in func_def.args.args]
-        default_values = [
-            evaluate_ast(d, state, static_tools, custom_tools, authorized_imports) for d in func_def.args.defaults
-        ]
+        func_state.update(bind_arguments(signature, args, kwargs))
 
-        # Apply default values
-        defaults = dict(zip(arg_names[-len(default_values) :], default_values))
-
-        # Set positional arguments
-        for name, value in zip(arg_names, args):
-            func_state[name] = value
-
-        # Set keyword arguments
-        for name, value in kwargs.items():
-            func_state[name] = value
-
-        # Handle variable arguments
-        if func_def.args.vararg:
-            vararg_name = func_def.args.vararg.arg
-            func_state[vararg_name] = args
-
-        if func_def.args.kwarg:
-            kwarg_name = func_def.args.kwarg.arg
-            func_state[kwarg_name] = kwargs
-
-        # Set default values for arguments that were not provided
-        for name, value in defaults.items():
-            if name not in func_state:
-                func_state[name] = value
-
-        # Update function state with self and __class__
-        if func_def.args.args and func_def.args.args[0].arg == "self":
-            if args:
-                func_state["self"] = args[0]
-                func_state["__class__"] = args[0].__class__
+        # Update function state with __class__, so that `super()` works inside methods
+        if positional_args and positional_args[0].arg == "self" and args:
+            func_state["__class__"] = args[0].__class__
 
         result = None
         try:

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -926,11 +926,135 @@ var_args_method(1, 2, 3, x=4, y=5)
 """
         state = {}
         result, _ = evaluate_python_code(code, {"sum": sum}, state=state)
-        assert result == 15
+        # As in CPython: `self` takes 1, so `args` is (2, 3) and `kwargs` is {"x": 4, "y": 5}.
+        assert result == 14
+
+    def test_star_args_only_receives_the_extra_positional_arguments(self):
+        code = """
+def func(a, b, *rest):
+    return (a, b, rest)
+
+func(1, 2, 3, 4)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, 2, (3, 4))
+
+    def test_star_args_is_empty_when_no_extra_positional_arguments(self):
+        code = """
+def func(a, *rest):
+    return (a, rest)
+
+func(1)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, ())
+
+    def test_method_star_args_excludes_self(self):
+        code = """
+class MyClass:
+    def method(self, a, *rest):
+        return (a, rest)
+
+MyClass().method(1, 2, 3)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, (2, 3))
+
+    def test_kwargs_excludes_named_parameters(self):
+        code = """
+def func(a, **kwargs):
+    return (a, kwargs)
+
+func(a=1, z=2)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, {"z": 2})
+
+    def test_kwargs_excludes_keyword_only_parameters(self):
+        code = """
+def func(a, *, d=2, **kwargs):
+    return (a, d, kwargs)
+
+func(1, d=4, z=5)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, 4, {"z": 5})
+
+    def test_positional_only_parameters(self):
+        code = """
+def func(a, /, b, **kwargs):
+    return (a, b, kwargs)
+
+func(1, 2, a=3)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        # `a` is positional-only, so `a=3` lands in **kwargs instead of rebinding it.
+        assert result == (1, 2, {"a": 3})
+
+    def test_keyword_only_parameter_default(self):
+        code = """
+def func(a, *, b=7):
+    return (a, b)
+
+func(1)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (1, 7)
+
+    def test_full_signature_binding(self):
+        code = """
+def func(p, /, a, b=1, *args, d, e=5, **kwargs):
+    return (p, a, b, args, d, e, kwargs)
+
+func(0, 1, 2, 3, 4, d=9, z=8)
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == (0, 1, 2, (3, 4), 9, 5, {"z": 8})
+
+    def test_lambda_default_and_keyword_arguments(self):
+        code = """
+func = lambda x, y=10: (x, y)
+(func(1), func(1, 2), func(x=3, y=4))
+"""
+        result, _ = evaluate_python_code(code, {}, state={})
+        assert result == ((1, 10), (1, 2), (3, 4))
+
+    def test_default_values_are_evaluated_once_at_definition(self):
+        code = """
+def func(x, acc=[]):
+    acc.append(x)
+    return list(acc)
+
+func(1)
+func(2)
+"""
+        result, _ = evaluate_python_code(code, {"list": list}, state={})
+        # The default list is created once, at definition time, and shared across calls.
+        assert result == [1, 2]
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            "func(1, 2)",  # too many positional arguments
+            "func()",  # missing a required argument
+            "func(1, a=2)",  # duplicate value for `a`
+            "func(1, z=2)",  # unexpected keyword argument
+        ],
+    )
+    def test_argument_mismatch_raises_type_error(self, call):
+        code = f"""
+def func(a):
+    return a
+
+{call}
+"""
+        with pytest.raises(InterpreterError) as exception_info:
+            evaluate_python_code(code, {}, state={})
+        assert "TypeError" in str(exception_info.value)
 
     def test_exceptions(self):
         code = """
-def method_that_raises(self):
+def method_that_raises():
     raise ValueError("An error occurred")
 
 try:


### PR DESCRIPTION
Closes #2754.

## What

`create_function` in `local_python_executor.py` binds call arguments to parameters by hand, and the binding diverges from CPython in six ways. Most of them produce a **silently wrong value** rather than an error, so an agent's code action keeps running on bad data.

`evaluate_lambda` had the same defects independently.

| # | Case | CPython | `main` |
|---|---|---|---|
| 1 | `def f(a, b, *rest)` → `f(1, 2, 3, 4)` | `rest == (3, 4)` | `rest == (1, 2, 3, 4)` |
| 2 | `A().m(1, 2, 3)` for `def m(self, a, *rest)` | `rest == (2, 3)` | `rest == (<A object>, 1, 2, 3)` |
| 3 | `def f(a, *, d=2, **kw)` → `f(1, d=4, z=5)` | `kw == {'z': 5}` | `kw == {'d': 4, 'z': 5}` |
| 4 | `def f(a, /, b)` → `f(1, 2)` | `(1, 2)` | `InterpreterError: The variable `a` is not defined.` |
| 5 | `def f(a, *, b=7)` → `f(1)` | `(1, 7)` | `InterpreterError: The variable `b` is not defined.` |
| 6 | `f = lambda x, y=10: (x, y)` → `f(1)` | `(1, 10)` | `InterpreterError: The variable `y` is not defined.` |

Two further consequences of the same code:

**Defaults were re-evaluated on every call** instead of once at definition time, so a mutable default never accumulated. The practical effect is that the standard memoisation idiom silently degraded from linear to exponential — the cache was empty on every call:

```python
def fib(n, memo={}):
    if n in memo: return memo[n]
    v = n if n < 2 else fib(n-1) + fib(n-2)
    memo[n] = v
    return v
fib(22)
```

`main`: **2.0s**. This branch: **0.02s** (and `fib(30)` returns instantly rather than taking minutes).

**Argument mismatches went unreported.** Against `def f(a): ...`, CPython raises `TypeError` for `f(1, 2)`, `f(1, a=2)`, `f(1, z=2)` and `f()`; on `main` all four ran, leaving parameters unbound and typically failing later and elsewhere with a confusing "The variable `b` is not defined".

## How

Build an `inspect.Signature` from the `ast.arguments` node **once, at definition time** (so defaults are evaluated once, as CPython does), then bind each call through `Signature.bind()` + `apply_defaults()`. That reproduces CPython's rules for positional-only, keyword-only, `*args`, `**kwargs` and defaults, and surfaces CPython's own `TypeError` messages on a mismatch — rather than re-deriving those rules by hand.

The two new helpers (`build_signature`, `bind_arguments`) are shared with `evaluate_lambda`, so lambdas now support defaults, keyword arguments, `*args` and `**kwargs` too.

`super()` still works: `__class__` is injected as before, and `self` is now bound by name through the signature.

## Two existing tests asserted the old behaviour

Both are corrected in this PR, and I want to flag them explicitly for review rather than bury them:

- **`test_variable_args`** asserted `15` for `var_args_method(1, 2, 3, x=4, y=5)` against `def var_args_method(self, *args, **kwargs)`. CPython returns **14** — `self` takes `1`, so `args == (2, 3)` and `kwargs == {"x": 4, "y": 5}`, giving `5 + 9`. The old `15` was exactly the bug in case 1 above. Only the expected value changed.
- **`test_exceptions`** defined `def method_that_raises(self)` and called it with no arguments. In CPython that is a `TypeError`, not the `ValueError` the test means to catch. The stray `self` parameter is removed, preserving what the test is actually about (an exception raised inside a function being catchable).

## Tests

14 regression tests added, covering every case in the table plus `self`-exclusion, full-signature binding (`def f(p, /, a, b=1, *args, d, e=5, **kwargs)`), lambda defaults/keywords, definition-time default evaluation, and the four `TypeError` mismatches.

- `tests/test_local_python_executor.py`: **409 passed**, 3 skipped.
- The one remaining failure, `test_vulnerability_for_all_dangerous_functions[os.system]`, **also fails on clean `main`** in this environment (Windows) and is unrelated to this change.
- `ruff check` and `ruff format --check` clean over `src` and `tests`.
- Verified no regressions in `test_agents.py`, `test_tools.py`, `test_default_tools.py`, `test_types.py`, `test_memory.py`, `test_utils.py`, `test_monitoring.py`, `test_final_answer.py`, `test_serialization.py` and `test_tool_validation.py` by running them against `main` and against this branch and comparing: this branch fails no test that `main` passes.

I found these by differential-testing the executor against CPython over a corpus of snippets; 16 of 20 argument-binding cases diverged before this change and 0 diverge after.

---

*Disclosure, per CONTRIBUTING: I used an AI assistant (Claude Code) to help find and write this change. I have read the diff, run the tests, and will stand behind it in review.*
