### PR TITLE
fix(executor): avoid passing control flow exceptions to context manager __exit__ (#2758)

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -1166,6 +1166,8 @@ def evaluate_try(
     try:
         for stmt in try_node.body:
             evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
+    except (ReturnException, BreakException, ContinueException):
+        raise
     except Exception as e:
         matched = False
         for handler in try_node.handlers:
@@ -1251,6 +1253,23 @@ def evaluate_with(
     try:
         for stmt in with_node.body:
             evaluate_ast(stmt, state, static_tools, custom_tools, authorized_imports)
+    except (ReturnException, BreakException, ContinueException) as control_flow_exc:
+        exc_info = (None, None, None)
+        exit_raised = False
+        for context in reversed(contexts):
+            try:
+                if exc_info[1] is not None:
+                    if context.__exit__(*exc_info):
+                        exc_info = (None, None, None)
+                else:
+                    context.__exit__(None, None, None)
+            except Exception as exit_exc:
+                exc_info = (type(exit_exc), exit_exc, exit_exc.__traceback__)
+                exit_raised = True
+        if exc_info[1] is not None:
+            raise exc_info[1].with_traceback(exc_info[2])
+        if not exit_raised:
+            raise control_flow_exc
     except Exception as e:
         # exc_info tracks the active exception as we unwind (from innermost context manager)
         # Resetting it to (None, None, None) signals suppression to the remaining outer managers

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -1216,6 +1216,148 @@ with RaisingExit():
         with pytest.raises(InterpreterError, match="from __exit__"):
             evaluate_python_code(code, {}, state={})
 
+    def test_with_return_passes_none_to_exit(self):
+        """Test that a return statement inside a with block passes (None, None, None) to __exit__."""
+        code = """
+exit_args = []
+class CM:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        exit_args.append((exc_type, exc_val))
+
+def func():
+    with CM():
+        return 42
+    return 99
+
+res = func()
+assert res == 42
+assert len(exit_args) == 1
+assert exit_args[0] == (None, None)
+"""
+        evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
+    def test_with_return_sqlite_transaction_commits(self):
+        """Test that a normal return inside a with block commits a SQLite transaction (#2758)."""
+        import contextlib
+        import sqlite3
+
+        code = """
+def write():
+    with db:
+        db.execute("INSERT INTO t VALUES (1)")
+        return 42
+value = write()
+result = (value, db.execute("SELECT count(*) FROM t").fetchone()[0])
+"""
+        with contextlib.closing(sqlite3.connect(":memory:")) as connection:
+            connection.execute("CREATE TABLE t (value INTEGER)")
+            result, _ = evaluate_python_code(
+                code + "\nresult",
+                BASE_PYTHON_TOOLS,
+                state={"db": connection},
+                timeout_seconds=None,
+            )
+            assert result == (42, 1)
+
+    def test_with_suppress_does_not_swallow_return(self):
+        """Test that contextlib.suppress does not swallow return statements inside with blocks."""
+        code = """
+import contextlib
+
+def f():
+    with contextlib.suppress(Exception):
+        return 42
+    return 99
+
+res = f()
+assert res == 42
+"""
+        evaluate_python_code(code, BASE_PYTHON_TOOLS, state={}, authorized_imports=["contextlib"])
+
+    def test_with_break_and_continue_pass_none_to_exit(self):
+        """Test that break and continue inside with blocks pass (None, None, None) to __exit__."""
+        code = """
+exit_calls = []
+class CM:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        exit_calls.append(exc_type)
+
+res = []
+for i in range(5):
+    with CM():
+        if i == 1:
+            continue
+        if i == 3:
+            break
+        res.append(i)
+
+assert res == [0, 2]
+assert exit_calls == [None, None, None, None]
+"""
+        evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
+    def test_try_except_does_not_catch_control_flow(self):
+        """Test that except Exception and bare except do not intercept return, break, or continue."""
+        code = """
+def test_ret():
+    try:
+        return 42
+    except Exception:
+        return 99
+
+def test_ret_bare():
+    try:
+        return 42
+    except:
+        return 99
+
+assert test_ret() == 42
+assert test_ret_bare() == 42
+
+res = []
+for i in range(4):
+    try:
+        if i == 2:
+            break
+        res.append(i)
+    except Exception:
+        res.append(99)
+
+assert res == [0, 1]
+"""
+        evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
+    def test_with_nested_exit_exception_suppression_discards_return(self):
+        """Test that if an inner __exit__ raises during a pending return and an outer __exit__ suppresses it,
+        the pending return is discarded and execution continues after the with statement (CPython semantics).
+        """
+        code = """
+class Outer:
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        return True
+
+class Inner:
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        raise ValueError("exit")
+
+def f():
+    with Outer(), Inner():
+        return 42
+    return 99
+
+res = f()
+assert res == 99
+"""
+        evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
     def test_default_arg_in_function(self):
         code = """
 def f(a, b=333, n=1000):


### PR DESCRIPTION
Closes #2758.

## What

In `local_python_executor.py`, normal control-flow operations (`return`, `break`, `continue`) are implemented via internal exception classes (`ReturnException`, `BreakException`, `ContinueException`).

Because these classes inherit from `Exception`, `evaluate_with` was catching them in its generic `except Exception as e:` handler and passing `(type(e), e, tb)` into the context managers' `__exit__` method during unwinding.

This caused two severe divergences from CPython semantics:
1. **SQLite transactions were rolled back on normal return**: `sqlite3.Connection.__exit__` checks whether an exception occurred to decide between `commit()` and `rollback()`. When a function executed `return` inside a `with db:` block, SQLite received `ReturnException` and issued a rollback, silently discarding database writes made during successful agent execution.
2. **`contextlib.suppress(Exception)` swallowed returns**: `suppress` treats `ReturnException` as a matched exception, suppressing it and preventing the function from returning.
3. Similarly, user-level `except Exception:` and bare `except:` blocks in `evaluate_try` were intercepting `ReturnException`, `BreakException`, and `ContinueException`.

## How

- In `evaluate_with`, intercept `(ReturnException, BreakException, ContinueException)` before generic `except Exception:`. In accordance with PEP 343 non-local-goto unwind semantics, call `__exit__(None, None, None)` for each active context in reverse order, then re-raise the control flow exception so that outer loops/functions resume control flow uninterrupted.
- In `evaluate_try`, intercept `(ReturnException, BreakException, ContinueException)` before generic `except Exception:`, ensuring that user `except` handlers cannot intercept returns/breaks while still executing `finally` blocks.

## Tests

Added 5 regression tests in `tests/test_local_python_executor.py`:
- `test_with_return_passes_none_to_exit`: asserts that `(None, None)` is passed to `__exit__` when returning from inside a `with` block.
- `test_with_return_sqlite_transaction_commits`: validates that a SQLite transaction commits on `return` inside a `with db:` block (issue #2758).
- `test_with_suppress_does_not_swallow_return`: validates that `contextlib.suppress(Exception)` does not swallow `return`.
- `test_with_break_and_continue_pass_none_to_exit`: validates that `break` and `continue` inside `with` blocks pass `None` to `__exit__`.
- `test_try_except_does_not_catch_control_flow`: validates that `except Exception:` and bare `except:` do not intercept `return` or `break`.

Verification:
- `pytest tests/test_local_python_executor.py` (402 passed, 2 skipped)
- `ruff check src/smolagents/local_python_executor.py tests/test_local_python_executor.py` (passed)
- `ruff format --check src/smolagents/local_python_executor.py tests/test_local_python_executor.py` (passed)