### PR TITLE
fix: refuse decorated defs loudly in LocalPythonExecutor

### DIFF
--- a/src/smolagents/local_python_executor.py
+++ b/src/smolagents/local_python_executor.py
@@ -533,6 +533,11 @@ def evaluate_function_def(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> Callable:
+    if func_def.decorator_list:
+        raise InterpreterError(
+            f"Decorators are not supported on function '{func_def.name}'. "
+            "Remove the decorator(s) or rewrite without them."
+        )
     custom_tools[func_def.name] = create_function(func_def, state, static_tools, custom_tools, authorized_imports)
     return custom_tools[func_def.name]
 
@@ -544,6 +549,11 @@ def evaluate_class_def(
     custom_tools: dict[str, Callable],
     authorized_imports: list[str],
 ) -> type:
+    if class_def.decorator_list:
+        raise InterpreterError(
+            f"Decorators are not supported on class '{class_def.name}'. "
+            "Remove the decorator(s) or rewrite without them."
+        )
     class_name = class_def.name
     bases = [evaluate_ast(base, state, static_tools, custom_tools, authorized_imports) for base in class_def.bases]
 

--- a/tests/test_local_python_executor.py
+++ b/tests/test_local_python_executor.py
@@ -80,6 +80,50 @@ class TestEvaluatePythonCode:
             evaluate_python_code(code, {"print": print}, state={})
         assert "Cannot assign to name 'print': doing this would erase the existing tool!" in str(e)
 
+    def test_function_decorator_is_rejected(self):
+        code = dedent(
+            """
+            def double(fn):
+                def wrapper(*a, **k):
+                    return fn(*a, **k) * 2
+                return wrapper
+
+            @double
+            def value():
+                return 21
+
+            value()
+            """
+        )
+        with pytest.raises(InterpreterError, match="Decorators are not supported on function 'value'"):
+            evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
+    def test_class_decorator_is_rejected(self):
+        code = dedent(
+            """
+            def mark(cls):
+                return cls
+
+            @mark
+            class A:
+                pass
+            """
+        )
+        with pytest.raises(InterpreterError, match="Decorators are not supported on class 'A'"):
+            evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
+    def test_method_decorator_is_rejected(self):
+        code = dedent(
+            """
+            class A:
+                @property
+                def v(self):
+                    return 7
+            """
+        )
+        with pytest.raises(InterpreterError, match="Decorators are not supported on function 'v'"):
+            evaluate_python_code(code, BASE_PYTHON_TOOLS, state={})
+
     def test_subscript_call(self):
         code = """def foo(x,y):return x*y\n\ndef boo(y):\n\treturn y**3\nfun = [foo, boo]\nresult_foo = fun[0](4,2)\nresult_boo = fun[1](4)"""
         state = {}


### PR DESCRIPTION
## Summary
- `LocalPythonExecutor` previously ignored `decorator_list` on `FunctionDef` / `ClassDef`, so decorated code silently returned the undecorated object (see #2771).
- This PR takes the **minimal refuse-first** path from the issue discussion: raise `InterpreterError` when decorators are present (functions, classes, and methods), matching how unsupported builtins already fail loudly.
- Full decorator application via `evaluate_call` can be a follow-up if maintainers prefer that design.

Closes #2771

## Test plan
- [x] Added unit tests for function / class / method decorator refusal
- [ ] CI `tests/test_local_python_executor.py`

## Notes
Asked for `status:accepted` on #2771 for the refuse-first direction. Happy to switch to applying decorators instead if that is preferred.

Disclosure: drafted with AI assistance; I reviewed the change and will own follow-ups.