### PR TITLE
fix: accept OpenAIServerModel alias in load_model

### DIFF
--- a/src/smolagents/cli.py
+++ b/src/smolagents/cli.py
@@ -192,7 +192,8 @@ def load_model(
     api_key: str | None = None,
     provider: str | None = None,
 ) -> Model:
-    if model_type == "OpenAIModel":
+    if model_type in ("OpenAIModel", "OpenAIServerModel"):
+        # OpenAIServerModel is an exported alias of OpenAIModel; interactive_mode offers it.
         return OpenAIModel(
             api_key=api_key or os.getenv("FIREWORKS_API_KEY"),
             api_base=api_base or "https://api.fireworks.ai/inference/v1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,16 @@ def test_load_model_openai_model(set_env_vars):
     assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
 
 
+def test_load_model_openai_server_model_alias(set_env_vars):
+    with patch("openai.OpenAI") as MockOpenAI:
+        model = load_model("OpenAIServerModel", "test_model_id")
+    assert isinstance(model, OpenAIModel)
+    assert model.model_id == "test_model_id"
+    assert MockOpenAI.call_count == 1
+    assert MockOpenAI.call_args.kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
+    assert MockOpenAI.call_args.kwargs["api_key"] == "test_fireworks_api_key"
+
+
 def test_load_model_litellm_model():
     model = load_model("LiteLLMModel", "test_model_id", api_key="test_api_key", api_base="https://api.test.com")
     assert isinstance(model, LiteLLMModel)


### PR DESCRIPTION
## Summary
- `interactive_mode()` offers `OpenAIServerModel`, but `load_model()` only matched `OpenAIModel`, so that choice (and `--model-type OpenAIServerModel`) always raised `ValueError`.
- Treat `OpenAIServerModel` as an alias of `OpenAIModel` in `load_model()` (it is already exported as that alias in `models.py`).
- Add `test_load_model_openai_server_model_alias`.

Closes #2726

## Test plan
- [x] Unit test added for the alias path
- [ ] `pytest tests/test_cli.py` on CI

## Notes
Per CONTRIBUTING I asked for `status:accepted` on #2726; opening this PR now so the fix is reviewable. Happy to adjust if maintainers prefer changing the interactive choices list to `OpenAIModel` instead.

Disclosure: drafted with AI assistance; I reviewed the change against `cli.py` / `models.py` and will own follow-ups.