### PR TITLE
fix: preserve tool calls with missing or duplicate ids

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1371,10 +1371,12 @@ class ToolCallingAgent(MultiStepAgent):
             `ToolCall | ToolOutput`: The tool call or tool output.
         """
         parallel_calls: dict[str, ToolCall] = {}
+        tool_call_ids: set[str] = set()
         assert chat_message.tool_calls is not None
-        for chat_tool_call in chat_message.tool_calls:
+        for index, chat_tool_call in enumerate(chat_message.tool_calls):
+            tool_call_id = self._make_unique_tool_call_id(chat_tool_call.id, index, tool_call_ids)
             tool_call = ToolCall(
-                name=chat_tool_call.function.name, arguments=chat_tool_call.function.arguments, id=chat_tool_call.id
+                name=chat_tool_call.function.name, arguments=chat_tool_call.function.arguments, id=tool_call_id
             )
             yield tool_call
             parallel_calls[tool_call.id] = tool_call
@@ -1440,6 +1442,22 @@ class ToolCallingAgent(MultiStepAgent):
         memory_step.observations = (
             memory_step.observations.rstrip("\n") if memory_step.observations else memory_step.observations
         )
+
+    @staticmethod
+    def _make_unique_tool_call_id(tool_call_id: str, index: int, used_ids: set[str]) -> str:
+        if tool_call_id and tool_call_id not in used_ids:
+            used_ids.add(tool_call_id)
+            return tool_call_id
+
+        fallback_prefix = tool_call_id or "tool_call"
+        unique_tool_call_id = f"{fallback_prefix}_{index}"
+        suffix = 1
+        while unique_tool_call_id in used_ids:
+            unique_tool_call_id = f"{fallback_prefix}_{index}_{suffix}"
+            suffix += 1
+
+        used_ids.add(unique_tool_call_id)
+        return unique_tool_call_id
 
     def _substitute_state_variables(self, arguments: dict[str, str] | str) -> dict[str, Any] | str:
         """Replace string values in arguments with their corresponding state values if they exist."""

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2088,6 +2088,41 @@ class TestToolCallingAgent:
                     for tool_call in test_case["tool_calls"]
                 ]
 
+    @pytest.mark.parametrize(
+        ("tool_call_ids", "expected_tool_call_ids"),
+        [
+            (["", ""], ["tool_call_0", "tool_call_1"]),
+            (["call_1", "call_1"], ["call_1", "call_1_1"]),
+        ],
+    )
+    def test_process_tool_calls_normalizes_missing_or_duplicate_ids(
+        self, tool_call_ids, expected_tool_call_ids, test_tool
+    ):
+        agent = ToolCallingAgent(tools=[test_tool], model=MagicMock())
+        chat_message = ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            tool_calls=[
+                ChatMessageToolCall(
+                    id=tool_call_id,
+                    type="function",
+                    function=ChatMessageToolCallFunction(name="test_tool", arguments={"input": value}),
+                )
+                for tool_call_id, value in zip(tool_call_ids, ["value1", "value2"])
+            ],
+        )
+        memory_step = ActionStep(step_number=10, timing="mock_timing", model_output="")
+
+        events = list(agent.process_tool_calls(chat_message, memory_step))
+        tool_calls = [event for event in events if isinstance(event, ToolCall)]
+        tool_outputs = [event for event in events if isinstance(event, ToolOutput)]
+
+        assert [tool_call.id for tool_call in tool_calls] == expected_tool_call_ids
+        assert [tool_call.id for tool_call in memory_step.tool_calls or []] == expected_tool_call_ids
+        assert sorted(tool_output.output for tool_output in tool_outputs) == ["Processed: value1", "Processed: value2"]
+        assert sorted(tool_output.id for tool_output in tool_outputs) == expected_tool_call_ids
+        assert memory_step.observations == "Processed: value1\nProcessed: value2"
+
 
 class TestCodeAgent:
     def test_code_agent_instructions(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #2683 by normalizing missing or duplicate tool call IDs before `ToolCallingAgent.process_tool_calls()` indexes pending calls.

Previously, `parallel_calls` was keyed directly by the provider-supplied `tool_call.id`, so empty or repeated IDs overwrote earlier calls. The generator yielded each requested `ToolCall`, but only the last call for a duplicated key was executed and recorded in memory.

This PR:

- keeps provider IDs unchanged when they are present and unique
- assigns stable fallback IDs such as `tool_call_0` for missing IDs
- suffixes repeated IDs such as `call_1_1` for duplicates
- adds regression coverage for both missing and duplicate IDs

## Before

The repro from #2683 printed:

```text
['second']
1
second
```

## Tests

```text
PYTHONPATH=src python -m pytest tests/test_agents.py::TestToolCallingAgent::test_process_tool_calls tests/test_agents.py::TestToolCallingAgent::test_process_tool_calls_normalizes_missing_or_duplicate_ids -q
```

Result: `9 passed, 2 warnings`

```text
ruff check src/smolagents/agents.py tests/test_agents.py
ruff format --check src/smolagents/agents.py tests/test_agents.py
git diff --check
```

Result: all passed.