### PR TITLE
Fix TransformersModel VLM image processor inputs

### DIFF
--- a/src/smolagents/models.py
+++ b/src/smolagents/models.py
@@ -334,6 +334,7 @@ def get_clean_message_list(
     role_conversions: dict[MessageRole, MessageRole] | dict[str, str] = {},
     convert_images_to_image_urls: bool = False,
     flatten_messages_as_text: bool = False,
+    encode_images: bool = True,
 ) -> list[dict[str, Any]]:
     """
     Creates a list of messages to give as input to the LLM. These messages are dictionaries and chat template compatible with transformers LLM chat template.
@@ -344,6 +345,7 @@ def get_clean_message_list(
         role_conversions (`dict[MessageRole, MessageRole]`, *optional* ): Mapping to convert roles.
         convert_images_to_image_urls (`bool`, default `False`): Whether to convert images to image URLs.
         flatten_messages_as_text (`bool`, default `False`): Whether to flatten messages as text.
+        encode_images (`bool`, default `True`): Whether to encode image inputs as base64 strings.
     """
     output_message_list: list[dict[str, Any]] = []
     message_list = deepcopy(message_list)  # Avoid modifying the original list
@@ -362,6 +364,8 @@ def get_clean_message_list(
                 assert isinstance(element, dict), "Error: this element should be a dict:" + str(element)
                 if element["type"] == "image":
                     assert not flatten_messages_as_text, f"Cannot use images with {flatten_messages_as_text=}"
+                    if not encode_images:
+                        continue
                     if convert_images_to_image_urls:
                         element.update(
                             {
@@ -508,6 +512,7 @@ class Model:
         custom_role_conversions: dict[str, str] | None = None,
         convert_images_to_image_urls: bool = False,
         tool_choice: str | dict | None = "required",  # Configurable tool_choice parameter
+        encode_images: bool = True,
         **kwargs,
     ) -> dict[str, Any]:
         """
@@ -525,6 +530,7 @@ class Model:
             role_conversions=custom_role_conversions or tool_role_conversions,
             convert_images_to_image_urls=convert_images_to_image_urls,
             flatten_messages_as_text=flatten_messages_as_text,
+            encode_images=encode_images,
         )
         # Start with messages
         completion_kwargs = {
@@ -1010,6 +1016,7 @@ class TransformersModel(Model):
             stop_sequences=stop_sequences,
             tools_to_call_from=tools_to_call_from,
             tool_choice=None,
+            encode_images=not hasattr(self, "processor"),
             **kwargs,
         )
 
@@ -1024,17 +1031,45 @@ class TransformersModel(Model):
             or self.kwargs.get("max_tokens")
             or 1024
         )
-        prompt_tensor = (self.processor if hasattr(self, "processor") else self.tokenizer).apply_chat_template(
-            messages,
-            tools=tools,
-            return_tensors="pt",
-            add_generation_prompt=True,
-            tokenize=True,
-            return_dict=True,
-            **self.apply_chat_template_kwargs,
-        )
+        if hasattr(self, "processor"):
+            images = [
+                element["image"]
+                for message in messages
+                for element in message.get("content", [])
+                if element.get("type") == "image"
+            ]
+            apply_chat_template_kwargs = {
+                "tools": tools,
+                "add_generation_prompt": True,
+                **self.apply_chat_template_kwargs,
+                "tokenize": False,
+            }
+            prompt = self.processor.apply_chat_template(
+                messages,
+                **apply_chat_template_kwargs,
+            )
+            prompt_tensor = self.processor(
+                text=prompt,
+                images=images or None,
+                return_tensors="pt",
+            )
+        else:
+            prompt_tensor = self.tokenizer.apply_chat_template(
+                messages,
+                tools=tools,
+                return_tensors="pt",
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                **self.apply_chat_template_kwargs,
+            )
         prompt_tensor = prompt_tensor.to(self.model.device)  # type: ignore
-        if hasattr(prompt_tensor, "input_ids"):
+        generation_inputs = {}
+        if hasattr(prompt_tensor, "items"):
+            generation_inputs = {key: value for key, value in prompt_tensor.items() if key != "input_ids"}
+        if isinstance(prompt_tensor, dict):
+            prompt_tensor = prompt_tensor["input_ids"]
+        elif hasattr(prompt_tensor, "input_ids"):
             prompt_tensor = prompt_tensor["input_ids"]
 
         model_tokenizer = self.processor.tokenizer if hasattr(self, "processor") else self.tokenizer
@@ -1046,6 +1081,7 @@ class TransformersModel(Model):
             inputs=prompt_tensor,
             use_cache=True,
             stopping_criteria=stopping_criteria,
+            **generation_inputs,
             **completion_kwargs,
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,7 @@
 import json
 import sys
 from contextlib import ExitStack
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, sentinel
 
 import pytest
 from huggingface_hub import ChatCompletionOutputMessage
@@ -682,6 +682,74 @@ class TestTransformersModel:
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.args == ("test-model",)
             assert mocks["transformers.AutoProcessor.from_pretrained"].call_args.kwargs == {"trust_remote_code": True}
 
+    def test_prepare_completion_args_for_vlm_keeps_raw_images_for_processor(self):
+        input_ids = MagicMock()
+        input_ids.shape = (1, 3)
+        pixel_values = MagicMock()
+        prompt_tensor = {"input_ids": input_ids, "pixel_values": pixel_values}
+        prompt_tensor_mock = MagicMock()
+        prompt_tensor_mock.to.return_value = prompt_tensor
+
+        processor = MagicMock()
+        processor.apply_chat_template.return_value = "rendered prompt"
+        processor.return_value = prompt_tensor_mock
+        processor.tokenizer = MagicMock()
+
+        model = TransformersModel.__new__(TransformersModel)
+        Model.__init__(model, model_id="test-vlm", flatten_messages_as_text=False, max_new_tokens=8)
+        model.processor = processor
+        model.model = MagicMock()
+        model.model.device = "cpu"
+        model.apply_chat_template_kwargs = {}
+
+        image = sentinel.image
+        messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "image", "image": image}])]
+
+        with patch("smolagents.models.encode_image_base64") as mock_encode:
+            generation_kwargs = model._prepare_completion_args(messages)
+
+        mock_encode.assert_not_called()
+        processor.apply_chat_template.assert_called_once_with(
+            [{"role": MessageRole.USER, "content": [{"type": "image", "image": image}]}],
+            tools=None,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        processor.assert_called_once_with(text="rendered prompt", images=[image], return_tensors="pt")
+        assert generation_kwargs["inputs"] is input_ids
+        assert generation_kwargs["pixel_values"] is pixel_values
+
+    def test_prepare_completion_args_for_vlm_handles_template_kwargs(self):
+        input_ids = MagicMock()
+        input_ids.shape = (1, 3)
+        prompt_tensor_mock = MagicMock()
+        prompt_tensor_mock.to.return_value = {"input_ids": input_ids}
+
+        processor = MagicMock()
+        processor.apply_chat_template.return_value = "rendered prompt"
+        processor.return_value = prompt_tensor_mock
+        processor.tokenizer = MagicMock()
+
+        model = TransformersModel.__new__(TransformersModel)
+        Model.__init__(model, model_id="test-vlm", flatten_messages_as_text=False)
+        model.processor = processor
+        model.model = MagicMock()
+        model.model.device = "cpu"
+        model.apply_chat_template_kwargs = {"add_generation_prompt": False, "tokenize": True}
+
+        messages = [ChatMessage(role=MessageRole.USER, content=[{"type": "text", "text": "Describe this"}])]
+
+        generation_kwargs = model._prepare_completion_args(messages)
+
+        processor.apply_chat_template.assert_called_once_with(
+            [{"role": MessageRole.USER, "content": [{"type": "text", "text": "Describe this"}]}],
+            tools=None,
+            add_generation_prompt=False,
+            tokenize=False,
+        )
+        processor.assert_called_once_with(text="rendered prompt", images=None, return_tensors="pt")
+        assert generation_kwargs["inputs"] is input_ids
+
 
 def test_get_clean_message_list_basic():
     messages = [
@@ -792,6 +860,17 @@ def test_get_clean_message_list_image_encoding(convert_images_to_image_urls, exp
         mock_encode.assert_any_call(b"second_image_data")
         assert len(result) == 1
         assert result[0] == expected_clean_message
+
+
+def test_get_clean_message_list_can_keep_raw_images():
+    image = sentinel.image
+    message = ChatMessage(role=MessageRole.USER, content=[{"type": "image", "image": image}])
+
+    with patch("smolagents.models.encode_image_base64") as mock_encode:
+        result = get_clean_message_list([message], encode_images=False)
+
+    mock_encode.assert_not_called()
+    assert result == [{"role": MessageRole.USER, "content": [{"type": "image", "image": image}]}]
 
 
 def test_get_clean_message_list_flatten_messages_as_text():


### PR DESCRIPTION
## Summary

Fixes #841 by making `TransformersModel` preserve raw image objects for multimodal processors instead of base64-encoding them before the processor sees them.

For processor-backed models, the change now:

- keeps raw image objects in cleaned messages;
- renders the chat template with `tokenize=False`;
- calls the processor with `text=...` and `images=...` so VLM-specific inputs such as `pixel_values` are produced;
- forwards those additional processor outputs to `model.generate(...)` alongside `input_ids`.

Tokenizer-only models keep the existing path unchanged.

This is the VLM-only portion split out of #2402 so the unrelated MCP serialization work can be reviewed independently. The current upstream `main` has not changed `src/smolagents/models.py` or `tests/test_models.py` since the original implementation, so this branch is based directly on current `main` and changes only those two files.

## Tests

The focused regression coverage checks that:

- raw image objects are not passed through `encode_image_base64` for processor-backed models;
- the processor receives the rendered prompt and image list;
- multimodal processor outputs such as `pixel_values` are forwarded into generation kwargs;
- template kwargs still behave correctly.

The same VLM-specific tests passed in the original #2402 validation. This split is one commit on current `main`; upstream CI should provide the final repository-wide result.

## AI disclosure

This PR was prepared with Codex (GPT-5) acting as an AI coding agent on behalf of @luohui1.

Fixes #841